### PR TITLE
fix: apply fee payer limits per token

### DIFF
--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -825,39 +825,12 @@ func defaultFeePayerPolicies() map[string]FeePayerPolicy {
 }
 
 func feePayerPolicyForDecimals(decimals int) FeePayerPolicy {
-	if decimals == tempo.DefaultDecimals {
-		return FeePayerPolicy{
-			Decimals:             decimals,
-			MaxFeePerGas:         big.NewInt(100_000),
-			MaxPriorityFeePerGas: big.NewInt(100_000),
-			MaxTotalFee:          big.NewInt(150_000_000),
-		}
-	}
-	maxFeePerGas := scaleFeePayerCap(feePayerMaxFeePerGas, decimals)
-	maxTotalFee := scaleFeePayerCap(feePayerMaxTotalFee, decimals)
-	minimumDefaultTotalFee := new(big.Int).Mul(new(big.Int).SetUint64(tempo.DefaultGasLimit), maxFeePerGas)
-	if maxTotalFee.Cmp(minimumDefaultTotalFee) < 0 {
-		maxTotalFee = minimumDefaultTotalFee
-	}
 	return FeePayerPolicy{
 		Decimals:             decimals,
-		MaxFeePerGas:         maxFeePerGas,
-		MaxPriorityFeePerGas: scaleFeePayerCap(feePayerMaxPriorityFeePerGas, decimals),
-		MaxTotalFee:          maxTotalFee,
+		MaxFeePerGas:         new(big.Int).Set(feePayerMaxFeePerGas),
+		MaxPriorityFeePerGas: new(big.Int).Set(feePayerMaxPriorityFeePerGas),
+		MaxTotalFee:          new(big.Int).Set(feePayerMaxTotalFee),
 	}
-}
-
-func scaleFeePayerCap(value *big.Int, decimals int) *big.Int {
-	if decimals >= 18 {
-		multiplier := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals-18)), nil)
-		return new(big.Int).Mul(new(big.Int).Set(value), multiplier)
-	}
-	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(18-decimals)), nil)
-	quotient := new(big.Int).Quo(new(big.Int).Set(value), divisor)
-	if quotient.Sign() > 0 {
-		return quotient
-	}
-	return big.NewInt(1)
 }
 
 func (i *Intent) feePayerPolicyFor(currency string) (FeePayerPolicy, error) {

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -818,8 +818,9 @@ func normalizeFeePayerPolicies(configured map[string]FeePayerPolicy) (map[string
 func defaultFeePayerPolicies() map[string]FeePayerPolicy {
 	policy := feePayerPolicyForDecimals(tempo.DefaultDecimals)
 	return map[string]FeePayerPolicy{
-		tempotx.AlphaUSDAddress.Hex(): policy,
-		tempo.MainnetUSDCAddress:      policy,
+		"0x20c0000000000000000000000000000000000000": policy,
+		tempotx.AlphaUSDAddress.Hex():                policy,
+		tempo.MainnetUSDCAddress:                     policy,
 	}
 }
 

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -23,8 +23,8 @@ import (
 const receiptRetryDelay = 500 * time.Millisecond
 const receiptRetryAttempts = 20
 
-// Sponsor policy caps for fee-payer transactions. These values match the
-// narrow Tempo charge flow this package supports today.
+// Sponsor policy caps for fee-payer transactions. These values are defined in
+// 18-decimal precision and scaled per supported fee token.
 var feePayerMaxGas = uint64(2_000_000)
 
 var feePayerMaxFeePerGas = big.NewInt(100_000_000_000)
@@ -42,6 +42,14 @@ type sourceDID struct {
 	address string
 }
 
+// FeePayerPolicy configures sponsored transaction limits for one fee token.
+type FeePayerPolicy struct {
+	Decimals             int
+	MaxFeePerGas         *big.Int
+	MaxPriorityFeePerGas *big.Int
+	MaxTotalFee          *big.Int
+}
+
 // IntentConfig configures Tempo charge verification.
 type IntentConfig struct {
 	// RPC overrides the Tempo JSON-RPC client used for verification.
@@ -54,6 +62,8 @@ type IntentConfig struct {
 	FeePayerPrivateKey string
 	// FeePayerPrivateKeyEnv loads the fee-payer key from an environment variable when FeePayerPrivateKey is empty.
 	FeePayerPrivateKeyEnv string
+	// FeePayerPolicies allowlists the fee tokens this verifier will sponsor.
+	FeePayerPolicies map[string]FeePayerPolicy
 	// Store persists replay-protection keys for hash and proof credentials.
 	Store tempo.Store
 }
@@ -63,6 +73,7 @@ type Intent struct {
 	rpc            tempo.RPCClient
 	rpcURL         string
 	feePayerSigner *temposigner.Signer
+	feePayerPolicy map[string]FeePayerPolicy
 	store          tempo.Store
 }
 
@@ -87,10 +98,15 @@ func NewIntent(config IntentConfig) (*Intent, error) {
 	if store == nil {
 		store = tempo.NewMemoryStore()
 	}
+	feePayerPolicy, err := normalizeFeePayerPolicies(config.FeePayerPolicies)
+	if err != nil {
+		return nil, err
+	}
 	return &Intent{
 		rpc:            config.RPC,
 		rpcURL:         config.RPCURL,
 		feePayerSigner: feePayerSigner,
+		feePayerPolicy: feePayerPolicy,
 		store:          store,
 	}, nil
 }
@@ -254,9 +270,13 @@ func (i *Intent) verifyTransaction(
 	}
 
 	if request.MethodDetails.FeePayer {
+		policy, err := i.feePayerPolicyFor(request.Currency)
+		if err != nil {
+			return nil, err
+		}
 		// tempo-go exposes the signing primitives already; this package keeps the
 		// sponsor policy checks local until a shared helper exists upstream.
-		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires); err != nil {
+		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires, policy); err != nil {
 			return nil, err
 		}
 		if !tx.AwaitingFeePayer {
@@ -293,7 +313,7 @@ func (i *Intent) verifyTransaction(
 		if !transactionMatches(tx, request, credential.Challenge.Realm, credential.Challenge.ID) {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction does not contain a matching Tempo transfer")
 		}
-		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires); err != nil {
+		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires, policy); err != nil {
 			return nil, err
 		}
 		if tx.AwaitingFeePayer {
@@ -761,7 +781,90 @@ func signWithRemoteFeePayer(ctx context.Context, feePayerURL, raw string) (strin
 	return serialized, nil
 }
 
-func validateFeePayerTransaction(tx *tempotx.Tx, challengeExpires string) error {
+func normalizeFeePayerPolicies(configured map[string]FeePayerPolicy) (map[string]FeePayerPolicy, error) {
+	if len(configured) == 0 {
+		configured = defaultFeePayerPolicies()
+	}
+	policies := make(map[string]FeePayerPolicy, len(configured))
+	for currency, policy := range configured {
+		if !common.IsHexAddress(currency) {
+			return nil, fmt.Errorf("tempo server: invalid fee payer policy currency %q", currency)
+		}
+		if policy.Decimals < 0 {
+			return nil, fmt.Errorf("tempo server: invalid fee payer policy decimals for %s", currency)
+		}
+		if policy.MaxFeePerGas == nil || policy.MaxFeePerGas.Sign() <= 0 {
+			return nil, fmt.Errorf("tempo server: invalid max fee per gas for %s", currency)
+		}
+		if policy.MaxPriorityFeePerGas == nil || policy.MaxPriorityFeePerGas.Sign() <= 0 {
+			return nil, fmt.Errorf("tempo server: invalid max priority fee per gas for %s", currency)
+		}
+		if policy.MaxPriorityFeePerGas.Cmp(policy.MaxFeePerGas) > 0 {
+			return nil, fmt.Errorf("tempo server: max priority fee per gas exceeds max fee per gas for %s", currency)
+		}
+		if policy.MaxTotalFee == nil || policy.MaxTotalFee.Sign() <= 0 {
+			return nil, fmt.Errorf("tempo server: invalid max total fee for %s", currency)
+		}
+		policies[common.HexToAddress(currency).Hex()] = FeePayerPolicy{
+			Decimals:             policy.Decimals,
+			MaxFeePerGas:         new(big.Int).Set(policy.MaxFeePerGas),
+			MaxPriorityFeePerGas: new(big.Int).Set(policy.MaxPriorityFeePerGas),
+			MaxTotalFee:          new(big.Int).Set(policy.MaxTotalFee),
+		}
+	}
+	return policies, nil
+}
+
+func defaultFeePayerPolicies() map[string]FeePayerPolicy {
+	policy := feePayerPolicyForDecimals(tempo.DefaultDecimals)
+	return map[string]FeePayerPolicy{
+		tempotx.AlphaUSDAddress.Hex(): policy,
+		tempo.MainnetUSDCAddress:      policy,
+	}
+}
+
+func feePayerPolicyForDecimals(decimals int) FeePayerPolicy {
+	maxFeePerGas := scaleFeePayerCap(feePayerMaxFeePerGas, decimals)
+	maxTotalFee := scaleFeePayerCap(feePayerMaxTotalFee, decimals)
+	minimumDefaultTotalFee := new(big.Int).Mul(new(big.Int).SetUint64(tempo.DefaultGasLimit), maxFeePerGas)
+	if maxTotalFee.Cmp(minimumDefaultTotalFee) < 0 {
+		maxTotalFee = minimumDefaultTotalFee
+	}
+	return FeePayerPolicy{
+		Decimals:             decimals,
+		MaxFeePerGas:         maxFeePerGas,
+		MaxPriorityFeePerGas: scaleFeePayerCap(feePayerMaxPriorityFeePerGas, decimals),
+		MaxTotalFee:          maxTotalFee,
+	}
+}
+
+func scaleFeePayerCap(value *big.Int, decimals int) *big.Int {
+	if decimals >= 18 {
+		multiplier := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals-18)), nil)
+		return new(big.Int).Mul(new(big.Int).Set(value), multiplier)
+	}
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(18-decimals)), nil)
+	quotient := new(big.Int).Quo(new(big.Int).Set(value), divisor)
+	if quotient.Sign() > 0 {
+		return quotient
+	}
+	return big.NewInt(1)
+}
+
+func (i *Intent) feePayerPolicyFor(currency string) (FeePayerPolicy, error) {
+	policy, ok := i.feePayerPolicy[common.HexToAddress(currency).Hex()]
+	if !ok {
+		return FeePayerPolicy{}, mpp.ErrInvalidPayload("fee payer transaction fee token is not supported")
+	}
+	return FeePayerPolicy{
+		Decimals:             policy.Decimals,
+		MaxFeePerGas:         new(big.Int).Set(policy.MaxFeePerGas),
+		MaxPriorityFeePerGas: new(big.Int).Set(policy.MaxPriorityFeePerGas),
+		MaxTotalFee:          new(big.Int).Set(policy.MaxTotalFee),
+	}, nil
+}
+
+func validateFeePayerTransaction(tx *tempotx.Tx, challengeExpires string, policy FeePayerPolicy) error {
 	if tx.Gas == 0 {
 		return mpp.ErrInvalidPayload("fee payer transaction must declare gas")
 	}
@@ -771,19 +874,19 @@ func validateFeePayerTransaction(tx *tempotx.Tx, challengeExpires string) error 
 	if tx.MaxFeePerGas == nil || tx.MaxFeePerGas.Sign() <= 0 {
 		return mpp.ErrInvalidPayload("fee payer transaction must declare max fee per gas")
 	}
-	if tx.MaxFeePerGas.Cmp(feePayerMaxFeePerGas) > 0 {
+	if tx.MaxFeePerGas.Cmp(policy.MaxFeePerGas) > 0 {
 		return mpp.ErrInvalidPayload("fee payer transaction max fee per gas exceeds sponsor policy")
 	}
 	if tx.MaxPriorityFeePerGas != nil {
 		if tx.MaxPriorityFeePerGas.Cmp(tx.MaxFeePerGas) > 0 {
 			return mpp.ErrInvalidPayload("fee payer transaction max priority fee exceeds max fee")
 		}
-		if tx.MaxPriorityFeePerGas.Cmp(feePayerMaxPriorityFeePerGas) > 0 {
+		if tx.MaxPriorityFeePerGas.Cmp(policy.MaxPriorityFeePerGas) > 0 {
 			return mpp.ErrInvalidPayload("fee payer transaction max priority fee exceeds sponsor policy")
 		}
 	}
 	maxTotalFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas), tx.MaxFeePerGas)
-	if maxTotalFee.Cmp(feePayerMaxTotalFee) > 0 {
+	if maxTotalFee.Cmp(policy.MaxTotalFee) > 0 {
 		return mpp.ErrInvalidPayload("fee payer transaction total fee budget exceeds sponsor policy")
 	}
 	if tx.ValidBefore != 0 {

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -825,6 +825,14 @@ func defaultFeePayerPolicies() map[string]FeePayerPolicy {
 }
 
 func feePayerPolicyForDecimals(decimals int) FeePayerPolicy {
+	if decimals == tempo.DefaultDecimals {
+		return FeePayerPolicy{
+			Decimals:             decimals,
+			MaxFeePerGas:         big.NewInt(100_000),
+			MaxPriorityFeePerGas: big.NewInt(100_000),
+			MaxTotalFee:          big.NewInt(150_000_000),
+		}
+	}
 	maxFeePerGas := scaleFeePayerCap(feePayerMaxFeePerGas, decimals)
 	maxTotalFee := scaleFeePayerCap(feePayerMaxTotalFee, decimals)
 	minimumDefaultTotalFee := new(big.Int).Mul(new(big.Int).SetUint64(tempo.DefaultGasLimit), maxFeePerGas)

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -506,6 +506,85 @@ func TestChargeFlow_RejectsFeePayerTransactionOutsideSponsorPolicy(t *testing.T)
 	}
 }
 
+func TestChargeFlow_RejectsUnsupportedFeePayerToken(t *testing.T) {
+	ctx := context.Background()
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:    "0.50",
+		Currency:  "0x20c0000000000000000000000000000000000002",
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+		FeePayer:  true,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	}
+	rpc := newMockRPC(request)
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("Verify() error = %v, want unsupported fee token rejection", err)
+	}
+	if len(rpc.sentRawTxs) != 0 {
+		t.Fatalf("expected unsupported fee token to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs))
+	}
+}
+
+func TestChargeFlow_CustomFeePayerPolicyAllowsConfiguredToken(t *testing.T) {
+	ctx := context.Background()
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:    "0.50",
+		Currency:  "0x20c0000000000000000000000000000000000002",
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+		FeePayer:  true,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	}
+	rpc := newMockRPC(request)
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{
+		RPC:                rpc,
+		FeePayerPrivateKey: feePayerKey,
+		FeePayerPolicies: map[string]FeePayerPolicy{
+			request.Currency: {
+				Decimals:             6,
+				MaxFeePerGas:         big.NewInt(10),
+				MaxPriorityFeePerGas: big.NewInt(10),
+				MaxTotalFee:          big.NewInt(1_000_000),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected configured fee token to broadcast once, got %d", len(rpc.sentRawTxs))
+	}
+}
+
 func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
 	rpc := &mockRPC{receipts: map[string]map[string]any{}}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/tempo/server/config.go
+++ b/pkg/tempo/server/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	FeePayerPrivateKey string
 	// FeePayerPrivateKeyEnv loads the fee-payer key from an environment variable when FeePayerPrivateKey is empty.
 	FeePayerPrivateKeyEnv string
+	// FeePayerPolicies allowlists the fee tokens this verifier will sponsor.
+	FeePayerPolicies map[string]FeePayerPolicy
 	// Store persists replay-protection keys for hash and proof credentials.
 	Store tempo.Store
 }
@@ -60,6 +62,7 @@ func MethodFromConfig(config Config) (*Method, error) {
 			FeePayerSigner:        config.FeePayerSigner,
 			FeePayerPrivateKey:    config.FeePayerPrivateKey,
 			FeePayerPrivateKeyEnv: config.FeePayerPrivateKeyEnv,
+			FeePayerPolicies:      config.FeePayerPolicies,
 			Store:                 config.Store,
 		})
 		if err != nil {

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -1,6 +1,7 @@
 package chargeserver
 
 import (
+	"math/big"
 	"testing"
 
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
@@ -42,5 +43,45 @@ func TestNewIntentLoadsFeePayerPrivateKeyFromEnv(t *testing.T) {
 	}
 	if intent.feePayerSigner == nil {
 		t.Fatal("intent.feePayerSigner = nil, want signer")
+	}
+}
+
+func TestNewIntent_DefaultFeePayerPoliciesIncludeKnownTokens(t *testing.T) {
+	intent, err := NewIntent(IntentConfig{})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	moderatoPolicy, ok := intent.feePayerPolicy[tempotx.AlphaUSDAddress.Hex()]
+	if !ok {
+		t.Fatalf("missing default policy for %s", tempotx.AlphaUSDAddress.Hex())
+	}
+	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(1_000_000)) != 0 {
+		t.Fatalf("moderato max total fee = %s, want 1000000", moderatoPolicy.MaxTotalFee)
+	}
+	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("moderato max fee per gas = %s, want 1", moderatoPolicy.MaxFeePerGas)
+	}
+	mainnetPolicy, ok := intent.feePayerPolicy[tempo.MainnetUSDCAddress]
+	if !ok {
+		t.Fatalf("missing default policy for %s", tempo.MainnetUSDCAddress)
+	}
+	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("mainnet max priority fee per gas = %s, want 1", mainnetPolicy.MaxPriorityFeePerGas)
+	}
+}
+
+func TestNewIntentRejectsInvalidFeePayerPolicy(t *testing.T) {
+	_, err := NewIntent(IntentConfig{
+		FeePayerPolicies: map[string]FeePayerPolicy{
+			testCurrency: {
+				Decimals:             6,
+				MaxFeePerGas:         big.NewInt(1),
+				MaxPriorityFeePerGas: big.NewInt(2),
+				MaxTotalFee:          big.NewInt(10),
+			},
+		},
+	})
+	if err == nil || err.Error() != "tempo server: max priority fee per gas exceeds max fee per gas for 0x20c0000000000000000000000000000000000001" {
+		t.Fatalf("NewIntent() error = %v, want max priority fee validation error", err)
 	}
 }

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -55,25 +55,25 @@ func TestNewIntent_DefaultFeePayerPoliciesIncludeKnownTokens(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing default policy for %s", tempotx.AlphaUSDAddress.Hex())
 	}
-	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(150_000_000)) != 0 {
-		t.Fatalf("moderato max total fee = %s, want 150000000", moderatoPolicy.MaxTotalFee)
+	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)) != 0 {
+		t.Fatalf("moderato max total fee = %s, want 50000000000000000", moderatoPolicy.MaxTotalFee)
 	}
