### PR TITLE
fix: include the challenge realm in proof signatures

### DIFF
--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -121,7 +121,7 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 		return nil, fmt.Errorf("tempo client: chain id mismatch (rpc=%d, expected=%d)", chainID, expected)
 	}
 	if request.Amount == "0" {
-		signature, err := m.signProof(int64(chainID), challenge.ID)
+		signature, err := m.signProof(int64(chainID), challenge.ID, challenge.Realm)
 		if err != nil {
 			return nil, err
 		}
@@ -241,8 +241,8 @@ func (m *Method) buildTransfer(
 	return serialized, nil
 }
 
-func (m *Method) signProof(chainID int64, challengeID string) (string, error) {
-	hash, err := tempo.ProofTypedDataHash(chainID, challengeID)
+func (m *Method) signProof(chainID int64, challengeID, realm string) (string, error) {
+	hash, err := tempo.ProofTypedDataHash(chainID, challengeID, realm)
 	if err != nil {
 		return "", fmt.Errorf("tempo client: build proof payload: %w", err)
 	}

--- a/pkg/tempo/proof.go
+++ b/pkg/tempo/proof.go
@@ -14,7 +14,7 @@ func ProofSource(chainID int64, address common.Address) string {
 }
 
 // ProofTypedDataHash returns the EIP-712 digest for a Tempo proof credential.
-func ProofTypedDataHash(chainID int64, challengeID string) (common.Hash, error) {
+func ProofTypedDataHash(chainID int64, challengeID, realm string) (common.Hash, error) {
 	typedData := apitypes.TypedData{
 		Types: apitypes.Types{
 			"EIP712Domain": {
@@ -24,6 +24,7 @@ func ProofTypedDataHash(chainID int64, challengeID string) (common.Hash, error) 
 			},
 			"Proof": {
 				{Name: "challengeId", Type: "string"},
+				{Name: "realm", Type: "string"},
 			},
 		},
 		PrimaryType: "Proof",
@@ -34,6 +35,7 @@ func ProofTypedDataHash(chainID int64, challengeID string) (common.Hash, error) 
 		},
 		Message: apitypes.TypedDataMessage{
 			"challengeId": challengeID,
+			"realm":       realm,
 		},
 	}
 	hash, _, err := apitypes.TypedDataAndHash(typedData)

--- a/pkg/tempo/proof_rpc_test.go
+++ b/pkg/tempo/proof_rpc_test.go
@@ -31,23 +31,30 @@ func TestProofHelpers(t *testing.T) {
 		t.Fatalf("ProofSource() = %q, want %q", got, "did:pkh:eip155:42431:"+address.Hex())
 	}
 
-	hash1, err := ProofTypedDataHash(42431, "challenge-1")
+	hash1, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
 	if err != nil {
 		t.Fatalf("ProofTypedDataHash() error = %v", err)
 	}
-	hash2, err := ProofTypedDataHash(42431, "challenge-1")
+	hash2, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
 	if err != nil {
 		t.Fatalf("ProofTypedDataHash() repeat error = %v", err)
 	}
-	hash3, err := ProofTypedDataHash(42431, "challenge-2")
+	hash3, err := ProofTypedDataHash(42431, "challenge-2", "api.example.com")
 	if err != nil {
 		t.Fatalf("ProofTypedDataHash() different challenge error = %v", err)
+	}
+	hash4, err := ProofTypedDataHash(42431, "challenge-1", "other.example.com")
+	if err != nil {
+		t.Fatalf("ProofTypedDataHash() different realm error = %v", err)
 	}
 	if hash1 != hash2 {
 		t.Fatalf("hash1 = %s, want same hash as hash2 %s", hash1.Hex(), hash2.Hex())
 	}
 	if hash1 == hash3 {
 		t.Fatalf("hash1 = %s, want different hash from hash3 %s", hash1.Hex(), hash3.Hex())
+	}
+	if hash1 == hash4 {
+		t.Fatalf("hash1 = %s, want different hash from hash4 %s", hash1.Hex(), hash4.Hex())
 	}
 }
 

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -201,7 +201,7 @@ func (i *Intent) verifyProof(
 	if source.chainID != chainID {
 		return nil, mpp.ErrInvalidPayload("credential source chain id does not match the challenge")
 	}
-	proofHash, err := tempo.ProofTypedDataHash(chainID, credential.Challenge.ID)
+	proofHash, err := tempo.ProofTypedDataHash(chainID, credential.Challenge.ID, credential.Challenge.Realm)
 	if err != nil {
 		return nil, mpp.ErrVerificationFailed("failed to construct proof payload")
 	}

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -234,7 +234,7 @@ func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSigner(access key) error = %v", err)
 	}
-	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID)
+	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
 	if err != nil {
 		t.Fatalf("ProofTypedDataHash() error = %v", err)
 	}
@@ -293,7 +293,7 @@ func TestChargeFlow_ProofCredentialWithAccessKeyWithoutExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSigner(access key) error = %v", err)
 	}
-	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID)
+	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
 	if err != nil {
 		t.Fatalf("ProofTypedDataHash() error = %v", err)
 	}
@@ -481,6 +481,37 @@ func TestChargeFlow_RejectsMalformedCredentialSource(t *testing.T) {
 	}
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "credential source is invalid") {
 		t.Fatalf("Verify() error = %v, want invalid credential source", err)
+	}
+}
+
+func TestChargeFlow_ProofCredentialRejectsDifferentRealm(t *testing.T) {
+	ctx := context.Background()
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:    "0",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	}
+	rpc := newMockRPC(request)
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeProof)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+	credential.Challenge.Realm = "other.example.com"
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "proof signature does not match source") {
+		t.Fatalf("Verify() error = %v, want proof signature mismatch", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- bind zero-amount proof signatures to the challenge realm
- update client and server proof handling
- add realm-sensitive regression coverage

## Testing
- go test ./...