### PR TITLE
server: add ComposeMiddleware for multi-method routes

### DIFF
--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+// ComposeConfig pairs an Mpp instance with the ChargeParams for one payment
+// method. Pass one or more of these to ComposeMiddleware to advertise multiple
+// payment options on a single route.
+type ComposeConfig struct {
+	Mpp    *Mpp
+	Params ChargeParams
+}
+
+// composedEntry is a frozen, pre-resolved config entry used at request time.
+type composedEntry struct {
+	mpp     *Mpp
+	params  ChargeParams
+	request map[string]any
+}
+
+// ComposeMiddleware creates an http.Handler middleware that supports multiple
+// payment methods on a single route.
+//
+// When no credential is present, it fans out to every configured method and
+// returns a merged 402 response with one WWW-Authenticate header per method.
+// When a credential is present, it dispatches to the matching method by
+// comparing the credential's echoed method, intent, and canonical request.
+//
+// All configs must share the same realm. ComposeMiddleware panics if configs
+// is empty, any Mpp is nil, or realms differ.
+func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler {
+	if len(configs) == 0 {
+		panic("server: ComposeMiddleware requires at least one ComposeConfig")
+	}
+
+	realm := configs[0].Mpp.realm
+	entries := make([]composedEntry, len(configs))
+	for i, cfg := range configs {
+		if cfg.Mpp == nil {
+			panic(fmt.Sprintf("server: ComposeConfig[%d].Mpp is nil", i))
+		}
+		if cfg.Mpp.realm != realm {
+			panic(fmt.Sprintf("server: ComposeConfig[%d] realm %q differs from [0] realm %q", i, cfg.Mpp.realm, realm))
+		}
+		request, err := cfg.Mpp.buildChargeRequest(cfg.Params)
+		if err != nil {
+			panic(fmt.Sprintf("server: ComposeConfig[%d] buildChargeRequest: %v", i, err))
+		}
+		entries[i] = composedEntry{
+			mpp:     cfg.Mpp,
+			params:  cfg.Params,
+			request: request,
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+
+			// No credential — fan out and merge all challenges.
+			if mpp.FindPaymentAuthorization(auth) == "" {
+				composeChallenges(w, r, entries, realm)
+				return
+			}
+
+			// Credential present — find the matching entry.
+			cred, err := mpp.ParseCredential(auth)
+			if err != nil {
+				WritePaymentError(w, mpp.ErrMalformedCredential(err.Error()))
+				return
+			}
+
+			entry, ok := findMatchingEntry(entries, cred)
+			if !ok {
+				WritePaymentError(w, mpp.ErrMethodUnsupported(cred.Challenge.Method+"/"+cred.Challenge.Intent))
+				return
+			}
+
+			params := entry.params
+			params.Authorization = auth
+
+			result, err := entry.mpp.Charge(r.Context(), params)
+			if err != nil {
+				WritePaymentError(w, err)
+				return
+			}
+			if result.Challenge != nil {
+				WriteChallenge(w, result.Challenge, realm)
+				return
+			}
+
+			serveVerified(next, w, r, result.Credential, result.Receipt)
+		})
+	}
+}
+
+// composeChallenges issues a 402 with all configured challenges merged into
+// separate WWW-Authenticate header values.
+func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string) {
+	var challenges []*mpp.Challenge
+	for _, entry := range entries {
+		params := entry.params
+		params.Authorization = ""
+
+		result, err := entry.mpp.Charge(r.Context(), params)
+		if err != nil {
+			WritePaymentError(w, err)
+			return
+		}
+		if result.Challenge != nil {
+			challenges = append(challenges, result.Challenge)
+		}
+	}
+
+	if len(challenges) == 0 {
+		WritePaymentError(w, mpp.ErrBadRequest("no challenges could be generated"))
+		return
+	}
+
+	for _, challenge := range challenges {
+		w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(realm))
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusPaymentRequired)
+
+	problem := mpp.ErrPaymentRequired(realm, "")
+	json.NewEncoder(w).Encode(problem.ProblemDetails(""))
+}
+
+// findMatchingEntry selects the entry whose method, intent, and canonical
+// request match the credential. This allows multiple entries with the same
+// method+intent but different amounts or currencies.
+func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool) {
+	echoedRequest, err := echoedRequestMap(cred)
+	if err != nil {
+		return composedEntry{}, false
+	}
+
+	// Prefer an exact match on method + intent + request.
+	for _, entry := range entries {
+		method := entry.mpp.method
+		if cred.Challenge.Method != method.Name() {
+			continue
+		}
+		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
+			continue
+		}
+		if mpp.JSONEqual(echoedRequest, entry.request) {
+			return entry, true
+		}
+	}
+
+	// Fall back to method + intent only (let Charge return the precise error).
+	for _, entry := range entries {
+		method := entry.mpp.method
+		if cred.Challenge.Method != method.Name() {
+			continue
+		}
+		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
+			continue
+		}
+		return entry, true
+	}
+
+	return composedEntry{}, false
+}

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
@@ -37,6 +38,9 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 	if len(configs) == 0 {
 		panic("server: ComposeMiddleware requires at least one ComposeConfig")
 	}