-	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(100_000)) != 0 {
-		t.Fatalf("moderato max fee per gas = %s, want 100000", moderatoPolicy.MaxFeePerGas)
+	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(100_000_000_000)) != 0 {
+		t.Fatalf("moderato max fee per gas = %s, want 100000000000", moderatoPolicy.MaxFeePerGas)
 	}
 	legacyPolicy, ok := intent.feePayerPolicy["0x20C0000000000000000000000000000000000000"]
 	if !ok {
 		t.Fatal("missing default policy for legacy moderato fee token")
 	}
-	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(150_000_000)) != 0 {
-		t.Fatalf("legacy moderato max total fee = %s, want 150000000", legacyPolicy.MaxTotalFee)
+	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)) != 0 {
+		t.Fatalf("legacy moderato max total fee = %s, want 50000000000000000", legacyPolicy.MaxTotalFee)
 	}
 	mainnetPolicy, ok := intent.feePayerPolicy[tempo.MainnetUSDCAddress]
 	if !ok {
 		t.Fatalf("missing default policy for %s", tempo.MainnetUSDCAddress)
 	}
-	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(100_000)) != 0 {
-		t.Fatalf("mainnet max priority fee per gas = %s, want 100000", mainnetPolicy.MaxPriorityFeePerGas)
+	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(100_000_000_000)) != 0 {
+		t.Fatalf("mainnet max priority fee per gas = %s, want 100000000000", mainnetPolicy.MaxPriorityFeePerGas)
 	}
 }
 

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -55,25 +55,25 @@ func TestNewIntent_DefaultFeePayerPoliciesIncludeKnownTokens(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing default policy for %s", tempotx.AlphaUSDAddress.Hex())
 	}
