### PR TITLE
docs: simplify import aliases in README examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# mpp-go
+
+Go SDK for the "Payment" HTTP Authentication Scheme (402 Protocol).
+
+## Vision
+
+mpp-go provides abstractions for the complete HTTP 402 payment flow — both client and server. The architecture has two layers:
+
+### Core Abstractions
+
+1. **`server.Mpp`** — Top-level payment handler. Groups a `Method` with realm and secret, handles the HTTP 402 flow (challenge/credential parsing, header serialization, verification).
+
+2. **`server.Method`** — A payment method definition. Each method provides intents (e.g., `charge`) and builds challenge requests with method-specific parameters.
+
+```
+┌────────────────────┐       ┌────────────────┐
+│    server.Mpp      │ 1   1 │ server.Method  │
+│    (handler)       ├───────┤  (definition)  │
+└────────────────────┘ has   └────────────────┘
+│ payment            │       │ tempo/charge   │
+└────────────────────┘       └────────────────┘
+```
+
+```
+Client (client.Client)                              Server (server.Mpp)
+   │                                                   │
+   │  (1) GET /resource                                │
+   ├──────────────────────────────────────────────────>│
+   │                                                   │
+   │             (2) server.Charge(request, { ... })   │
+   │                   402 + WWW-Authenticate: Payment │
+   │<──────────────────────────────────────────────────┤
+   │                                                   │
+   │  (3) method.CreateCredential(challenge)           │
+   │                                                   │
+   │  (4) GET /resource                                │
+   │      Authorization: Payment <credential>          │
+   ├──────────────────────────────────────────────────>│
+   │                                                   │
+   │               (5) server.Charge(request)          │
+   │                                                   │
+   │               (6) 200 OK                          │
+   │                   Payment-Receipt: <receipt>      │
+   │<──────────────────────────────────────────────────┤
+   │                                                   │
+```
+
+### Primitives
+
+Low-level data structures in `pkg/mpp` that compose into the core abstractions:
+
+- **`Challenge`** — Server-issued payment request (appears in `WWW-Authenticate` header). Contains `ID`, `Realm`, `Method`, `Intent`, `Request`, and optional `Expires`/`Digest`.
+- **`Credential`** — Client-submitted payment proof (appears in `Authorization` header). Contains `Challenge` echo, `Payload` (method-specific proof), and optional `Source` (payer identity).
+- **`Receipt`** — Server-issued settlement confirmation (appears in `Payment-Receipt` header). Contains `Status`, `Method`, `Timestamp`, and `Reference`.
+
+### Package Layout
+
+```
+pkg/
+├── client/          # Generic HTTP 402 retry transport
+├── mpp/             # Protocol primitives (Challenge, Credential, Receipt, parsing)
+├── server/          # Generic challenge-or-verify flow
+└── tempo/           # Tempo blockchain support
+    ├── client/      # Tempo charge client method
+    └── server/      # Tempo charge server method
+```
+
+## Import Conventions
+
+**Use bare package names** — do not alias `pkg/server` as `mppserver` or `pkg/client` as `mppclient`. The Tempo-specific packages already use the `charge` alias, so there is no conflict:
+
+```go
+// ✅ Good
+import (
+    "github.com/tempoxyz/mpp-go/pkg/server"
+    charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+payment := server.New(method, realm, secret)
+
+// ❌ Bad
+import (
+    mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+)
+
+payment := mppserver.New(method, realm, secret)
+```
+
+When a local variable would shadow the package name, use a short variable name (`c`, `srv`) instead of aliasing the import.
+
+**Exception**: Internal library code in `pkg/tempo/server` and `pkg/tempo/client` must use `mppserver`/`mppclient` aliases because the file's own package name (`server`/`client`) would conflict.
+
+## Spec Reference
+
+Canonical specs live at [mpp-specs](https://tempoxyz.github.io/mpp-specs/) and [paymentauth.org](https://paymentauth.org).
+
+### Spec Documents
+
+| Layer         | Spec                                                                                                                                        | Description                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Core**      | [draft-httpauth-payment-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/core/draft-httpauth-payment-00.md)                | 402 flow, `WWW-Authenticate`/`Authorization` headers, `Payment-Receipt` |
+| **Intent**    | [draft-payment-intent-charge-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/intents/draft-payment-intent-charge-00.md)   | One-time immediate payment                                              |
+| **Method**    | [draft-tempo-charge-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/methods/tempo/draft-tempo-charge-00.md)               | TIP-20 token transfers on Tempo                                         |
+
+### Key Protocol Details
+
+- **Challenge**: `WWW-Authenticate: Payment id="...", realm="...", method="...", intent="...", request="<base64url>"`
+- **Credential**: `Authorization: Payment <base64url>` → `{ challenge, payload, source? }`
+- **Receipt**: `Payment-Receipt: <base64url>` → `{ status, method, timestamp, reference }`
+- **Encoding**: All JSON payloads use base64url without padding (RFC 4648)
+
+### Challenge ID Binding
+
+The challenge `id` is an HMAC-SHA256 over the challenge parameters, cryptographically binding the ID to its contents. This prevents tampering and ensures the server can verify challenge integrity without storing state.
+
+**HMAC input** (concatenated, pipe-delimited):
+
+```
+realm | method | intent | request | expires | digest
+```
+
+**Generation:**
+
+```
+id = base64url(HMAC-SHA256(server_secret, input))
+```
+
+**Verification:** Server recomputes HMAC from echoed challenge parameters and compares to `id`. If mismatch, reject credential.
+
+## Commands
+
+```bash
+go test ./...                                        # Run unit tests
+go build ./...                                       # Build all packages
+docker compose up -d                                 # Start local Tempo devnet
+go run ./examples/charge-basic                       # Run charge-basic example
+TEMPO_RPC_URL=http://localhost:8545 make integration  # Run integration tests
+```
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Start the local Tempo devnet before running them:
 docker compose up -d
 ```
 
-The examples use `mppclient` and `mppserver` for the generic HTTP 402 packages.
+The examples import `pkg/client` and `pkg/server` by their bare package names.
 Each file aliases the Tempo charge package to `charge`, since it only uses one
 side of the Tempo flow at a time.
 

--- a/examples/charge-basic/client.go
+++ b/examples/charge-basic/client.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
 )
@@ -25,9 +26,13 @@ func runClient(ctx context.Context, url, rpcURL string, chainID int64) (*clientR
 	if err != nil {
 		return nil, err
 	}
-	client := mppclient.New([]mppclient.Method{method})
+	cl := client.New([]client.Method{method})
 
-	response, err := client.Get(ctx, url+"/paid")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/paid", nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := cl.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/charge-basic/server.go
+++ b/examples/charge-basic/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/server"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 )
 
@@ -26,21 +26,21 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 		Currency:  devnet.Currency,
 		Recipient: devnet.Recipient,
 	})
-	payment := mppserver.New(method, devnet.Realm, "example-secret")
+	payment := server.New(method, devnet.Realm, "example-secret")
 
-	handler := mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:      "0.50",
 		Description: "Basic Tempo charge example",
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		credential := mppserver.CredentialFromContext(r.Context())
+		credential := server.CredentialFromContext(r.Context())
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data":  "paid content",
 			"payer": credential.Source,
 		})
 	}))
 
-	server := httptest.NewServer(handler)
-	return &exampleServer{url: server.URL, server: server}, nil
+	srv := httptest.NewServer(handler)
+	return &exampleServer{url: srv.URL, server: srv}, nil
 }
 
 func (s *exampleServer) Close() {

--- a/examples/charge-fee-payer/client.go
+++ b/examples/charge-fee-payer/client.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
 )
@@ -24,9 +25,13 @@ func runClient(ctx context.Context, url, rpcURL string, chainID int64) (*clientR
 	if err != nil {
 		return nil, err
 	}
-	client := mppclient.New([]mppclient.Method{method})
+	cl := client.New([]client.Method{method})
 
-	response, err := client.Get(ctx, url+"/paid")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/paid", nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := cl.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/charge-fee-payer/server.go
+++ b/examples/charge-fee-payer/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/server"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 )
 
@@ -30,20 +30,20 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 		FeePayer:  true,
 		Recipient: devnet.Recipient,
 	})
-	payment := mppserver.New(method, devnet.Realm, "example-secret")
+	payment := server.New(method, devnet.Realm, "example-secret")
 
-	handler := mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:      "0.50",
 		Description: "Fee-payer Tempo charge example",
 		FeePayer:    true,
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tx": mppserver.ReceiptFromContext(r.Context()).Reference,
+			"tx": server.ReceiptFromContext(r.Context()).Reference,
 		})
 	}))
 
-	server := httptest.NewServer(handler)
-	return &exampleServer{url: server.URL, server: server}, nil
+	srv := httptest.NewServer(handler)
+	return &exampleServer{url: srv.URL, server: srv}, nil
 }
 
 func (s *exampleServer) Close() {

--- a/examples/charge-hash/client.go
+++ b/examples/charge-hash/client.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
+	"github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
@@ -26,9 +27,13 @@ func runClient(ctx context.Context, url, rpcURL string, chainID int64) (*clientR
 	if err != nil {
 		return nil, err
 	}
-	client := mppclient.New([]mppclient.Method{method})
+	cl := client.New([]client.Method{method})
 
-	response, err := client.Get(ctx, url+"/paid")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/paid", nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := cl.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/charge-hash/server.go
+++ b/examples/charge-hash/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
-	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 )
@@ -28,20 +28,20 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 		Recipient:      devnet.Recipient,
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
-	payment := mppserver.New(method, devnet.Realm, "example-secret")
+	payment := server.New(method, devnet.Realm, "example-secret")
 
-	handler := mppserver.ChargeMiddleware(payment, mppserver.ChargeParams{
+	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:         "0.50",
 		Description:    "Hash credential Tempo charge example",
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tx": mppserver.ReceiptFromContext(r.Context()).Reference,
+			"tx": server.ReceiptFromContext(r.Context()).Reference,
 		})
 	}))
 
-	server := httptest.NewServer(handler)
-	return &exampleServer{url: server.URL, server: server}, nil
+	srv := httptest.NewServer(handler)
+	return &exampleServer{url: srv.URL, server: srv}, nil
 }
 
 func (s *exampleServer) Close() {

--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -1,6 +1,6 @@
 // Package client provides the generic HTTP 402 retry transport used by MPP
 // payment methods.
 //
-// When paired with Tempo charge helpers, examples typically import this package
-// as mppclient to distinguish it from the Tempo charge package alias `charge`.
+// Examples import this package by its bare name. The Tempo charge package
+// uses the alias `charge`, so there is no conflict.
 package client

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -1,6 +1,6 @@
 // Package server provides the generic challenge-or-verify flow for Payment
 // authentication on the server side.
 //
-// When paired with Tempo charge helpers, examples typically import this package
-// as mppserver to distinguish it from the Tempo charge package alias `charge`.
+// Examples import this package by its bare name. The Tempo charge package
+// uses the alias `charge`, so there is no conflict.
 package server


### PR DESCRIPTION
Drop `mppserver`/`mppclient` aliases — use bare `server`/`client` package names instead. Rename local variables to `srv`/`c` where they would shadow the package name.

**Changes:**
- Add `AGENTS.md` with import convention rule (based on mppx structure)
- Update all 6 example files (`charge-basic`, `charge-hash`, `charge-fee-payer`)
- Update `pkg/server/doc.go` and `pkg/client/doc.go` comments
- Update `examples/README.md`

All packages build, all tests pass, examples verified on devnet and testnet.