### PR TITLE
test: add example parity and cross-SDK challenge vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ func main() {
 
 | Example | Description |
 |---------|-------------|
-| [charge-basic](./examples/charge-basic/) | Generic Tempo charge flow using the high-level MPP client and server helpers |
-| [charge-hash](./examples/charge-hash/) | Push-mode charge flow with a hash credential |
-| [charge-fee-payer](./examples/charge-fee-payer/) | Sponsored Tempo charge flow where the server co-signs as a fee payer |
+| [basic](./examples/basic/) | Separate-process demo with a long-running server and standalone client, mirroring the `mpp-rs` sample layout |
+| [charge-basic](./examples/charge-basic/) | Generic Tempo charge flow using the high-level MPP client and server helpers, available in both one-command and separate-process layouts |
+| [charge-hash](./examples/charge-hash/) | Push-mode charge flow with a hash credential, available in both one-command and separate-process layouts |
+| [charge-fee-payer](./examples/charge-fee-payer/) | Sponsored Tempo charge flow where the server co-signs as a fee payer, available in both one-command and separate-process layouts |
 
 ## Protocol
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,11 @@
 # Examples
 
-Each example directory is a runnable end-to-end demo with the same layout:
+The repo has two kinds of examples:
+
+- `charge-*` directories are one-command end-to-end demos that start an in-process server and immediately call it with the client
+- `basic/server`, `basic/client`, and each `charge-*/server` / `charge-*/client` pair are separate-process examples you can run in different terminals, similar to the `mpp-rs` sample layout
+
+Each `charge-*` example directory is a runnable end-to-end demo with the same layout:
 
 - `server.go` starts a paid HTTP handler using the generic `pkg/server` helpers
 - `client.go` configures the generic `pkg/client` retry flow with the Tempo method
@@ -22,6 +27,14 @@ Run any example directly from the repo root:
 go run ./examples/charge-basic
 go run ./examples/charge-hash
 go run ./examples/charge-fee-payer
+go run ./examples/basic/server
+go run ./examples/basic/client
+go run ./examples/charge-basic/server
+go run ./examples/charge-basic/client
+go run ./examples/charge-hash/server
+go run ./examples/charge-hash/client
+go run ./examples/charge-fee-payer/server
+go run ./examples/charge-fee-payer/client
 ```
 
 Set `TEMPO_RPC_URL` to point at a different node if you are not using the

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,48 @@
+# Basic
+
+A realistic two-process Tempo charge example for `mpp-go`, mirroring the
+separate server/client setup from `mpp-rs`.
+
+The server exposes three endpoints:
+
+- `GET /api/health` — Free, returns `{"status":"ok"}`
+- `GET /api/ping` — Costs `0.01`, returns `{"pong":true}`
+- `GET /api/fortune` — Costs `1.00`, returns a random fortune and payer DID
+
+## Running
+
+Start the local Tempo devnet first:
+
+```bash
+docker compose up -d
+```
+
+### 1. Start the server
+
+```bash
+go run ./examples/basic/server
+```
+
+The server listens on `http://localhost:3000`.
+It generates and funds a fresh merchant address on startup, similar to the
+`mpp-rs` basic example.
+
+### 2. Run the client
+
+In another terminal:
+
+```bash
+go run ./examples/basic/client
+```
+
+The client automatically handles the 402 flow, pays the challenge, retries,
+and prints the returned receipt.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PRIVATE_KEY` | bundled devnet payer key | Client private key used to pay |
+| `BASE_URL` | `http://localhost:3000` | Base URL for the example server |
+| `TEMPO_RPC_URL` | `http://127.0.0.1:8545` | Tempo RPC endpoint |
+| `MPP_SECRET_KEY` | `basic-example-secret` | Secret key used to sign server challenges |

--- a/examples/basic/client/main.go
+++ b/examples/basic/client/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	privateKey := os.Getenv("PRIVATE_KEY")
+	if privateKey == "" {
+		privateKey = devnet.PayerPrivateKey
+	}
+
+	signer, err := temposigner.NewSigner(privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := devnet.FundAddress(ctx, rpc, signer.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	method, err := charge.New(charge.Config{
+		PrivateKey: privateKey,
+		ChainID:    chainID,
+		RPCURL:     rpcURL,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client := mppclient.New([]mppclient.Method{method})
+	baseURL := os.Getenv("BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3000"
+	}
+	target := baseURL + "/api/fortune"
+	if len(os.Args) > 1 {
+		target = os.Args[1]
+	}
+
+	resp, err := client.Get(ctx, target)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	receipt, err := mpp.ParsePaymentReceipt(resp.Header.Get("Payment-Receipt"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		log.Fatal(err)
+	}
+
+	prettyBody, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Status: %s\n", resp.Status)
+	if receipt.Reference != "" {
+		fmt.Printf("Receipt: %s\n", receipt.Reference)
+	}
+	if payer, ok := body["payer"].(string); ok && payer != "" {
+		fmt.Printf("Payer: %s\n", payer)
+	}
+	if fortune, ok := body["fortune"].(string); ok && fortune != "" {
+		fmt.Printf("Fortune: %s\n", fortune)
+	} else {
+		fmt.Printf("Response: %s\n", strings.TrimSpace(string(prettyBody)))
+	}
+}

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"math/rand/v2"
+	"net/http"
+	"os"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+var fortunes = []string{
+	"A beautiful, smart, and loving person will come into your life.",
+	"A dubious friend may be an enemy in camouflage.",
+	"A faithful friend is a strong defense.",
+	"A fresh start will put you on your way.",
+	"A golden egg of opportunity falls into your lap this month.",
+	"A good time to finish up old tasks.",
+	"A hunch is creativity trying to tell you something.",
+	"A lifetime of happiness lies ahead of you.",
+	"A light heart carries you through all the hard times.",
+	"A new perspective will come with the new year.",
+}
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	merchantKey, err := crypto.GenerateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+	merchant := temposigner.NewSignerFromKey(merchantKey)
+	if err := devnet.FundAddress(ctx, rpc, merchant.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	intent, err := charge.NewChargeIntent(charge.ChargeIntentConfig{RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	method := charge.NewMethod(charge.MethodConfig{
+		Intent:    intent,
+		ChainID:   chainID,
+		Currency:  devnet.Currency,
+		Recipient: merchant.Address().Hex(),
+	})
+
+	secretKey := "basic-example-secret"
+	if envSecret := getenv("MPP_SECRET_KEY"); envSecret != "" {
+		secretKey = envSecret
+	}
+
+	payment := mppserver.New(method, devnet.Realm, secretKey)
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	})
+
+	mux.Handle("/api/ping", mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+		Amount:      "0.01",
+		Description: "Ping the API",
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"pong": true})
+	})))
+
+	mux.Handle("/api/fortune", mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+		Amount:      "1.00",
+		Description: "Get a fortune",
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		credential := mppserver.CredentialFromContext(r.Context())
+		fortune := fortunes[rand.IntN(len(fortunes))]
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fortune": fortune,
+			"payer":   credential.Source,
+		})
+	})))
+
+	log.Printf("MPP basic server listening on http://localhost:3000")
+	log.Printf("Recipient: %s", merchant.Address().Hex())
+	log.Printf("RPC URL: %s", rpcURL)
+	if err := http.ListenAndServe(":3000", mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getenv(key string) string {
+	return os.Getenv(key)
+}

--- a/examples/charge-basic/README.md
+++ b/examples/charge-basic/README.md
@@ -1,0 +1,26 @@
+# Charge Basic
+
+Tempo charge example in both supported layouts:
+
+- `go run ./examples/charge-basic` runs the existing one-command end-to-end demo
+- `go run ./examples/charge-basic/server` and `go run ./examples/charge-basic/client` run the same flow in separate terminals
+
+## Running
+
+Start the local devnet first:
+
+```bash
+docker compose up -d
+```
+
+### 1. Start the server
+
+```bash
+go run ./examples/charge-basic/server
+```
+
+### 2. Run the client
+
+```bash
+go run ./examples/charge-basic/client
+```

--- a/examples/charge-basic/client/main.go
+++ b/examples/charge-basic/client/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	privateKey := os.Getenv("PRIVATE_KEY")
+	if privateKey == "" {
+		privateKey = devnet.PayerPrivateKey
+	}
+	signer, err := temposigner.NewSigner(privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := devnet.FundAddress(ctx, rpc, signer.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	method, err := charge.New(charge.Config{ChainID: chainID, PrivateKey: privateKey, RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := mppclient.New([]mppclient.Method{method})
+
+	baseURL := os.Getenv("BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3000"
+	}
+	response, err := client.Get(ctx, baseURL+"/paid")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	receipt, err := mpp.ParsePaymentReceipt(response.Header.Get("Payment-Receipt"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	var body struct {
+		Data  string `json:"data"`
+		Payer string `json:"payer"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("paid request for %q from %s with receipt %s\n", body.Data, body.Payer, receipt.Reference)
+}

--- a/examples/charge-basic/server/main.go
+++ b/examples/charge-basic/server/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	intent, err := charge.NewChargeIntent(charge.ChargeIntentConfig{RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	method := charge.NewMethod(charge.MethodConfig{
+		Intent:    intent,
+		ChainID:   chainID,
+		Currency:  devnet.Currency,
+		Recipient: devnet.Recipient,
+	})
+	payment := mppserver.New(method, devnet.Realm, "example-secret")
+
+	mux := http.NewServeMux()
+	mux.Handle("/paid", mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+		Amount:      "0.50",
+		Description: "Basic Tempo charge example",
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		credential := mppserver.CredentialFromContext(r.Context())
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":  "paid content",
+			"payer": credential.Source,
+		})
+	})))
+
+	log.Printf("charge-basic server listening on http://localhost:3000")
+	if err := http.ListenAndServe(":3000", mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/charge-fee-payer/README.md
+++ b/examples/charge-fee-payer/README.md
@@ -1,0 +1,26 @@
+# Charge Fee Payer
+
+Sponsored Tempo charge example in both supported layouts:
+
+- `go run ./examples/charge-fee-payer` runs the existing one-command end-to-end demo
+- `go run ./examples/charge-fee-payer/server` and `go run ./examples/charge-fee-payer/client` run the same flow in separate terminals
+
+## Running
+
+Start the local devnet first:
+
+```bash
+docker compose up -d
+```
+
+### 1. Start the server
+
+```bash
+go run ./examples/charge-fee-payer/server
+```
+
+### 2. Run the client
+
+```bash
+go run ./examples/charge-fee-payer/client
+```

--- a/examples/charge-fee-payer/client/main.go
+++ b/examples/charge-fee-payer/client/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	privateKey := os.Getenv("PRIVATE_KEY")
+	if privateKey == "" {
+		privateKey = devnet.PayerPrivateKey
+	}
+	signer, err := temposigner.NewSigner(privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := devnet.FundAddress(ctx, rpc, signer.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	method, err := charge.New(charge.Config{ChainID: chainID, PrivateKey: privateKey, RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := mppclient.New([]mppclient.Method{method})
+
+	baseURL := os.Getenv("BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3000"
+	}
+	response, err := client.Get(ctx, baseURL+"/paid")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	receipt, err := mpp.ParsePaymentReceipt(response.Header.Get("Payment-Receipt"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	var body struct {
+		Tx string `json:"tx"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("co-signed fee-payer transaction received receipt %s (body tx %s)\n", receipt.Reference, body.Tx)
+}

--- a/examples/charge-fee-payer/server/main.go
+++ b/examples/charge-fee-payer/server/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	feePayer, err := temposigner.NewSigner(devnet.FeePayerPrivateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := devnet.FundAddress(ctx, rpc, feePayer.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	intent, err := charge.NewChargeIntent(charge.ChargeIntentConfig{FeePayerPrivateKey: devnet.FeePayerPrivateKey, RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	method := charge.NewMethod(charge.MethodConfig{
+		Intent:    intent,
+		ChainID:   chainID,
+		Currency:  devnet.Currency,
+		FeePayer:  true,
+		Recipient: devnet.Recipient,
+	})
+	payment := mppserver.New(method, devnet.Realm, "example-secret")
+
+	mux := http.NewServeMux()
+	mux.Handle("/paid", mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+		Amount:      "0.50",
+		Description: "Fee-payer Tempo charge example",
+		FeePayer:    true,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"tx": mppserver.ReceiptFromContext(r.Context()).Reference})
+	})))
+
+	log.Printf("charge-fee-payer server listening on http://localhost:3000")
+	if err := http.ListenAndServe(":3000", mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/charge-hash/README.md
+++ b/examples/charge-hash/README.md
@@ -1,0 +1,26 @@
+# Charge Hash
+
+Push-mode Tempo charge example in both supported layouts:
+
+- `go run ./examples/charge-hash` runs the existing one-command end-to-end demo
+- `go run ./examples/charge-hash/server` and `go run ./examples/charge-hash/client` run the same flow in separate terminals
+
+## Running
+
+Start the local devnet first:
+
+```bash
+docker compose up -d
+```
+
+### 1. Start the server
+
+```bash
+go run ./examples/charge-hash/server
+```
+
+### 2. Run the client
+
+```bash
+go run ./examples/charge-hash/client
+```

--- a/examples/charge-hash/client/main.go
+++ b/examples/charge-hash/client/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	privateKey := os.Getenv("PRIVATE_KEY")
+	if privateKey == "" {
+		privateKey = devnet.PayerPrivateKey
+	}
+	signer, err := temposigner.NewSigner(privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := devnet.FundAddress(ctx, rpc, signer.Address()); err != nil {
+		log.Fatal(err)
+	}
+
+	method, err := charge.New(charge.Config{ChainID: chainID, CredentialType: tempo.CredentialTypeHash, PrivateKey: privateKey, RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := mppclient.New([]mppclient.Method{method})
+
+	baseURL := os.Getenv("BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3000"
+	}
+	response, err := client.Get(ctx, baseURL+"/paid")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	receipt, err := mpp.ParsePaymentReceipt(response.Header.Get("Payment-Receipt"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	var body struct {
+		Tx string `json:"tx"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("broadcast hash credential and received receipt %s (body tx %s)\n", receipt.Reference, body.Tx)
+}

--- a/examples/charge-hash/server/main.go
+++ b/examples/charge-hash/server/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+func main() {
+	ctx := context.Background()
+	rpcURL := devnet.RPCURL()
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := devnet.WaitForRPC(ctx, rpc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	intent, err := charge.NewChargeIntent(charge.ChargeIntentConfig{RPCURL: rpcURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+	method := charge.NewMethod(charge.MethodConfig{
+		Intent:         intent,
+		ChainID:        chainID,
+		Currency:       devnet.Currency,
+		Recipient:      devnet.Recipient,
+		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
+	})
+	payment := mppserver.New(method, devnet.Realm, "example-secret")
+
+	mux := http.NewServeMux()
+	mux.Handle("/paid", mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+		Amount:         "0.50",
+		Description:    "Hash credential Tempo charge example",
+		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"tx": mppserver.ReceiptFromContext(r.Context()).Reference})
+	})))
+
+	log.Printf("charge-hash server listening on http://localhost:3000")
+	if err := http.ListenAndServe(":3000", mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/mpp/challenge_vectors_test.go
+++ b/pkg/mpp/challenge_vectors_test.go
@@ -1,0 +1,324 @@
+package mpp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateChallengeIDCrossSDKCompatibilityVectors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   GenerateChallengeIDInput
+		want string
+	}{
+		{
+			name: "basic charge",
+			in: GenerateChallengeIDInput{
+				SecretKey: "test-secret-key-12345",
+				Realm:     "api.example.com",
+				Method:    "tempo",
+				Intent:    "charge",
+				Request: map[string]any{
+					"amount":    "1000000",
+					"currency":  "0x20c0000000000000000000000000000000000000",
+					"recipient": "0x1234567890abcdef1234567890abcdef12345678",
+				},
+			},
+			want: "XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4",
+		},
+		{
+			name: "with expires",
+			in: GenerateChallengeIDInput{
+				SecretKey: "test-secret-key-12345",
+				Realm:     "api.example.com",
+				Method:    "tempo",
+				Intent:    "charge",
+				Expires:   "2026-01-29T12:00:00Z",
+				Request: map[string]any{
+					"amount":    "5000000",
+					"currency":  "0x20c0000000000000000000000000000000000000",
+					"recipient": "0xabcdef1234567890abcdef1234567890abcdef12",
+				},
+			},
+			want: "EvqUWMPJjqhoVJVG3mhTYVqCa3Mk7bUVd_OjeJGek1A",
+		},
+		{
+			name: "with digest",
+			in: GenerateChallengeIDInput{
+				SecretKey: "my-server-secret",
+				Realm:     "payments.example.org",
+				Method:    "tempo",
+				Intent:    "charge",
+				Digest:    "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=",
+				Request: map[string]any{
+					"amount":    "250000",
+					"currency":  "USD",
+					"recipient": "0x9999999999999999999999999999999999999999",
+				},
+			},
+			want: "qcJUPoapy4bFLznQjQUutwPLyXW7FvALrWA_sMENgAY",
+		},
+		{
+			name: "full challenge",
+			in: GenerateChallengeIDInput{
+				SecretKey: "production-secret-abc123",
+				Realm:     "api.tempo.xyz",
+				Method:    "tempo",
+				Intent:    "charge",
+				Expires:   "2026-02-01T00:00:00Z",
+				Digest:    "sha-256=abc123def456",
+				Request: map[string]any{
+					"amount":      "10000000",
+					"currency":    "0x20c0000000000000000000000000000000000000",
+					"recipient":   "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+					"description": "API access fee",
+					"externalId":  "order-12345",
+				},
+			},
+			want: "J6w7zq6nHLnchss3AYbLxNirdpuaV8_Msn37DQSz6Bw",
+		},
+		{
+			name: "different secret different id",
+			in: GenerateChallengeIDInput{
+				SecretKey: "different-secret-key",
+				Realm:     "api.example.com",
+				Method:    "tempo",
+				Intent:    "charge",
+				Request: map[string]any{
+					"amount":    "1000000",
+					"currency":  "0x20c0000000000000000000000000000000000000",
+					"recipient": "0x1234567890abcdef1234567890abcdef12345678",
+				},
+			},
+			want: "_o55RP0duNvJYtw9PXnf44mGyY5ajV_wwGzoGdTFuNs",
+		},
+		{
+			name: "empty request alternate fixture",
+			in: GenerateChallengeIDInput{
+				SecretKey: "test-key",
+				Realm:     "test.example.com",
+				Method:    "tempo",
+				Intent:    "authorize",
+				Request:   map[string]any{},
+			},
+			want: "MYEC2oq3_B3cHa_My1Lx3NQKn_iUiMfsns6361N0SX0",
+		},
+		{
+			name: "unicode request data",
+			in: GenerateChallengeIDInput{
+				SecretKey: "unicode-test-key",
+				Realm:     "api.example.com",
+				Method:    "tempo",
+				Intent:    "charge",
+				Request: map[string]any{
+					"amount":      "100",
+					"currency":    "EUR",
+					"recipient":   "0x1111111111111111111111111111111111111111",
+					"description": "Payment for caf\u00e9 \u2615",
+				},
+			},
+			want: "1_GKJqATKvVnIUY3f8MFq48bMs18JHz_3CBK8pu52yA",
+		},
+		{
+			name: "nested methodDetails with fee payer",
+			in: GenerateChallengeIDInput{
+				SecretKey: "nested-test-key",
+				Realm:     "api.tempo.xyz",
+				Method:    "tempo",
+				Intent:    "charge",
+				Request: map[string]any{
+					"amount":    "5000000",
+					"currency":  "0x20c0000000000000000000000000000000000000",
+					"recipient": "0x2222222222222222222222222222222222222222",
+					"methodDetails": map[string]any{
+						"chainId":  42431,
+						"feePayer": true,
+					},
+				},
+			},
+			want: "VkSq83C7vQFvdX3MqHM7s-N1QOo2nae4F1iHmbV5pgg",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GenerateChallengeID(tt.in); got != tt.want {
+				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateChallengeIDGoldenVectors(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-vector-secret"
+	tests := []struct {
+		name string
+		in   GenerateChallengeIDInput
+		want string
+	}{
+		{
+			name: "required fields only",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000"}},
+			want: "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4",
+		},
+		{
+			name: "with expires",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000"}, Expires: "2025-01-06T12:00:00Z"},
+			want: "ChPX33RkKSZoSUyZcu8ai4hhkvjZJFkZVnvWs5s0iXI",
+		},
+		{
+			name: "with digest",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000"}, Digest: "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"},
+			want: "JHB7EFsPVb-xsYCo8LHcOzeX1gfXWVoUSzQsZhKAfKM",
+		},
+		{
+			name: "with expires and digest",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000"}, Expires: "2025-01-06T12:00:00Z", Digest: "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"},
+			want: "m39jbWWCIfmfJZSwCfvKFFtBl0Qwf9X4nOmDb21peLA",
+		},
+		{
+			name: "multi field request",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000", "currency": "0x1234", "recipient": "0xabcd"}},
+			want: "_H5TOnnlW0zduQ5OhQ3EyLVze_TqxLDPda2CGZPZxOc",
+		},
+		{
+			name: "nested methodDetails",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000", "currency": "0x1234", "methodDetails": map[string]any{"chainId": 42431}}},
+			want: "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8",
+		},
+		{
+			name: "empty request",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{}},
+			want: "yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU",
+		},
+		{
+			name: "different realm",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "payments.other.com", Method: "tempo", Intent: "charge", Request: map[string]any{"amount": "1000000"}},
+			want: "3F5bOo2a9RUihdwKk4hGRvBvzQmVPBMDvW0YM-8GD00",
+		},
+		{
+			name: "different method",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "stripe", Intent: "charge", Request: map[string]any{"amount": "1000000"}},
+			want: "o0ra2sd7HcB4Ph0Vns69gRDUhSj5WNOnUopcDqKPLz4",
+		},
+		{
+			name: "different intent",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "session", Request: map[string]any{"amount": "1000000"}},
+			want: "aAY7_IEDzsznNYplhOSE8cERQxvjFcT4Lcn-7FHjLVE",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GenerateChallengeID(tt.in); got != tt.want {
+				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateChallengeIDOpaqueGoldenVectors(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-vector-secret"
+	request := map[string]any{"amount": "1000000"}
+	tests := []struct {
+		name string
+		in   GenerateChallengeIDInput
+		want string
+	}{
+		{
+			name: "with opaque",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: request, Opaque: map[string]string{"pi": "pi_3abc123XYZ"}},
+			want: "rxzKZ2qjXvinqCH96RORTZEPs1KXsA-0AUjrCAPFOWc",
+		},
+		{
+			name: "with opaque and expires",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: request, Expires: "2025-01-06T12:00:00Z", Opaque: map[string]string{"pi": "pi_3abc123XYZ"}},
+			want: "KAfoMrA4fnzS1DPWN_cUv_b3_yHxCizdp6OhH7gluMY",
+		},
+		{
+			name: "with empty opaque object",
+			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: request, Opaque: map[string]string{}},
+			want: "vb4IyH-0LdJ3s7L0QAw8jIzcZkyxksPhIvEfmHmzA9k",
+		},
+		{
+			name: "with multi key opaque",
+			in: GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: request, Opaque: map[string]string{
+				"deposit": "dep_456",
+				"pi":      "pi_3abc123XYZ",
+			}},
+			want: "aKskU8sadR5ZuFbUCsIwhO-ENxuVpTw17FdwHEXsJDk",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GenerateChallengeID(tt.in); got != tt.want {
+				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmptyOpaquePreservedOnWire(t *testing.T) {
+	t.Parallel()
+
+	challenge := NewChallenge(
+		"test-vector-secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": "1000000"},
+		WithMeta(map[string]string{}),
+	)
+
+	header := challenge.ToWWWAuthenticate("api.example.com")
+	if !strings.Contains(header, `opaque="`) {
+		t.Fatalf("challenge header = %q, want opaque field", header)
+	}
+
+	parsed, err := ParseChallenge(header)
+	if err != nil {
+		t.Fatalf("ParseChallenge() error = %v", err)
+	}
+	if parsed.Opaque == nil {
+		t.Fatal("parsed.Opaque = nil, want empty map")
+	}
+	if got := GenerateChallengeID(GenerateChallengeIDInput{
+		SecretKey: "test-vector-secret",
+		Realm:     "api.example.com",
+		Method:    "tempo",
+		Intent:    "charge",
+		Request:   map[string]any{"amount": "1000000"},
+		Opaque:    parsed.Opaque,
+	}); got != challenge.ID {
+		t.Fatalf("GenerateChallengeID(parsed opaque) = %q, want %q", got, challenge.ID)
+	}
+
+	credential := &Credential{Challenge: challenge.ToEcho(), Payload: map[string]any{"type": "hash", "hash": "0xabc123"}}
+	authorization := credential.ToAuthorization()
+	if !strings.Contains(authorization, "ey") {
+		t.Fatalf("credential authorization = %q, want base64 payload", authorization)
+	}
+	parsedCredential, err := ParseCredential(authorization)
+	if err != nil {
+		t.Fatalf("ParseCredential() error = %v", err)
+	}
+	if parsedCredential.Challenge.Opaque == nil {
+		t.Fatal("parsedCredential.Challenge.Opaque = nil, want empty map")
+	}
+}

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -1,0 +1,229 @@
+package mpp
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPaymentErrorConstructors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		err    *PaymentError
+		want   string
+		status int
+		detail string
+	}{
+		{
+			name:   "payment required default detail",
+			err:    ErrPaymentRequired("api.example.com", ""),
+			want:   "https://mpp.dev/errors/payment-required",
+			status: http.StatusPaymentRequired,
+			detail: "Payment is required to access this resource",
+		},
+		{
+			name:   "payment required custom detail",
+			err:    ErrPaymentRequired("api.example.com", "custom detail"),
+			want:   "https://mpp.dev/errors/payment-required",
+			status: http.StatusPaymentRequired,
+			detail: "custom detail",
+		},
+		{
+			name:   "malformed credential",
+			err:    ErrMalformedCredential("bad credential"),
+			want:   "https://mpp.dev/errors/malformed-credential",
+			status: http.StatusBadRequest,
+			detail: "bad credential",
+		},
+		{
+			name:   "invalid challenge",
+			err:    ErrInvalidChallenge("challenge-1", "tampered"),
+			want:   "https://mpp.dev/errors/invalid-challenge",
+			status: http.StatusBadRequest,
+			detail: "challenge challenge-1: tampered",
+		},
+		{
+			name:   "verification failed",
+			err:    ErrVerificationFailed("signature mismatch"),
+			want:   "https://mpp.dev/errors/verification-failed",
+			status: http.StatusPaymentRequired,
+			detail: "signature mismatch",
+		},
+		{
+			name:   "payment expired",
+			err:    ErrPaymentExpired("2026-01-01T00:00:00Z"),
+			want:   "https://mpp.dev/errors/payment-expired",
+			status: http.StatusPaymentRequired,
+			detail: "payment expired at 2026-01-01T00:00:00Z",
+		},
+		{
+			name:   "invalid payload",
+			err:    ErrInvalidPayload("invalid payload"),
+			want:   "https://mpp.dev/errors/invalid-payload",
+			status: http.StatusBadRequest,
+			detail: "invalid payload",
+		},
+		{
+			name:   "bad request",
+			err:    ErrBadRequest("bad request"),
+			want:   "https://mpp.dev/errors/bad-request",
+			status: http.StatusBadRequest,
+			detail: "bad request",
+		},
+		{
+			name:   "payment insufficient",
+			err:    ErrPaymentInsufficient("not enough"),
+			want:   "https://mpp.dev/errors/payment-insufficient",
+			status: http.StatusPaymentRequired,
+			detail: "not enough",
+		},
+		{
+			name:   "method unsupported",
+			err:    ErrMethodUnsupported("stripe"),
+			want:   "https://mpp.dev/errors/method-unsupported",
+			status: http.StatusBadRequest,
+			detail: `payment method "stripe" is not supported`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.err.Type != tt.want {
+				t.Fatalf("err.Type = %q, want %q", tt.err.Type, tt.want)
+			}
+			if tt.err.Status != tt.status {
+				t.Fatalf("err.Status = %d, want %d", tt.err.Status, tt.status)
+			}
+			if tt.err.Detail != tt.detail {
+				t.Fatalf("err.Detail = %q, want %q", tt.err.Detail, tt.detail)
+			}
+		})
+	}
+}
+
+func TestPaymentErrorHelpers(t *testing.T) {
+	t.Parallel()
+
+	err := ErrVerificationFailed("signature mismatch")
+	if got := err.Error(); got != "Verification Failed: signature mismatch" {
+		t.Fatalf("err.Error() = %q, want %q", got, "Verification Failed: signature mismatch")
+	}
+	if !errors.Is(err, ErrVerification) {
+		t.Fatal("errors.Is(err, ErrVerification) = false, want true")
+	}
+
+	problem := err.ProblemDetails("challenge-1")
+	if problem["type"] != err.Type {
+		t.Fatalf("problem[type] = %#v, want %q", problem["type"], err.Type)
+	}
+	if problem["challengeId"] != "challenge-1" {
+		t.Fatalf("problem[challengeId] = %#v, want %q", problem["challengeId"], "challenge-1")
+	}
+
+	nonVerification := ErrBadRequest("invalid")
+	if errors.Is(nonVerification, ErrVerification) {
+		t.Fatal("errors.Is(nonVerification, ErrVerification) = true, want false")
+	}
+	if got := nonVerification.ProblemDetails(""); got["challengeId"] != nil {
+		t.Fatalf("problem[challengeId] = %#v, want nil", got["challengeId"])
+	}
+}
+
+func TestReceiptRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	receipt := Success(
+		"ref-123",
+		WithReceiptMethod("tempo"),
+		WithExternalID("ext-123"),
+		WithExtra(map[string]any{"settled": true}),
+	)
+	if receipt.Status != "success" {
+		t.Fatalf("receipt.Status = %q, want %q", receipt.Status, "success")
+	}
+	if receipt.Timestamp.Location() != time.UTC {
+		t.Fatalf("receipt.Timestamp.Location() = %v, want UTC", receipt.Timestamp.Location())
+	}
+
+	header := receipt.ToPaymentReceipt()
+	parsed, err := FromPaymentReceipt(header)
+	if err != nil {
+		t.Fatalf("FromPaymentReceipt() error = %v", err)
+	}
+	if parsed.Reference != receipt.Reference {
+		t.Fatalf("parsed.Reference = %q, want %q", parsed.Reference, receipt.Reference)
+	}
+	if parsed.Method != receipt.Method {
+		t.Fatalf("parsed.Method = %q, want %q", parsed.Method, receipt.Method)
+	}
+	if parsed.ExternalID != receipt.ExternalID {
+		t.Fatalf("parsed.ExternalID = %q, want %q", parsed.ExternalID, receipt.ExternalID)
+	}
+	if parsed.Extra["settled"] != true {
+		t.Fatalf("parsed.Extra[settled] = %#v, want true", parsed.Extra["settled"])
+	}
+	if got, want := parsed.Timestamp.Format("2006-01-02T15:04:05.000Z"), receipt.Timestamp.Format("2006-01-02T15:04:05.000Z"); got != want {
+		t.Fatalf("parsed.Timestamp = %q, want %q", got, want)
+	}
+}
+
+func TestParsePaymentReceiptValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParsePaymentReceipt(b64EncodeAny(map[string]any{
+		"status":    "pending",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid receipt status") {
+		t.Fatalf("ParsePaymentReceipt() error = %v, want invalid status error", err)
+	}
+
+	_, err = ParsePaymentReceipt(b64EncodeAny(map[string]any{
+		"status": "success",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "receipt missing reference") {
+		t.Fatalf("ParsePaymentReceipt() error = %v, want missing reference error", err)
+	}
+}
+
+func TestChallengeVerifyAndToEcho(t *testing.T) {
+	t.Parallel()
+
+	challenge := NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": "100"},
+		WithExpires("2026-01-01T00:00:00.000Z"),
+	)
+	if !challenge.Verify("secret-key", "api.example.com") {
+		t.Fatal("challenge.Verify(secret-key, api.example.com) = false, want true")
+	}
+	if challenge.Verify("secret-key", "other.example.com") {
+		t.Fatal("challenge.Verify(secret-key, other.example.com) = true, want false")
+	}
+
+	challenge.RequestB64 = ""
+	echo := challenge.ToEcho()
+	if echo.Request == "" {
+		t.Fatal("echo.Request = empty, want base64-encoded request")
+	}
+	if !ConstantTimeEqual(challenge.ID, echo.ID) {
+		t.Fatal("ConstantTimeEqual(challenge.ID, echo.ID) = false, want true")
+	}
+	if ConstantTimeEqual(challenge.ID, "different") {
+		t.Fatal("ConstantTimeEqual(challenge.ID, different) = true, want false")
+	}
+	if echo.Expires != challenge.Expires {
+		t.Fatalf("echo.Expires = %q, want %q", echo.Expires, challenge.Expires)
+	}
+}

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -32,7 +32,7 @@ func GenerateChallengeID(opts GenerateChallengeIDInput) string {
 	requestB64 := b64EncodeRequest(opts.Request)
 
 	opaqueB64 := ""
-	if len(opts.Opaque) > 0 {
+	if opts.Opaque != nil {
 		opaqueB64 = b64EncodeSortedStringMap(opts.Opaque)
 	}
 

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -258,7 +258,7 @@ func FormatWWWAuthenticate(c *Challenge, realm string) string {
 	add("expires", c.Expires)
 	add("description", c.Description)
 
-	if len(c.Opaque) > 0 {
+	if c.Opaque != nil {
 		add("opaque", b64EncodeSortedStringMap(c.Opaque))
 	}
 
@@ -387,7 +387,7 @@ func FormatAuthorization(c *Credential) string {
 	if c.Challenge.Digest != "" {
 		challengeDict["digest"] = c.Challenge.Digest
 	}
-	if len(c.Challenge.Opaque) > 0 {
+	if c.Challenge.Opaque != nil {
 		if raw, ok := c.Challenge.Opaque["_raw"]; ok {
 			challengeDict["opaque"] = raw
 		} else {

--- a/pkg/server/defaults_test.go
+++ b/pkg/server/defaults_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectRealmPrecedenceAndDefault(t *testing.T) {
+	for _, envVar := range realmEnvVars {
+		t.Setenv(envVar, "")
+	}
+
+	if got := DetectRealm(); got != "MPP Payment" {
+		t.Fatalf("DetectRealm() = %q, want %q", got, "MPP Payment")
+	}
+
+	t.Setenv("HOSTNAME", "host.example.com")
+	t.Setenv("VERCEL_URL", "vercel.example.com")
+	t.Setenv("MPP_REALM", "api.example.com")
+
+	if got := DetectRealm(); got != "api.example.com" {
+		t.Fatalf("DetectRealm() = %q, want %q", got, "api.example.com")
+	}
+}
+
+func TestDetectSecretKey(t *testing.T) {
+	t.Setenv("MPP_SECRET_KEY", "")
+	if _, err := DetectSecretKey(); err == nil || !strings.Contains(err.Error(), "MPP_SECRET_KEY environment variable is not set") {
+		t.Fatalf("DetectSecretKey() error = %v, want missing env error", err)
+	}
+
+	t.Setenv("MPP_SECRET_KEY", "secret-key")
+	key, err := DetectSecretKey()
+	if err != nil {
+		t.Fatalf("DetectSecretKey() error = %v", err)
+	}
+	if key != "secret-key" {
+		t.Fatalf("DetectSecretKey() = %q, want %q", key, "secret-key")
+	}
+}

--- a/pkg/server/payment_middleware_test.go
+++ b/pkg/server/payment_middleware_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+func TestPaymentMiddleware_ChargeIntentIssuesChallenge(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := PaymentMiddleware(payment, "0.50")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusPaymentRequired {
+		t.Fatalf("response.Code = %d, want %d", response.Code, http.StatusPaymentRequired)
+	}
+	if _, err := mpp.ParseChallenge(response.Header().Get("WWW-Authenticate")); err != nil {
+		t.Fatalf("ParseChallenge() error = %v", err)
+	}
+}
+
+func TestPaymentMiddleware_UnsupportedIntentReturnsInternalServerError(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := PaymentMiddleware(payment, "0.50", WithIntent("session"))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("response.Code = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestWritePaymentError_FormatsProblemResponses(t *testing.T) {
+	t.Parallel()
+
+	paymentErrorResponse := httptest.NewRecorder()
+	writePaymentError(paymentErrorResponse, mpp.ErrBadRequest("bad request"))
+	if paymentErrorResponse.Code != http.StatusBadRequest {
+		t.Fatalf("paymentErrorResponse.Code = %d, want %d", paymentErrorResponse.Code, http.StatusBadRequest)
+	}
+	if got := paymentErrorResponse.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Fatalf("Content-Type = %q, want %q", got, "application/problem+json")
+	}
+
+	genericErrorResponse := httptest.NewRecorder()
+	writePaymentError(genericErrorResponse, errors.New("verification failed"))
+	if genericErrorResponse.Code != http.StatusPaymentRequired {
+		t.Fatalf("genericErrorResponse.Code = %d, want %d", genericErrorResponse.Code, http.StatusPaymentRequired)
+	}
+}

--- a/pkg/server/server_charge_test.go
+++ b/pkg/server/server_charge_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type chargeTestMethod struct {
+	intents map[string]Intent
+}
+
+func (m chargeTestMethod) Name() string { return "tempo" }
+
+func (m chargeTestMethod) Intents() map[string]Intent { return m.intents }
+
+func TestMppCharge_UsesExtraAsChallengeMeta(t *testing.T) {
+	t.Parallel()
+
+	mppServer := New(chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}, "api.example.com", "secret-key")
+	result, err := mppServer.Charge(context.Background(), ChargeParams{
+		Amount:     "0.50",
+		Currency:   "0x20c0000000000000000000000000000000000001",
+		Recipient:  "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		ExternalID: "ext-123",
+		FeePayer:   true,
+		ChainID:    42431,
+		Memo:       "0x" + strings.Repeat("ab", 32),
+		Extra:      map[string]string{"trace": "abc123"},
+	})
+	if err != nil {
+		t.Fatalf("Charge() error = %v", err)
+	}
+	if !result.IsChallenge() {
+		t.Fatal("result.IsChallenge() = false, want true")
+	}
+	if result.Challenge.Opaque["trace"] != "abc123" {
+		t.Fatalf("result.Challenge.Opaque[trace] = %q, want %q", result.Challenge.Opaque["trace"], "abc123")
+	}
+	if result.Challenge.Request["amount"] != "0.50" {
+		t.Fatalf("result.Challenge.Request[amount] = %#v, want %q", result.Challenge.Request["amount"], "0.50")
+	}
+	if result.Challenge.Request["recipient"] != "0x70997970c51812dc3a010c7d01b50e0d17dc79c8" {
+		t.Fatalf("result.Challenge.Request[recipient] = %#v", result.Challenge.Request["recipient"])
+	}
+	if result.Challenge.Request["externalId"] != "ext-123" {
+		t.Fatalf("result.Challenge.Request[externalId] = %#v, want %q", result.Challenge.Request["externalId"], "ext-123")
+	}
+	if result.Challenge.Request["feePayer"] != true {
+		t.Fatalf("result.Challenge.Request[feePayer] = %#v, want true", result.Challenge.Request["feePayer"])
+	}
+	if result.Challenge.Request["chainId"] != 42431 {
+		t.Fatalf("result.Challenge.Request[chainId] = %#v, want %d", result.Challenge.Request["chainId"], 42431)
+	}
+	if result.Challenge.Request["memo"] != "0x"+strings.Repeat("ab", 32) {
+		t.Fatalf("result.Challenge.Request[memo] = %#v", result.Challenge.Request["memo"])
+	}
+}
+
+func TestMppCharge_RequiresChargeIntent(t *testing.T) {
+	t.Parallel()
+
+	mppServer := New(chargeTestMethod{intents: map[string]Intent{}}, "api.example.com", "secret-key")
+	_, err := mppServer.Charge(context.Background(), ChargeParams{Amount: "0.50"})
+	if err == nil || !strings.Contains(err.Error(), `does not support charge intent`) {
+		t.Fatalf("Charge() error = %v, want missing charge intent error", err)
+	}
+}

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -68,7 +68,7 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	if params.Description != "" {
 		opts = append(opts, mpp.WithDescription(params.Description))
 	}
-	if len(params.Meta) > 0 {
+	if params.Meta != nil {
 		opts = append(opts, mpp.WithMeta(params.Meta))
 	}
 
@@ -192,7 +192,7 @@ func echoedChallengeOpts(cred *mpp.Credential) []mpp.ChallengeOption {
 	if cred.Challenge.Digest != "" {
 		opts = append(opts, mpp.WithDigest(cred.Challenge.Digest))
 	}
-	if len(cred.Challenge.Opaque) > 0 {
+	if cred.Challenge.Opaque != nil {
 		opts = append(opts, mpp.WithMeta(cred.Challenge.Opaque))
 	}
 	return opts

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -62,3 +62,58 @@ func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {
 		t.Fatalf("expected successful receipt, got %#v", result)
 	}
 }
+
+func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
+	request := map[string]any{
+		"amount":    "100",
+		"currency":  "0xabc",
+		"recipient": "0xdef",
+	}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithMeta(map[string]string{}),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	issued, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: "",
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Meta:          map[string]string{},
+		Expires:       challenge.Expires,
+	})
+	if err != nil {
+		t.Fatalf("VerifyOrChallenge(issue) error = %v", err)
+	}
+	if issued.Challenge == nil || issued.Challenge.Opaque == nil {
+		t.Fatalf("issued challenge opaque = %#v, want empty map", issued.Challenge)
+	}
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Meta:          map[string]string{},
+		Expires:       challenge.Expires,
+	})
+	if err != nil {
+		t.Fatalf("VerifyOrChallenge(verify) error = %v", err)
+	}
+	if result.Receipt == nil || result.Receipt.Reference != "0xreceipt" {
+		t.Fatalf("expected successful receipt, got %#v", result)
+	}
+}

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -182,3 +182,64 @@ func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
 		t.Fatal("MatchTransferCalldata() = true, want false for wrong challenge binding")
 	}
 }
+
+func TestParseChargeCredentialPayload_RoundTripsPayloadShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   map[string]any
+		want    ChargeCredentialPayload
+		wantErr string
+	}{
+		{
+			name:  "hash payload",
+			input: map[string]any{"type": "hash", "hash": "0xabc123"},
+			want:  ChargeCredentialPayload{Type: CredentialTypeHash, Hash: "0xabc123"},
+		},
+		{
+			name:  "transaction payload",
+			input: map[string]any{"type": "transaction", "signature": "0xsigned"},
+			want:  ChargeCredentialPayload{Type: CredentialTypeTransaction, Signature: "0xsigned"},
+		},
+		{
+			name:  "proof payload",
+			input: map[string]any{"type": "proof", "signature": "0xproof"},
+			want:  ChargeCredentialPayload{Type: CredentialTypeProof, Signature: "0xproof"},
+		},
+		{
+			name:    "missing hash",
+			input:   map[string]any{"type": "hash"},
+			wantErr: "missing hash",
+		},
+		{
+			name:    "unsupported type",
+			input:   map[string]any{"type": "other"},
+			wantErr: "unsupported credential payload type",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := ParseChargeCredentialPayload(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseChargeCredentialPayload() error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseChargeCredentialPayload() error = %v", err)
+			}
+			if !reflect.DeepEqual(payload, tt.want) {
+				t.Fatalf("ParseChargeCredentialPayload() = %#v, want %#v", payload, tt.want)
+			}
+			if !reflect.DeepEqual(payload.Map(), tt.input) {
+				t.Fatalf("payload.Map() = %#v, want %#v", payload.Map(), tt.input)
+			}
+		})
+	}
+}

--- a/pkg/tempo/proof_rpc_test.go
+++ b/pkg/tempo/proof_rpc_test.go
@@ -1,0 +1,105 @@
+package tempo
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+func TestDefaultRPCURLForChain(t *testing.T) {
+	t.Parallel()
+
+	if got := DefaultRPCURLForChain(tempotx.ChainIdModerato); got != tempotx.RpcUrlModerato {
+		t.Fatalf("DefaultRPCURLForChain(moderato) = %q, want %q", got, tempotx.RpcUrlModerato)
+	}
+	if got := DefaultRPCURLForChain(tempotx.ChainIdMainnet); got != tempotx.RpcUrlMainnet {
+		t.Fatalf("DefaultRPCURLForChain(mainnet) = %q, want %q", got, tempotx.RpcUrlMainnet)
+	}
+	if got := DefaultRPCURLForChain(999999); got != tempotx.RpcUrlMainnet {
+		t.Fatalf("DefaultRPCURLForChain(unknown) = %q, want %q", got, tempotx.RpcUrlMainnet)
+	}
+}
+
+func TestProofHelpers(t *testing.T) {
+	t.Parallel()
+
+	address := common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8")
+	if got := ProofSource(42431, address); got != "did:pkh:eip155:42431:"+address.Hex() {
+		t.Fatalf("ProofSource() = %q, want %q", got, "did:pkh:eip155:42431:"+address.Hex())
+	}
+
+	hash1, err := ProofTypedDataHash(42431, "challenge-1")
+	if err != nil {
+		t.Fatalf("ProofTypedDataHash() error = %v", err)
+	}
+	hash2, err := ProofTypedDataHash(42431, "challenge-1")
+	if err != nil {
+		t.Fatalf("ProofTypedDataHash() repeat error = %v", err)
+	}
+	hash3, err := ProofTypedDataHash(42431, "challenge-2")
+	if err != nil {
+		t.Fatalf("ProofTypedDataHash() different challenge error = %v", err)
+	}
+	if hash1 != hash2 {
+		t.Fatalf("hash1 = %s, want same hash as hash2 %s", hash1.Hex(), hash2.Hex())
+	}
+	if hash1 == hash3 {
+		t.Fatalf("hash1 = %s, want different hash from hash3 %s", hash1.Hex(), hash3.Hex())
+	}
+}
+
+func TestParseHexHelpersAndClientConstruction(t *testing.T) {
+	t.Parallel()
+
+	parsedUint, err := ParseHexUint64("0x2a")
+	if err != nil {
+		t.Fatalf("ParseHexUint64() error = %v", err)
+	}
+	if parsedUint != 42 {
+		t.Fatalf("ParseHexUint64() = %d, want %d", parsedUint, 42)
+	}
+
+	parsedBig, err := ParseHexBigInt("0x2a")
+	if err != nil {
+		t.Fatalf("ParseHexBigInt() error = %v", err)
+	}
+	if parsedBig.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("ParseHexBigInt() = %s, want %d", parsedBig.String(), 42)
+	}
+
+	zero, err := ParseHexBigInt("0x")
+	if err != nil {
+		t.Fatalf("ParseHexBigInt(0x) error = %v", err)
+	}
+	if zero.Sign() != 0 {
+		t.Fatalf("ParseHexBigInt(0x) = %s, want 0", zero.String())
+	}
+
+	if _, err := ParseHexBigInt("0xzz"); err == nil {
+		t.Fatal("ParseHexBigInt(0xzz) error = nil, want error")
+	}
+
+	if client := NewRPCClient("https://rpc.example.com"); client == nil {
+		t.Fatal("NewRPCClient() = nil, want client")
+	}
+}
+
+func TestTransferABIHelpers(t *testing.T) {
+	t.Parallel()
+
+	recipient := common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8")
+	amount := big.NewInt(42)
+	calldata := EncodeTransfer(recipient.Hex(), amount)
+	if len(calldata) != 2+8+64+64 {
+		t.Fatalf("len(calldata) = %d, want %d", len(calldata), 2+8+64+64)
+	}
+	if got := ParseTopicAddress("0x" + strings.Repeat("0", 24) + recipient.Hex()[2:]); got != recipient.Hex() {
+		t.Fatalf("ParseTopicAddress() = %q, want %q", got, recipient.Hex())
+	}
+	if got := ParseTopicAddress("0x1234"); got != "" {
+		t.Fatalf("ParseTopicAddress(short) = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add separate-process client/server examples for `basic`, `charge-basic`, `charge-hash`, and `charge-fee-payer` to mirror the `mpp-rs` sample layout while keeping the existing one-command demos
- make the `basic` server generate and fund a fresh merchant address on startup, closer to the Rust sample behavior
- import cross-SDK challenge ID golden vectors from the Rust/Python SDK suites and add targeted regression coverage for untested helpers
- fix `opaque={}` handling so empty opaque metadata is preserved in HMAC and wire-format roundtrips like the other SDKs

## Testing
- `GOTOOLCHAIN=auto go test ./...`