+	if configs[0].Mpp == nil {
+		panic("server: ComposeConfig[0].Mpp is nil")
+	}
 
 	realm := configs[0].Mpp.realm
 	entries := make([]composedEntry, len(configs))
@@ -61,28 +65,33 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auth := r.Header.Get("Authorization")
+			paymentAuth := mpp.FindPaymentAuthorization(auth)
 
 			// No credential — fan out and merge all challenges.
-			if mpp.FindPaymentAuthorization(auth) == "" {
+			if paymentAuth == "" {
 				composeChallenges(w, r, entries, realm)
 				return
 			}
 
 			// Credential present — find the matching entry.
-			cred, err := mpp.ParseCredential(auth)
+			cred, err := mpp.ParseCredential(paymentAuth)
 			if err != nil {
 				WritePaymentError(w, mpp.ErrMalformedCredential(err.Error()))
 				return
 			}
 
-			entry, ok := findMatchingEntry(entries, cred)
+			entry, ok, err := findMatchingEntry(entries, cred)
+			if err != nil {
+				WritePaymentError(w, err)
+				return
+			}
 			if !ok {
 				WritePaymentError(w, mpp.ErrMethodUnsupported(cred.Challenge.Method+"/"+cred.Challenge.Intent))
 				return
 			}
 
 			params := entry.params
-			params.Authorization = auth
+			params.Authorization = paymentAuth
 
 			result, err := entry.mpp.Charge(r.Context(), params)
 			if err != nil {
@@ -135,11 +144,11 @@ func composeChallenges(w http.ResponseWriter, r *http.Request, entries []compose
 
 // findMatchingEntry selects the entry whose method, intent, and canonical
 // request match the credential. This allows multiple entries with the same
-// method+intent but different amounts or currencies.
-func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool) {
+// method+intent but different amounts, currencies, or opaque metadata.
+func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool, error) {
 	echoedRequest, err := echoedRequestMap(cred)
 	if err != nil {
-		return composedEntry{}, false
+		return composedEntry{}, false, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
 	}
 
 	// Prefer an exact match on method + intent + request.
@@ -151,8 +160,8 @@ func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedE
 		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
 			continue
 		}
-		if mpp.JSONEqual(echoedRequest, entry.request) {
-			return entry, true
+		if mpp.JSONEqual(echoedRequest, entry.request) && reflect.DeepEqual(cred.Challenge.Opaque, entry.params.Meta) {
+			return entry, true, nil
 		}
 	}
 
@@ -165,8 +174,8 @@ func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedE
 		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
 			continue
 		}
-		return entry, true
+		return entry, true, nil
 	}
 
-	return composedEntry{}, false
+	return composedEntry{}, false, nil
 }

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -205,6 +206,43 @@ func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
 	}
 }
 