-	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(1_000_000)) != 0 {
-		t.Fatalf("moderato max total fee = %s, want 1000000", moderatoPolicy.MaxTotalFee)
+	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(150_000_000)) != 0 {
+		t.Fatalf("moderato max total fee = %s, want 150000000", moderatoPolicy.MaxTotalFee)
 	}
-	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(1)) != 0 {
-		t.Fatalf("moderato max fee per gas = %s, want 1", moderatoPolicy.MaxFeePerGas)
+	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(100_000)) != 0 {
+		t.Fatalf("moderato max fee per gas = %s, want 100000", moderatoPolicy.MaxFeePerGas)
 	}
 	legacyPolicy, ok := intent.feePayerPolicy["0x20C0000000000000000000000000000000000000"]
 	if !ok {
 		t.Fatal("missing default policy for legacy moderato fee token")
 	}
-	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(1_000_000)) != 0 {
-		t.Fatalf("legacy moderato max total fee = %s, want 1000000", legacyPolicy.MaxTotalFee)
+	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(150_000_000)) != 0 {
+		t.Fatalf("legacy moderato max total fee = %s, want 150000000", legacyPolicy.MaxTotalFee)
 	}
 	mainnetPolicy, ok := intent.feePayerPolicy[tempo.MainnetUSDCAddress]
 	if !ok {
 		t.Fatalf("missing default policy for %s", tempo.MainnetUSDCAddress)
 	}
