### PR TITLE
feat: streamline Tempo charge setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -95,8 +96,8 @@ import (
 
 func main() {
 	method, _ := charge.New(charge.Config{
-		PrivateKeyEnv: "MPP_PRIVATE_KEY",
-		RPCURL:        "https://rpc.moderato.tempo.xyz",
+		PrivateKey: os.Getenv("MPP_PRIVATE_KEY"),
+		RPCURL:     "https://rpc.moderato.tempo.xyz",
 	})
 
 	c := client.New([]client.Method{method})

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import (
 )
 
 func main() {
-	method, _ := charge.New(charge.Config{
+	method, _ := charge.MethodFromConfig(charge.Config{
 		RPCURL: "https://rpc.moderato.tempo.xyz",
 		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 	})

--- a/README.md
+++ b/README.md
@@ -53,19 +53,12 @@ import (
 	"net/http"
 
 	"github.com/tempoxyz/mpp-go/pkg/server"
-	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 )
 
 func main() {
-	intent, _ := charge.NewIntent(charge.IntentConfig{
+	method, _ := charge.New(charge.Config{
 		RPCURL: "https://rpc.moderato.tempo.xyz",
-	})
-
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
-		ChainID:   42431,
-		Currency:  tempo.DefaultCurrencyForChain(42431),
 		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 	})
 
@@ -102,9 +95,8 @@ import (
 
 func main() {
 	method, _ := charge.New(charge.Config{
-		PrivateKey: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-		ChainID:    42431,
-		RPCURL:     "https://rpc.moderato.tempo.xyz",
+		PrivateKeyEnv: "MPP_PRIVATE_KEY",
+		RPCURL:        "https://rpc.moderato.tempo.xyz",
 	})
 
 	c := client.New([]client.Method{method})

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -47,17 +47,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: merchant.Address().Hex(),
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	secretKey := "basic-example-secret"
 	if envSecret := getenv("MPP_SECRET_KEY"); envSecret != "" {

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -47,7 +47,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/charge-basic/server.go
+++ b/examples/charge-basic/server.go
@@ -16,7 +16,7 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/charge-basic/server.go
+++ b/examples/charge-basic/server.go
@@ -16,16 +16,15 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		return nil, err
-	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: devnet.Recipient,
 	})
+	if err != nil {
+		return nil, err
+	}
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-basic/server/main.go
+++ b/examples/charge-basic/server/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/charge-basic/server/main.go
+++ b/examples/charge-basic/server/main.go
@@ -21,16 +21,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: devnet.Recipient,
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	mux := http.NewServeMux()

--- a/examples/charge-fee-payer/server.go
+++ b/examples/charge-fee-payer/server.go
@@ -16,7 +16,7 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:             rpcURL,
 		ChainID:            chainID,
 		Currency:           devnet.Currency,

--- a/examples/charge-fee-payer/server.go
+++ b/examples/charge-fee-payer/server.go
@@ -16,20 +16,17 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	intent, err := charge.NewIntent(charge.IntentConfig{
-		FeePayerPrivateKey: devnet.FeePayerPrivateKey,
+	method, err := charge.New(charge.Config{
 		RPCURL:             rpcURL,
+		ChainID:            chainID,
+		Currency:           devnet.Currency,
+		FeePayerPrivateKey: devnet.FeePayerPrivateKey,
+		FeePayer:           true,
+		Recipient:          devnet.Recipient,
 	})
 	if err != nil {
 		return nil, err
 	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
-		ChainID:   chainID,
-		Currency:  devnet.Currency,
-		FeePayer:  true,
-		Recipient: devnet.Recipient,
-	})
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-fee-payer/server/main.go
+++ b/examples/charge-fee-payer/server/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:             rpcURL,
 		ChainID:            chainID,
 		Currency:           devnet.Currency,

--- a/examples/charge-fee-payer/server/main.go
+++ b/examples/charge-fee-payer/server/main.go
@@ -30,17 +30,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{FeePayerPrivateKey: devnet.FeePayerPrivateKey, RPCURL: rpcURL})
+	method, err := charge.New(charge.Config{
+		RPCURL:             rpcURL,
+		ChainID:            chainID,
+		Currency:           devnet.Currency,
+		FeePayerPrivateKey: devnet.FeePayerPrivateKey,
+		FeePayer:           true,
+		Recipient:          devnet.Recipient,
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
-		ChainID:   chainID,
-		Currency:  devnet.Currency,
-		FeePayer:  true,
-		Recipient: devnet.Recipient,
-	})
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	mux := http.NewServeMux()

--- a/examples/charge-hash/server.go
+++ b/examples/charge-hash/server.go
@@ -17,7 +17,7 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:         rpcURL,
 		ChainID:        chainID,
 		Currency:       devnet.Currency,

--- a/examples/charge-hash/server.go
+++ b/examples/charge-hash/server.go
@@ -17,17 +17,16 @@ type exampleServer struct {
 }
 
 func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		return nil, err
-	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:         intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:         rpcURL,
 		ChainID:        chainID,
 		Currency:       devnet.Currency,
 		Recipient:      devnet.Recipient,
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
+	if err != nil {
+		return nil, err
+	}
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-hash/server/main.go
+++ b/examples/charge-hash/server/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:         rpcURL,
 		ChainID:        chainID,
 		Currency:       devnet.Currency,

--- a/examples/charge-hash/server/main.go
+++ b/examples/charge-hash/server/main.go
@@ -21,17 +21,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:         intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:         rpcURL,
 		ChainID:        chainID,
 		Currency:       devnet.Currency,
 		Recipient:      devnet.Recipient,
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	payment := server.New(method, devnet.Realm, "example-secret")
 
 	mux := http.NewServeMux()

--- a/examples/chi/server/main.go
+++ b/examples/chi/server/main.go
@@ -34,17 +34,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: merchant.Address().Hex(),
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	secretKey := "chi-example-secret"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {

--- a/examples/chi/server/main.go
+++ b/examples/chi/server/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/echo/server/main.go
+++ b/examples/echo/server/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/echo/server/main.go
+++ b/examples/echo/server/main.go
@@ -34,17 +34,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: merchant.Address().Hex(),
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	secretKey := "echo-example-secret"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {

--- a/examples/gin/server/main.go
+++ b/examples/gin/server/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	method, err := charge.New(charge.Config{
+	method, err := charge.MethodFromConfig(charge.Config{
 		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,

--- a/examples/gin/server/main.go
+++ b/examples/gin/server/main.go
@@ -34,17 +34,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	intent, err := charge.NewIntent(charge.IntentConfig{RPCURL: rpcURL})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	method := charge.NewMethod(charge.MethodConfig{
-		Intent:    intent,
+	method, err := charge.New(charge.Config{
+		RPCURL:    rpcURL,
 		ChainID:   chainID,
 		Currency:  devnet.Currency,
 		Recipient: merchant.Address().Hex(),
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	secretKey := "gin-example-secret"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
 	"strings"
 	"time"
 
@@ -27,6 +28,8 @@ type Config struct {
 	Signer *temposigner.Signer
 	// PrivateKey constructs Signer when Signer is nil.
 	PrivateKey string
+	// PrivateKeyEnv loads the signing key from an environment variable when PrivateKey is empty.
+	PrivateKeyEnv string
 	// RPC overrides the Tempo JSON-RPC client used for signing flows.
 	RPC tempo.RPCClient
 	// RPCURL is used to build an RPC client when RPC is nil.
@@ -53,22 +56,36 @@ var _ mppclient.Method = (*Method)(nil)
 
 // New constructs a Tempo charge client method.
 func New(config Config) (*Method, error) {
+	if config.RPC == nil && config.RPCURL == "" && config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
+		return nil, fmt.Errorf("tempo client: unknown chain id %d; configure RPC or RPCURL explicitly", config.ChainID)
+	}
+	privateKey := config.PrivateKey
+	if privateKey == "" && config.PrivateKeyEnv != "" {
+		privateKey = os.Getenv(config.PrivateKeyEnv)
+		if privateKey == "" {
+			return nil, fmt.Errorf("tempo client: %s is not set", config.PrivateKeyEnv)
+		}
+	}
 	signer := config.Signer
 	if signer == nil {
-		if config.PrivateKey == "" {
+		if privateKey == "" {
 			return nil, fmt.Errorf("tempo client: signer or private key is required")
 		}
-		resolved, err := temposigner.NewSigner(config.PrivateKey)
+		resolved, err := temposigner.NewSigner(privateKey)
 		if err != nil {
 			return nil, err
 		}
 		signer = resolved
 	}
+	chainID := config.ChainID
+	if chainID == 0 {
+		chainID = tempo.InferChainIDFromRPCURL(config.RPCURL)
+	}
 	return &Method{
 		signer:         signer,
 		rpc:            config.RPC,
 		rpcURL:         config.RPCURL,
-		chainID:        config.ChainID,
+		chainID:        chainID,
 		clientID:       config.ClientID,
 		credentialType: config.CredentialType,
 	}, nil
@@ -98,7 +115,10 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 		credentialType = tempo.CredentialTypeTransaction
 	}
 
-	rpc, rpcURL := m.resolveRPC(request)
+	rpc, rpcURL, err := m.resolveRPC(request)
+	if err != nil {
+		return nil, err
+	}
 	if rpc == nil {
 		rpc = tempo.NewRPCClient(rpcURL)
 	}
@@ -340,18 +360,26 @@ func (m *Method) expectedChainID(request tempo.ChargeRequest) int64 {
 	return m.chainID
 }
 
-func (m *Method) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, string) {
+func (m *Method) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, string, error) {
 	if m.rpc != nil {
-		return m.rpc, m.rpcURL
+		return m.rpc, m.rpcURL, nil
 	}
 	if m.rpcURL != "" {
-		return nil, m.rpcURL
+		return nil, m.rpcURL, nil
 	}
 	if request.MethodDetails.ChainID != nil {
-		return nil, tempo.DefaultRPCURLForChain(*request.MethodDetails.ChainID)
+		rpcURL, err := tempo.RPCURLForChain(*request.MethodDetails.ChainID)
+		if err != nil {
+			return nil, "", fmt.Errorf("tempo client: %w; configure RPC or RPCURL explicitly", err)
+		}
+		return nil, rpcURL, nil
 	}
 	if m.chainID != 0 {
-		return nil, tempo.DefaultRPCURLForChain(m.chainID)
+		rpcURL, err := tempo.RPCURLForChain(m.chainID)
+		if err != nil {
+			return nil, "", fmt.Errorf("tempo client: %w; configure RPC or RPCURL explicitly", err)
+		}
+		return nil, rpcURL, nil
 	}
-	return nil, tempo.DefaultRPCURLForChain(0)
+	return nil, tempo.DefaultRPCURLForChain(0), nil
 }

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"strings"
 	"time"
 
@@ -28,8 +27,6 @@ type Config struct {
 	Signer *temposigner.Signer
 	// PrivateKey constructs Signer when Signer is nil.
 	PrivateKey string
-	// PrivateKeyEnv loads the signing key from an environment variable when PrivateKey is empty.
-	PrivateKeyEnv string
 	// RPC overrides the Tempo JSON-RPC client used for signing flows.
 	RPC tempo.RPCClient
 	// RPCURL is used to build an RPC client when RPC is nil.
@@ -59,19 +56,12 @@ func New(config Config) (*Method, error) {
 	if config.RPC == nil && config.RPCURL == "" && config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
 		return nil, fmt.Errorf("tempo client: unknown chain id %d; configure RPC or RPCURL explicitly", config.ChainID)
 	}
-	privateKey := config.PrivateKey
-	if privateKey == "" && config.PrivateKeyEnv != "" {
-		privateKey = os.Getenv(config.PrivateKeyEnv)
-		if privateKey == "" {
-			return nil, fmt.Errorf("tempo client: %s is not set", config.PrivateKeyEnv)
-		}
-	}
 	signer := config.Signer
 	if signer == nil {
-		if privateKey == "" {
+		if config.PrivateKey == "" {
 			return nil, fmt.Errorf("tempo client: signer or private key is required")
 		}
-		resolved, err := temposigner.NewSigner(privateKey)
+		resolved, err := temposigner.NewSigner(config.PrivateKey)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	temporpc "github.com/tempoxyz/tempo-go/pkg/client"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
 const (
@@ -139,6 +140,61 @@ func TestCreateCredentialScenarios(t *testing.T) {
 				t.Fatalf("len(tt.rpc.sentRawTxs) = %d, want %d", got, tt.wantBroadcasts)
 			}
 		})
+	}
+}
+
+func TestNewInfersChainIDFromRPCURL(t *testing.T) {
+	t.Parallel()
+
+	method, err := New(Config{
+		PrivateKey: testPrivateKey,
+		RPCURL:     tempotx.RpcUrlModerato,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if method.chainID != tempotx.ChainIdModerato {
+		t.Fatalf("method.chainID = %d, want %d", method.chainID, tempotx.ChainIdModerato)
+	}
+}
+
+func TestNewLoadsPrivateKeyFromEnv(t *testing.T) {
+	t.Setenv("MPP_PRIVATE_KEY", testPrivateKey)
+	method, err := New(Config{PrivateKeyEnv: "MPP_PRIVATE_KEY"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if method.signer == nil {
+		t.Fatal("method.signer = nil, want signer")
+	}
+}
+
+func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(Config{PrivateKey: testPrivateKey, ChainID: 999999})
+	if err == nil || err.Error() != "tempo client: unknown chain id 999999; configure RPC or RPCURL explicitly" {
+		t.Fatalf("New() error = %v, want unknown chain id error", err)
+	}
+}
+
+func TestCreateCredentialRejectsUnknownChallengeChainWithoutRPC(t *testing.T) {
+	t.Parallel()
+
+	method, err := New(Config{PrivateKey: testPrivateKey})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	challenge := buildChallenge(t, tempo.ChargeRequestParams{
+		Amount:    "0.50",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   999999,
+	})
+	_, err = method.CreateCredential(context.Background(), challenge)
+	if err == nil || !strings.Contains(err.Error(), "unknown chain id 999999") {
+		t.Fatalf("CreateCredential() error = %v, want unknown chain id error", err)
 	}
 }
 

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -158,17 +158,6 @@ func TestNewInfersChainIDFromRPCURL(t *testing.T) {
 	}
 }
 
-func TestNewLoadsPrivateKeyFromEnv(t *testing.T) {
-	t.Setenv("MPP_PRIVATE_KEY", testPrivateKey)
-	method, err := New(Config{PrivateKeyEnv: "MPP_PRIVATE_KEY"})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-	if method.signer == nil {
-		t.Fatal("method.signer = nil, want signer")
-	}
-}
-
 func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/defaults.go
+++ b/pkg/tempo/defaults.go
@@ -1,6 +1,10 @@
 package tempo
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
+
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 	"math/big"
 )
@@ -11,15 +15,65 @@ import (
 // ExpiringNonceKey is the reserved nonce key used for fee-payer transactions.
 var ExpiringNonceKey = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
 
+// RPCURLForChain returns the canonical Tempo RPC URL for a known chain ID.
+// Chain ID 0 falls back to mainnet defaults.
+func RPCURLForChain(chainID int64) (string, error) {
+	switch chainID {
+	case 0, tempotx.ChainIdMainnet:
+		return tempotx.RpcUrlMainnet, nil
+	case tempotx.ChainIdModerato:
+		return tempotx.RpcUrlModerato, nil
+	default:
+		return "", fmt.Errorf("unknown chain id %d", chainID)
+	}
+}
+
 // DefaultRPCURLForChain returns the canonical Tempo RPC URL for a chain ID.
 func DefaultRPCURLForChain(chainID int64) string {
-	switch chainID {
-	case tempotx.ChainIdModerato:
-		return tempotx.RpcUrlModerato
-	case tempotx.ChainIdMainnet:
-		fallthrough
+	if rpcURL, err := RPCURLForChain(chainID); err == nil {
+		return rpcURL
+	}
+	return tempotx.RpcUrlMainnet
+}
+
+// InferChainIDFromRPCURL maps known Tempo RPC URLs back to their chain IDs.
+// It returns 0 when the URL does not match a known Tempo endpoint.
+func InferChainIDFromRPCURL(rpcURL string) int64 {
+	normalized := normalizeRPCURL(rpcURL)
+	switch normalized {
+	case normalizeRPCURL(tempotx.RpcUrlModerato):
+		return tempotx.ChainIdModerato
+	case normalizeRPCURL(tempotx.RpcUrlMainnet):
+		return tempotx.ChainIdMainnet
+	}
+	if normalized == "" {
+		return 0
+	}
+	parsed, err := url.Parse(strings.TrimSpace(rpcURL))
+	if err != nil {
+		return 0
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "rpc.moderato.tempo.xyz", "rpc.testnet.tempo.xyz":
+		return tempotx.ChainIdModerato
+	case "rpc.tempo.xyz":
+		return tempotx.ChainIdMainnet
 	default:
-		return tempotx.RpcUrlMainnet
+		return 0
+	}
+}
+
+func normalizeRPCURL(rpcURL string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(rpcURL)), "/")
+}
+
+// IsKnownChainID reports whether the chain ID maps to a built-in Tempo network.
+func IsKnownChainID(chainID int64) bool {
+	switch chainID {
+	case tempotx.ChainIdMainnet, tempotx.ChainIdModerato:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/tempo/defaults_test.go
+++ b/pkg/tempo/defaults_test.go
@@ -19,3 +19,68 @@ func TestDefaultCurrencyForChain(t *testing.T) {
 		t.Fatalf("DefaultCurrencyForChain(unknown) = %q, want %q", got, tempotx.AlphaUSDAddress.Hex())
 	}
 }
+
+func TestInferChainIDFromRPCURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		rpcURL string
+		want   int64
+	}{
+		{name: "mainnet exact", rpcURL: tempotx.RpcUrlMainnet, want: tempotx.ChainIdMainnet},
+		{name: "mainnet trailing slash", rpcURL: tempotx.RpcUrlMainnet + "/", want: tempotx.ChainIdMainnet},
+		{name: "moderato exact", rpcURL: tempotx.RpcUrlModerato, want: tempotx.ChainIdModerato},
+		{name: "moderato path", rpcURL: tempotx.RpcUrlModerato + "/rpc", want: tempotx.ChainIdModerato},
+		{name: "unknown", rpcURL: "https://rpc.example.com", want: 0},
+		{name: "empty", rpcURL: "", want: 0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := InferChainIDFromRPCURL(tt.rpcURL); got != tt.want {
+				t.Fatalf("InferChainIDFromRPCURL(%q) = %d, want %d", tt.rpcURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRPCURLForChain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		chainID int64
+		want    string
+		wantErr string
+	}{
+		{name: "mainnet", chainID: tempotx.ChainIdMainnet, want: tempotx.RpcUrlMainnet},
+		{name: "moderato", chainID: tempotx.ChainIdModerato, want: tempotx.RpcUrlModerato},
+		{name: "zero defaults to mainnet", chainID: 0, want: tempotx.RpcUrlMainnet},
+		{name: "unknown", chainID: 999999, wantErr: "unknown chain id 999999"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := RPCURLForChain(tt.chainID)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("RPCURLForChain(%d) error = %v, want %q", tt.chainID, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RPCURLForChain(%d) error = %v", tt.chainID, err)
+			}
+			if got != tt.want {
+				t.Fatalf("RPCURLForChain(%d) = %q, want %q", tt.chainID, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -51,6 +52,8 @@ type IntentConfig struct {
 	FeePayerSigner *temposigner.Signer
 	// FeePayerPrivateKey constructs FeePayerSigner when FeePayerSigner is nil.
 	FeePayerPrivateKey string
+	// FeePayerPrivateKeyEnv loads the fee-payer key from an environment variable when FeePayerPrivateKey is empty.
+	FeePayerPrivateKeyEnv string
 	// Store persists replay-protection keys for hash and proof credentials.
 	Store tempo.Store
 }
@@ -65,9 +68,16 @@ type Intent struct {
 
 // NewIntent constructs a Tempo charge verifier.
 func NewIntent(config IntentConfig) (*Intent, error) {
+	feePayerPrivateKey := config.FeePayerPrivateKey
+	if feePayerPrivateKey == "" && config.FeePayerPrivateKeyEnv != "" {
+		feePayerPrivateKey = os.Getenv(config.FeePayerPrivateKeyEnv)
+		if feePayerPrivateKey == "" {
+			return nil, fmt.Errorf("tempo server: %s is not set", config.FeePayerPrivateKeyEnv)
+		}
+	}
 	feePayerSigner := config.FeePayerSigner
-	if feePayerSigner == nil && config.FeePayerPrivateKey != "" {
-		resolved, err := temposigner.NewSigner(config.FeePayerPrivateKey)
+	if feePayerSigner == nil && feePayerPrivateKey != "" {
+		resolved, err := temposigner.NewSigner(feePayerPrivateKey)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +128,10 @@ func (i *Intent) Verify(
 		return nil, mpp.ErrInvalidPayload(fmt.Sprintf("credential type %q is not allowed for this challenge", payload.Type))
 	}
 
-	rpc := i.resolveRPC(request)
+	rpc, err := i.resolveRPC(request)
+	if err != nil {
+		return nil, err
+	}
 
 	switch payload.Type {
 	case tempo.CredentialTypeHash:
@@ -328,17 +341,21 @@ func (i *Intent) verifyTransaction(
 	), nil
 }
 
-func (i *Intent) resolveRPC(request tempo.ChargeRequest) tempo.RPCClient {
+func (i *Intent) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, error) {
 	if i.rpc != nil {
-		return i.rpc
+		return i.rpc, nil
 	}
 	if i.rpcURL != "" {
-		return tempo.NewRPCClient(i.rpcURL)
+		return tempo.NewRPCClient(i.rpcURL), nil
 	}
 	if request.MethodDetails.ChainID != nil {
-		return tempo.NewRPCClient(tempo.DefaultRPCURLForChain(*request.MethodDetails.ChainID))
+		rpcURL, err := tempo.RPCURLForChain(*request.MethodDetails.ChainID)
+		if err != nil {
+			return nil, fmt.Errorf("tempo server: %w; configure Intent.RPC or Intent.RPCURL explicitly", err)
+		}
+		return tempo.NewRPCClient(rpcURL), nil
 	}
-	return tempo.NewRPCClient(tempo.DefaultRPCURLForChain(0))
+	return tempo.NewRPCClient(tempo.DefaultRPCURLForChain(0)), nil
 }
 
 // TODO(tempo-go): extract the Tempo transaction/receipt matching and fee-payer

--- a/pkg/tempo/server/config.go
+++ b/pkg/tempo/server/config.go
@@ -40,8 +40,8 @@ type Config struct {
 	Store tempo.Store
 }
 
-// New constructs a Tempo charge method from one config struct.
-func New(config Config) (*Method, error) {
+// MethodFromConfig constructs a Tempo charge method from one config struct.
+func MethodFromConfig(config Config) (*Method, error) {
 	methodConfig := MethodConfig{
 		Intent:         config.Intent,
 		Currency:       config.Currency,

--- a/pkg/tempo/server/config.go
+++ b/pkg/tempo/server/config.go
@@ -1,0 +1,71 @@
+package chargeserver
+
+import (
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+// Config combines the method defaults and intent verification settings used by
+// the high-level Tempo server constructor.
+type Config struct {
+	// Intent verifies Tempo charge credentials for this method.
+	Intent *Intent
+	// Currency is the default token contract address for issued challenges.
+	Currency string
+	// Recipient is the default payee address for issued challenges.
+	Recipient string
+	// Decimals controls how human-readable amounts are normalized.
+	Decimals int
+	// ChainID binds issued challenges to a specific Tempo chain when set.
+	ChainID int64
+	// FeePayer enables sponsored transaction flows by default.
+	FeePayer bool
+	// FeePayerURL points at a remote co-signer when the server does not sign locally.
+	FeePayerURL string
+	// Memo overrides the default attribution memo generation.
+	Memo string
+	// SupportedModes limits the credential submission modes advertised to clients.
+	SupportedModes []tempo.ChargeMode
+	// RPC overrides the Tempo JSON-RPC client used for verification.
+	RPC tempo.RPCClient
+	// RPCURL is used to build an RPC client when RPC is nil.
+	RPCURL string
+	// FeePayerSigner co-signs sponsored transactions locally when provided.
+	FeePayerSigner *temposigner.Signer
+	// FeePayerPrivateKey constructs FeePayerSigner when FeePayerSigner is nil.
+	FeePayerPrivateKey string
+	// FeePayerPrivateKeyEnv loads the fee-payer key from an environment variable when FeePayerPrivateKey is empty.
+	FeePayerPrivateKeyEnv string
+	// Store persists replay-protection keys for hash and proof credentials.
+	Store tempo.Store
+}
+
+// New constructs a Tempo charge method from one config struct.
+func New(config Config) (*Method, error) {
+	methodConfig := MethodConfig{
+		Intent:         config.Intent,
+		Currency:       config.Currency,
+		Recipient:      config.Recipient,
+		Decimals:       config.Decimals,
+		ChainID:        config.ChainID,
+		FeePayer:       config.FeePayer,
+		FeePayerURL:    config.FeePayerURL,
+		Memo:           config.Memo,
+		SupportedModes: append([]tempo.ChargeMode(nil), config.SupportedModes...),
+	}
+	if methodConfig.Intent == nil {
+		intent, err := NewIntent(IntentConfig{
+			RPC:                   config.RPC,
+			RPCURL:                config.RPCURL,
+			FeePayerSigner:        config.FeePayerSigner,
+			FeePayerPrivateKey:    config.FeePayerPrivateKey,
+			FeePayerPrivateKeyEnv: config.FeePayerPrivateKeyEnv,
+			Store:                 config.Store,
+		})
+		if err != nil {
+			return nil, err
+		}
+		methodConfig.Intent = intent
+	}
+	return NewMethod(methodConfig), nil
+}

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -8,15 +8,15 @@ import (
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
-func TestNewConvenienceBuildsMethod(t *testing.T) {
+func TestMethodFromConfigBuildsMethod(t *testing.T) {
 	t.Parallel()
 
-	method, err := New(Config{
+	method, err := MethodFromConfig(Config{
 		RPCURL:    tempotx.RpcUrlModerato,
 		Recipient: testRecipient,
 	})
 	if err != nil {
-		t.Fatalf("New() error = %v", err)
+		t.Fatalf("MethodFromConfig() error = %v", err)
 	}
 	requestMap, err := method.BuildChargeRequest(mppserver.ChargeParams{Amount: "0.50"})
 	if err != nil {

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -1,0 +1,46 @@
+package chargeserver
+
+import (
+	"testing"
+
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+func TestNewConvenienceBuildsMethod(t *testing.T) {
+	t.Parallel()
+
+	method, err := New(Config{
+		RPCURL:    tempotx.RpcUrlModerato,
+		Recipient: testRecipient,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	requestMap, err := method.BuildChargeRequest(mppserver.ChargeParams{Amount: "0.50"})
+	if err != nil {
+		t.Fatalf("BuildChargeRequest() error = %v", err)
+	}
+	request, err := tempo.ParseChargeRequest(requestMap)
+	if err != nil {
+		t.Fatalf("ParseChargeRequest() error = %v", err)
+	}
+	if request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato {
+		t.Fatalf("request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato)
+	}
+	if request.Currency != tempotx.AlphaUSDAddress.Hex() {
+		t.Fatalf("request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex())
+	}
+}
+
+func TestNewIntentLoadsFeePayerPrivateKeyFromEnv(t *testing.T) {
+	t.Setenv("FEE_PAYER_KEY", feePayerKey)
+	intent, err := NewIntent(IntentConfig{FeePayerPrivateKeyEnv: "FEE_PAYER_KEY"})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if intent.feePayerSigner == nil {
+		t.Fatal("intent.feePayerSigner = nil, want signer")
+	}
+}

--- a/pkg/tempo/server/method.go
+++ b/pkg/tempo/server/method.go
@@ -53,14 +53,17 @@ func NewMethod(config MethodConfig) *Method {
 	if decimals == 0 {
 		decimals = tempo.DefaultDecimals
 	}
-	chainID := config.ChainID
-	currency := config.Currency
-	if currency == "" {
-		currency = tempo.DefaultCurrencyForChain(chainID)
-	}
 	intent := config.Intent
 	if intent == nil {
 		intent, _ = NewIntent(IntentConfig{})
+	}
+	chainID := config.ChainID
+	if chainID == 0 {
+		chainID = tempo.InferChainIDFromRPCURL(intent.rpcURL)
+	}
+	currency := config.Currency
+	if currency == "" {
+		currency = tempo.DefaultCurrencyForChain(chainID)
 	}
 	return &Method{
 		intent:         intent,
@@ -104,6 +107,9 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 	chainID := int64(params.ChainID)
 	if chainID == 0 {
 		chainID = m.chainID
+	}
+	if chainID != 0 && m.intent.rpc == nil && m.intent.rpcURL == "" && !tempo.IsKnownChainID(chainID) {
+		return nil, fmt.Errorf("tempo server: unknown chain id %d; configure Intent.RPC or Intent.RPCURL explicitly", chainID)
 	}
 	memo := params.Memo
 	if memo == "" {

--- a/pkg/tempo/server/method_test.go
+++ b/pkg/tempo/server/method_test.go
@@ -5,10 +5,16 @@ import (
 
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
 func TestMethodBuildChargeRequest(t *testing.T) {
 	t.Parallel()
+
+	moderatoIntent, err := NewIntent(IntentConfig{RPCURL: tempotx.RpcUrlModerato})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
 
 	tests := []struct {
 		name       string
@@ -16,6 +22,35 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 		params     mppserver.ChargeParams
 		assertions func(*testing.T, tempo.ChargeRequest)
 	}{
+		{
+			name: "infers chain and currency from intent rpc url",
+			config: MethodConfig{
+				Intent:    moderatoIntent,
+				Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+			},
+			params: mppserver.ChargeParams{
+				Amount: "0.50",
+			},
+			assertions: func(t *testing.T, request tempo.ChargeRequest) {
+				t.Helper()
+				if request.Currency != tempotx.AlphaUSDAddress.Hex() {
+					t.Fatalf("request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex())
+				}
+				if request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato {
+					t.Fatalf("request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato)
+				}
+			},
+		},
+		{
+			name: "rejects unknown chain without intent rpc",
+			config: MethodConfig{
+				ChainID:   999999,
+				Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+			},
+			params: mppserver.ChargeParams{
+				Amount: "0.50",
+			},
+		},
 		{
 			name: "includes external id and fee payer url",
 			config: MethodConfig{
@@ -97,6 +132,12 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 
 			method := NewMethod(tt.config)
 			requestMap, err := method.BuildChargeRequest(tt.params)
+			if tt.name == "rejects unknown chain without intent rpc" {
+				if err == nil || err.Error() != "tempo server: unknown chain id 999999; configure Intent.RPC or Intent.RPCURL explicitly" {
+					t.Fatalf("BuildChargeRequest() error = %v, want unknown chain id error", err)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("BuildChargeRequest() error = %v", err)
 			}


### PR DESCRIPTION
## Summary
- add a high-level `charge.New` server constructor so Tempo charge setup fits in one config struct
- add env-backed key fields for client and server signing config
- stop silently routing unknown nonzero chain IDs to mainnet, and return explicit configuration errors instead

## Testing
- `go test ./...`
- `go build ./...`