+func TestComposeMiddleware_SameRequestDifferentMetaSelectsMatchingConfig(t *testing.T) {
+	methodBasic := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodPro := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodBasic, Params: ChargeParams{Amount: "1.00", Meta: map[string]string{"plan": "basic"}}},
+		ComposeConfig{Mpp: methodPro, Params: ChargeParams{Amount: "1.00", Meta: map[string]string{"plan": "pro"}}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	defer resp.Body.Close()
+
+	var proChallenge *mpp.Challenge
+	for _, h := range resp.Header.Values("WWW-Authenticate") {
+		c, err := mpp.ParseChallenge(h)
+		if err != nil {
+			t.Fatalf("ParseChallenge() error = %v", err)
+		}
+		if c.Opaque["plan"] == "pro" {
+			proChallenge = c
+			break
+		}
+	}
+	if proChallenge == nil {
+		t.Fatal("did not find the pro challenge")
+	}
+
+	paid := payWith(t, srv.URL, proChallenge)
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+	}
+}
+
 func TestComposeMiddleware_RejectsUnknownMethod(t *testing.T) {
 	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
@@ -255,6 +293,89 @@ func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
 
 	if paid.StatusCode == http.StatusOK {
 		t.Fatal("expected credential to be rejected, but got 200")
+	}
+}
+
+func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	betaChallenge := findChallenge(t, resp, "beta")
+	resp.Body.Close()
+
+	credential := &mpp.Credential{
+		Challenge: betaChallenge.ToEcho(),
+		Source:    "did:key:z6Mktest",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-token, "+credential.ToAuthorization())
+
+	paid, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+	}
+}
+
+func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	challenge := findChallenge(t, resp, "alpha")
+	resp.Body.Close()
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	credential.Challenge.Request = "%%%"
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", credential.ToAuthorization())
+
+	paid, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("status = %d, want %d; body = %s", paid.StatusCode, http.StatusBadRequest, body)
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(paid.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem) error = %v", err)
+	}
+	if problem.Type != string(mpp.ErrorTypeMalformedCredential) {
+		t.Fatalf("problem type = %q, want %q", problem.Type, mpp.ErrorTypeMalformedCredential)
 	}
 }
 

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -1,0 +1,323 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+// --- test helpers ---
+
+type composeTestMethod struct {
+	name string
+}
+
+func (m composeTestMethod) Name() string { return m.name }
+
+func (m composeTestMethod) Intents() map[string]Intent {
+	return map[string]Intent{"charge": composeTestIntent{method: m.name}}
+}
+
+type composeTestIntent struct {
+	method string
+}
+
+func (i composeTestIntent) Name() string { return "charge" }
+
+func (i composeTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
+	return mpp.Success("0xreceipt-"+i.method, mpp.WithReceiptMethod(i.method)), nil
+}
+
+const (
+	composeRealm  = "api.example.com"
+	composeSecret = "secret-key"
+)
+
+func composeTestServer(t *testing.T, configs ...ComposeConfig) *httptest.Server {
+	t.Helper()
+	handler := ComposeMiddleware(configs...)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cred := CredentialFromContext(r.Context())
+		receipt := ReceiptFromContext(r.Context())
+		io.WriteString(w, cred.Challenge.Method+":"+receipt.Reference)
+	}))
+	return httptest.NewServer(handler)
+}
+
+// getChallenge does a bare GET and returns the 402 response.
+func getChallenge(t *testing.T, url string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusPaymentRequired {
+		resp.Body.Close()
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPaymentRequired)
+	}
+	return resp
+}
+
+// findChallenge parses WWW-Authenticate headers and returns the one matching methodName.
+func findChallenge(t *testing.T, resp *http.Response, methodName string) *mpp.Challenge {
+	t.Helper()
+	for _, h := range resp.Header.Values("WWW-Authenticate") {
+		c, err := mpp.ParseChallenge(h)
+		if err != nil {
+			t.Fatalf("ParseChallenge() error = %v", err)
+		}
+		if c.Method == methodName {
+			return c
+		}
+	}
+	t.Fatalf("did not find challenge for method %q", methodName)
+	return nil
+}
+
+// payWith sends a credential and returns the response.
+func payWith(t *testing.T, url string, challenge *mpp.Challenge) *http.Response {
+	t.Helper()
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mktest",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", credential.ToAuthorization())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	return resp
+}
+
+// --- tests ---
+
+func TestComposeMiddleware_FansOutChallenges(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	defer resp.Body.Close()
+
+	wwwAuth := resp.Header.Values("WWW-Authenticate")
+	if len(wwwAuth) != 2 {
+		t.Fatalf("got %d WWW-Authenticate headers, want 2", len(wwwAuth))
+	}
+
+	challenge0, _ := mpp.ParseChallenge(wwwAuth[0])
+	challenge1, _ := mpp.ParseChallenge(wwwAuth[1])
+	if challenge0.Method == challenge1.Method {
+		t.Fatalf("expected different methods, both are %q", challenge0.Method)
+	}
+}
+
+func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	betaChallenge := findChallenge(t, resp, "beta")
+	resp.Body.Close()
+
+	paid := payWith(t, srv.URL, betaChallenge)
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(paid.Body)
+	if got := string(body); got != "beta:0xreceipt-beta" {
+		t.Fatalf("body = %q, want %q", got, "beta:0xreceipt-beta")
+	}
+
+	receipt, err := mpp.ParsePaymentReceipt(paid.Header.Get("Payment-Receipt"))
+	if err != nil {
+		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	}
+	if receipt.Reference != "0xreceipt-beta" {
+		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt-beta")
+	}
+}
+
+func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
+	// Two entries with the same method+intent but different amounts.
+	// The credential should dispatch to the correct entry based on request matching.
+	methodCheap := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodExpensive := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodCheap, Params: ChargeParams{Amount: "0.01"}},
+		ComposeConfig{Mpp: methodExpensive, Params: ChargeParams{Amount: "10.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	defer resp.Body.Close()
+
+	wwwAuth := resp.Header.Values("WWW-Authenticate")
+	if len(wwwAuth) != 2 {
+		t.Fatalf("got %d WWW-Authenticate headers, want 2", len(wwwAuth))
+	}
+
+	// Pick the second (expensive) challenge by parsing and checking the request amount.
+	var expensiveChallenge *mpp.Challenge
+	for _, h := range wwwAuth {
+		c, err := mpp.ParseChallenge(h)
+		if err != nil {
+			t.Fatalf("ParseChallenge() error = %v", err)
+		}
+		if amt, ok := c.Request["amount"]; ok && amt == "10.00" {
+			expensiveChallenge = c
+			break
+		}
+	}
+	if expensiveChallenge == nil {
+		t.Fatal("did not find the 10.00 amount challenge")
+	}
+
+	paid := payWith(t, srv.URL, expensiveChallenge)
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+	}
+}
+
+func TestComposeMiddleware_RejectsUnknownMethod(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+	)
+	defer srv.Close()
+
+	fakeChallenge := mpp.NewChallenge(composeSecret, composeRealm, "unknown", "charge", map[string]any{"amount": "1.00"})
+	resp := payWith(t, srv.URL, fakeChallenge)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	alphaChallenge := findChallenge(t, resp, "alpha")
+	resp.Body.Close()
+
+	// Tamper: change the method name in the echo to "beta" but keep alpha's HMAC.
+	echo := alphaChallenge.ToEcho()
+	echo.Method = "beta"
+	credential := &mpp.Credential{
+		Challenge: echo,
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", credential.ToAuthorization())
+
+	paid, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer paid.Body.Close()
+
+	if paid.StatusCode == http.StatusOK {
+		t.Fatal("expected credential to be rejected, but got 200")
+	}
+}
+
+func TestComposeMiddleware_SingleMethod(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	defer resp.Body.Close()
+
+	wwwAuth := resp.Header.Values("WWW-Authenticate")
+	if len(wwwAuth) != 1 {
+		t.Fatalf("got %d WWW-Authenticate headers, want 1", len(wwwAuth))
+	}
+
+	challenge, _ := mpp.ParseChallenge(wwwAuth[0])
+	paid := payWith(t, srv.URL, challenge)
+	defer paid.Body.Close()
+
+	if paid.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paid.Body)
+		t.Fatalf("status = %d, want 200; body = %s", paid.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(paid.Body)
+	if got := string(body); got != "alpha:0xreceipt-alpha" {
+		t.Fatalf("body = %q, want %q", got, "alpha:0xreceipt-alpha")
+	}
+}
+
+func TestComposeMiddleware_PanicsOnEmptyConfigs(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for empty configs")
+		}
+	}()
+	ComposeMiddleware()
+}
+
+func TestComposeMiddleware_PanicsOnNilMpp(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil Mpp")
+		}
+	}()
+	ComposeMiddleware(ComposeConfig{Mpp: nil, Params: ChargeParams{Amount: "1.00"}})
+}
+
+func TestComposeMiddleware_PanicsOnMixedRealms(t *testing.T) {
+	a := New(composeTestMethod{name: "alpha"}, "realm-a.example.com", composeSecret)
+	b := New(composeTestMethod{name: "beta"}, "realm-b.example.com", composeSecret)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for mixed realms")
+		}
+	}()
+	ComposeMiddleware(
+		ComposeConfig{Mpp: a, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: b, Params: ChargeParams{Amount: "2.00"}},
+	)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -101,6 +101,33 @@ func (r *ChargeResult) IsChallenge() bool {
 	return r.Challenge != nil
 }
 