-	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(1)) != 0 {
-		t.Fatalf("mainnet max priority fee per gas = %s, want 1", mainnetPolicy.MaxPriorityFeePerGas)
+	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(100_000)) != 0 {
+		t.Fatalf("mainnet max priority fee per gas = %s, want 100000", mainnetPolicy.MaxPriorityFeePerGas)
 	}
 }
 

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -61,6 +61,13 @@ func TestNewIntent_DefaultFeePayerPoliciesIncludeKnownTokens(t *testing.T) {
 	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(1)) != 0 {
 		t.Fatalf("moderato max fee per gas = %s, want 1", moderatoPolicy.MaxFeePerGas)
 	}
+	legacyPolicy, ok := intent.feePayerPolicy["0x20C0000000000000000000000000000000000000"]
+	if !ok {
+		t.Fatal("missing default policy for legacy moderato fee token")
+	}
+	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(1_000_000)) != 0 {
+		t.Fatalf("legacy moderato max total fee = %s, want 1000000", legacyPolicy.MaxTotalFee)
+	}
 	mainnetPolicy, ok := intent.feePayerPolicy[tempo.MainnetUSDCAddress]
 	if !ok {
 		t.Fatalf("missing default policy for %s", tempo.MainnetUSDCAddress)


### PR DESCRIPTION
## Summary
- add a fee token allowlist for sponsored transactions
- use token-specific fee payer limits for validation
- cover default and custom policy paths

## Testing
- go test ./...