### PR TITLE
fix: harden payment challenge verification

### DIFF
--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -137,6 +138,21 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		return nil, mpp.ErrInvalidChallenge(
 			echoed.ID,
 			"credential request does not match this route's requirements",
+		)
+	}
+	if echoed.Expires == "" {
+		return nil, mpp.ErrInvalidChallenge(echoed.ID, "missing required expires")
+	}
+	if params.Expires != "" && echoed.Expires != params.Expires {
+		return nil, mpp.ErrInvalidChallenge(
+			echoed.ID,
+			"credential expires does not match this route's requirements",
+		)
+	}
+	if !reflect.DeepEqual(echoed.Opaque, challenge.Opaque) {
+		return nil, mpp.ErrInvalidChallenge(
+			echoed.ID,
+			"credential opaque metadata does not match this route's requirements",
 		)
 	}
 

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -115,5 +116,80 @@ func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
 	}
 	if result.Receipt == nil || result.Receipt.Reference != "0xreceipt" {
 		t.Fatalf("expected successful receipt, got %#v", result)
+	}
+}
+
+func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
+	request := map[string]any{
+		"amount":    "100",
+		"currency":  "0xabc",
+		"recipient": "0xdef",
+	}
+	issued := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	tampered := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+	)
+	credential := &mpp.Credential{
+		Challenge: tampered.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       issued.Expires,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing required expires") {
+		t.Fatalf("VerifyOrChallenge() error = %v, want missing required expires", err)
+	}
+}
+
+func TestVerifyOrChallenge_RejectsOpaqueMismatch(t *testing.T) {
+	request := map[string]any{
+		"amount":    "100",
+		"currency":  "0xabc",
+		"recipient": "0xdef",
+	}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithMeta(map[string]string{"trace": "issued"}),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Meta:          map[string]string{"trace": "current"},
+		Expires:       challenge.Expires,
+	})
+	if err == nil || !strings.Contains(err.Error(), "opaque metadata does not match") {
+		t.Fatalf("VerifyOrChallenge() error = %v, want opaque metadata mismatch", err)
 	}
 }

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -130,6 +130,9 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 	if credentialType == tempo.CredentialTypeProof {
 		return nil, fmt.Errorf("tempo client: proof credentials are only valid for zero-amount challenges")
 	}
+	if credentialType == tempo.CredentialTypeHash && request.MethodDetails.Memo != "" {
+		return nil, fmt.Errorf("tempo client: hash credentials cannot be used with explicit memo challenges")
+	}
 	if credentialType == tempo.CredentialTypeHash && request.MethodDetails.FeePayer {
 		return nil, fmt.Errorf("tempo client: hash credentials cannot be used with fee payer challenges")
 	}

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -81,6 +81,24 @@ func TestCreateCredentialScenarios(t *testing.T) {
 			wantBroadcasts: 0,
 		},
 		{
+			name: "hash credential rejected for explicit memo challenge",
+			config: Config{
+				ChainID:        42431,
+				CredentialType: tempo.CredentialTypeHash,
+			},
+			rpc: &mockRPC{chainID: 42431},
+			params: tempo.ChargeRequestParams{
+				Amount:    "0.50",
+				Currency:  testCurrency,
+				Recipient: testRecipient,
+				Decimals:  6,
+				ChainID:   42431,
+				Memo:      "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+			},
+			wantErr:        "hash credentials cannot be used with explicit memo challenges",
+			wantBroadcasts: 0,
+		},
+		{
 			name: "chain id mismatch",
 			config: Config{
 				ChainID: 42431,

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -140,6 +140,9 @@ func (i *Intent) verifyHash(
 	hash string,
 	source *sourceDID,
 ) (*mpp.Receipt, error) {
+	if request.MethodDetails.Memo != "" {
+		return nil, mpp.ErrInvalidPayload("hash credentials are not supported when the primary transfer uses an explicit memo")
+	}
 	if source == nil {
 		return nil, mpp.ErrInvalidPayload("hash credential must include a source")
 	}

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -425,6 +425,43 @@ func TestChargeFlow_HashCredentialIgnoresFeeControllerLogs(t *testing.T) {
 	}
 }
 
+func TestChargeFlow_HashCredentialRejectsExplicitPrimaryMemo(t *testing.T) {
+	ctx := context.Background()
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:         "0.50",
+		Currency:       testCurrency,
+		Recipient:      testRecipient,
+		Decimals:       6,
+		ChainID:        42431,
+		Memo:           "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	}
+	signer, err := temposigner.NewSigner(testPrivateKey)
+	if err != nil {
+		t.Fatalf("NewSigner() error = %v", err)
+	}
+	challenge := buildChallenge(t, request)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload: tempo.ChargeCredentialPayload{
+			Type: tempo.CredentialTypeHash,
+			Hash: testReceiptHash,
+		}.Map(),
+		Source: tempo.ProofSource(42431, signer.Address()),
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: newMockRPC(request)})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "explicit memo") {
+		t.Fatalf("Verify() error = %v, want explicit memo rejection", err)
+	}
+}
+
 func TestChargeFlow_RejectsMalformedCredentialSource(t *testing.T) {
 	ctx := context.Background()
 	request := buildRequest(t, false, nil)

--- a/pkg/tempo/server/method.go
+++ b/pkg/tempo/server/method.go
@@ -125,7 +125,7 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 		FeePayerURL:    feePayerURL,
 		Memo:           memo,
 		Splits:         append([]tempo.SplitParams(nil), params.Splits...),
-		SupportedModes: resolvedModes(params.SupportedModes, m.supportedModes),
+		SupportedModes: resolvedModes(memo, params.SupportedModes, m.supportedModes),
 	})
 	if err != nil {
 		return nil, err
@@ -133,9 +133,24 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 	return request.Map(), nil
 }
 
-func resolvedModes(requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {
+func resolvedModes(memo string, requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {
+	var modes []tempo.ChargeMode
 	if len(requestModes) > 0 {
-		return append([]tempo.ChargeMode(nil), requestModes...)
+		modes = append([]tempo.ChargeMode(nil), requestModes...)
+	} else {
+		modes = append([]tempo.ChargeMode(nil), defaultModes...)
 	}
-	return append([]tempo.ChargeMode(nil), defaultModes...)
+	if memo == "" {
+		return modes
+	}
+	filtered := make([]tempo.ChargeMode, 0, len(modes))
+	for _, mode := range modes {
+		if mode != tempo.ChargeModePush {
+			filtered = append(filtered, mode)
+		}
+	}
+	if len(filtered) == 0 {
+		return []tempo.ChargeMode{tempo.ChargeModePull}
+	}
+	return filtered
 }

--- a/pkg/tempo/server/method_test.go
+++ b/pkg/tempo/server/method_test.go
@@ -69,6 +69,25 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "explicit primary memo forces pull mode",
+			config: MethodConfig{
+				Currency:  "0x20c0000000000000000000000000000000000001",
+				Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+				ChainID:   42431,
+			},
+			params: mppserver.ChargeParams{
+				Amount:         "0.50",
+				Memo:           "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+				SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
+			},
+			assertions: func(t *testing.T, request tempo.ChargeRequest) {
+				t.Helper()
+				if got := len(request.MethodDetails.SupportedModes); got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePull {
+					t.Fatalf("request.MethodDetails.SupportedModes = %#v, want [pull]", request.MethodDetails.SupportedModes)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Harden challenge verification
- Reject hash credentials for explicit memo charges

Co-Authored-By: Brendan Ryan <1572504+brendanjryan@users.noreply.github.com>

Prompted by: Brendan