+// buildChargeRequest produces the canonical request map for a charge operation.
+func (m *Mpp) buildChargeRequest(params ChargeParams) (map[string]any, error) {
+	if builder, ok := m.method.(ChargeRequestBuilder); ok {
+		return builder.BuildChargeRequest(params)
+	}
+	request := map[string]any{
+		"amount":   params.Amount,
+		"currency": params.Currency,
+	}
+	if params.Recipient != "" {
+		request["recipient"] = params.Recipient
+	}
+	if params.ExternalID != "" {
+		request["externalId"] = params.ExternalID
+	}
+	if params.FeePayer {
+		request["feePayer"] = true
+	}
+	if params.ChainID != 0 {
+		request["chainId"] = params.ChainID
+	}
+	if params.Memo != "" {
+		request["memo"] = params.Memo
+	}
+	return request, nil
+}
+
 // Charge handles a charge intent with human-readable amounts.
 func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, error) {
 	intent, ok := m.method.Intents()["charge"]
@@ -108,33 +135,9 @@ func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, e
 		return nil, fmt.Errorf("method %q does not support charge intent", m.method.Name())
 	}
 
-	request := map[string]any{}
-	if builder, ok := m.method.(ChargeRequestBuilder); ok {
-		var err error
-		request, err = builder.BuildChargeRequest(params)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		request = map[string]any{
-			"amount":   params.Amount,
-			"currency": params.Currency,
-		}
-		if params.Recipient != "" {
-			request["recipient"] = params.Recipient
-		}
-		if params.ExternalID != "" {
-			request["externalId"] = params.ExternalID
-		}
-		if params.FeePayer {
-			request["feePayer"] = true
-		}
-		if params.ChainID != 0 {
-			request["chainId"] = params.ChainID
-		}
-		if params.Memo != "" {
-			request["memo"] = params.Memo
-		}
+	request, err := m.buildChargeRequest(params)
+	if err != nil {
+		return nil, err
 	}
 
 	result, err := VerifyOrChallenge(ctx, VerifyParams{


### PR DESCRIPTION
## Summary

Adds `ComposeMiddleware(...ComposeConfig)` to support multiple payment methods on a single route — the Go equivalent of mppx's `Mppx.compose()`.

### How it works

- **No credential (402):** Fans out to all configured methods, merges their `WWW-Authenticate` headers into a single 402 response.
- **With credential:** Parses the credential, matches by method name + intent, dispatches to that handler. Returns `method-unsupported` if no match.

### Usage

```go
tempoPayment := server.New(tempoMethod, realm, secret)
stripePayment := server.New(stripeMethod, realm, secret)

mux.Handle("/api/premium",
    server.ComposeMiddleware(
        server.ComposeConfig{Mpp: tempoPayment, Params: server.ChargeParams{Amount: "0.01"}},
        server.ComposeConfig{Mpp: stripePayment, Params: server.ChargeParams{Amount: "1.00"}},
    )(premiumHandler),
)
```

### Tests

- Fan-out: verifies 402 returns N `WWW-Authenticate` headers
- Dispatch: picks the correct method from a credential
- Unknown method: returns 400 `method-unsupported`
- Cross-method replay: tampered method name is rejected via HMAC
- Single method: works as a drop-in for `ChargeMiddleware`