### PR TITLE
fix: consume sponsored challenges after one attempt

### DIFF
--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -271,6 +271,17 @@ func (i *Intent) verifyTransaction(
 		if tx.FeeToken != (common.Address{}) {
 			return nil, mpp.ErrInvalidPayload("fee payer transaction must omit fee token before co-signing")
 		}
+		accepted, err := i.store.PutIfAbsent(
+			ctx,
+			tempo.ChargeSponsoredChallengeStoreKey(credential.Challenge.ID),
+			credential.Challenge.ID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			return nil, mpp.ErrVerificationFailed("fee payer challenge already used")
+		}
 		if i.feePayerSigner != nil {
 			tx.From = sender
 			tx.FeeToken = common.HexToAddress(request.Currency)
@@ -308,6 +319,10 @@ func (i *Intent) verifyTransaction(
 		}
 		if coSignedSender != sender {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction sender does not match the credential signer")
+		}
+		tx.From = coSignedSender
+		if err := simulateTransactionPreflight(ctx, rpc, tx); err != nil {
+			return nil, err
 		}
 	}
 
@@ -759,6 +774,80 @@ func signWithRemoteFeePayer(ctx context.Context, feePayerURL, raw string) (strin
 		return "", mpp.ErrVerificationFailed("fee payer returned no signed transaction")
 	}
 	return serialized, nil
+}
+
+func simulateTransactionPreflight(ctx context.Context, rpc tempo.RPCClient, tx *tempotx.Tx) error {
+	response, err := rpc.SendRequest(ctx, "eth_estimateGas", transactionCallObject(tx))
+	if err != nil {
+		return mpp.ErrVerificationFailed("transaction preflight failed")
+	}
+	if err := response.CheckError(); err != nil {
+		return mpp.ErrVerificationFailed("transaction preflight failed")
+	}
+	return nil
+}
+
+func transactionCallObject(tx *tempotx.Tx) map[string]any {
+	callObject := map[string]any{
+		"accessList":           accessListCallObject(tx.AccessList),
+		"calls":                callsCallObject(tx.Calls),
+		"chainId":              hexBig(tx.ChainID),
+		"from":                 tx.From.Hex(),
+		"gas":                  hexutil.EncodeUint64(tx.Gas),
+		"maxFeePerGas":         hexBig(tx.MaxFeePerGas),
+		"maxPriorityFeePerGas": hexBig(tx.MaxPriorityFeePerGas),
+		"nonce":                hexutil.EncodeUint64(tx.Nonce),
+	}
+	if tx.NonceKey != nil {
+		callObject["nonceKey"] = hexBig(tx.NonceKey)
+	}
+	if tx.ValidBefore != 0 {
+		callObject["validBefore"] = hexutil.EncodeUint64(tx.ValidBefore)
+	}
+	if tx.ValidAfter != 0 {
+		callObject["validAfter"] = hexutil.EncodeUint64(tx.ValidAfter)
+	}
+	if tx.FeeToken != (common.Address{}) {
+		callObject["feeToken"] = tx.FeeToken.Hex()
+	}
+	return callObject
+}
+
+func callsCallObject(calls []tempotx.Call) []map[string]any {
+	encoded := make([]map[string]any, 0, len(calls))
+	for _, call := range calls {
+		entry := map[string]any{
+			"data":  hexutil.Encode(call.Data),
+			"value": hexBig(call.Value),
+		}
+		if call.To != nil {
+			entry["to"] = call.To.Hex()
+		}
+		encoded = append(encoded, entry)
+	}
+	return encoded
+}
+
+func accessListCallObject(accessList tempotx.AccessList) []map[string]any {
+	encoded := make([]map[string]any, 0, len(accessList))
+	for _, tuple := range accessList {
+		storageKeys := make([]string, 0, len(tuple.StorageKeys))
+		for _, key := range tuple.StorageKeys {
+			storageKeys = append(storageKeys, key.Hex())
+		}
+		encoded = append(encoded, map[string]any{
+			"address":     tuple.Address.Hex(),
+			"storageKeys": storageKeys,
+		})
+	}
+	return encoded
+}
+
+func hexBig(value *big.Int) string {
+	if value == nil {
+		return hexutil.EncodeBig(big.NewInt(0))
+	}
+	return hexutil.EncodeBig(value)
 }
 
 func validateFeePayerTransaction(tx *tempotx.Tx, challengeExpires string) error {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -35,14 +35,16 @@ const (
 )
 
 type mockRPC struct {
-	chainID     uint64
-	nonce       uint64
-	gasPrice    string
-	estimateGas string
-	callResult  string
-	receipts    map[string]map[string]any
-	sentRawTxs  []string
-	onSend      func(raw string) (string, map[string]any, error)
+	chainID          uint64
+	nonce            uint64
+	gasPrice         string
+	estimateGas      string
+	callResult       string
+	receipts         map[string]map[string]any
+	sentRawTxs       []string
+	estimateGasCalls []map[string]any
+	onSend           func(raw string) (string, map[string]any, error)
+	onEstimateGas    func(params ...interface{}) (*temporpc.JSONRPCResponse, error)
 }
 
 func (m *mockRPC) GetChainID(context.Context) (uint64, error) {
@@ -73,6 +75,14 @@ func (m *mockRPC) SendRequest(_ context.Context, method string, params ...interf
 	case "eth_gasPrice":
 		return &temporpc.JSONRPCResponse{Result: m.gasPrice}, nil
 	case "eth_estimateGas":
+		if len(params) > 0 {
+			if callObject, ok := params[0].(map[string]any); ok {
+				m.estimateGasCalls = append(m.estimateGasCalls, callObject)
+			}
+		}
+		if m.onEstimateGas != nil {
+			return m.onEstimateGas(params...)
+		}
 		return &temporpc.JSONRPCResponse{Result: m.estimateGas}, nil
 	case "eth_call":
 		return &temporpc.JSONRPCResponse{Result: m.callResult}, nil
@@ -503,6 +513,92 @@ func TestChargeFlow_RejectsFeePayerTransactionOutsideSponsorPolicy(t *testing.T)
 	}
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "sponsor policy") {
 		t.Fatalf("Verify() error = %v, want sponsor policy rejection", err)
+	}
+}
+
+func TestChargeFlow_FeePayerTransactionUsesChallengeOnceAfterRevert(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, nil)
+	rpc := newMockRPC(request)
+	rpc.onSend = func(raw string) (string, map[string]any, error) {
+		return testReceiptHash, map[string]any{"status": "0x0", "logs": []any{}}, nil
+	}
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction reverted") {
+		t.Fatalf("first Verify() error = %v, want reverted transaction", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs))
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "challenge already used") {
+		t.Fatalf("second Verify() error = %v, want reused challenge rejection", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected no second broadcast, got %d", len(rpc.sentRawTxs))
+	}
+}
+
+func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, nil)
+	rpc := newMockRPC(request)
+	rpc.onEstimateGas = func(params ...interface{}) (*temporpc.JSONRPCResponse, error) {
+		callObject, ok := params[0].(map[string]any)
+		if !ok {
+			t.Fatalf("estimateGas params[0] type = %T, want map[string]any", params[0])
+		}
+		if _, ok := callObject["calls"]; !ok {
+			return &temporpc.JSONRPCResponse{Result: rpc.estimateGas}, nil
+		}
+		if callObject["from"] == "" {
+			t.Fatal("estimateGas call object missing from")
+		}
+		if callObject["feeToken"] != request.Currency {
+			t.Fatalf("estimateGas feeToken = %v, want %s", callObject["feeToken"], request.Currency)
+		}
+		calls, ok := callObject["calls"].([]map[string]any)
+		if !ok || len(calls) == 0 {
+			t.Fatalf("estimateGas calls = %#v, want non-empty call batch", callObject["calls"])
+		}
+		if _, ok := callObject["nonceKey"]; !ok {
+			t.Fatal("estimateGas call object missing nonceKey")
+		}
+		if _, ok := callObject["validBefore"]; !ok {
+			t.Fatal("estimateGas call object missing validBefore")
+		}
+		return temporpc.NewJSONRPCErrorResponse(1, temporpc.InvalidTransactionType, "execution reverted", nil), nil
+	}
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction preflight failed") {
+		t.Fatalf("Verify() error = %v, want preflight failure", err)
+	}
+	if len(rpc.sentRawTxs) != 0 {
+		t.Fatalf("expected no broadcast after failed preflight, got %d", len(rpc.sentRawTxs))
+	}
+	if len(rpc.estimateGasCalls) < 2 {
+		t.Fatalf("expected client estimate and server preflight calls, got %d", len(rpc.estimateGasCalls))
 	}
 }
 

--- a/pkg/tempo/store.go
+++ b/pkg/tempo/store.go
@@ -74,6 +74,12 @@ func ChargeStoreKey(hash string) string {
 	return ReplayKeyPrefix + strings.ToLower(hash)
 }
 
+// ChargeSponsoredChallengeStoreKey normalizes a replay-protection key for a
+// sponsored Tempo challenge.
+func ChargeSponsoredChallengeStoreKey(challengeID string) string {
+	return ReplayKeyPrefix + "sponsor:" + challengeID
+}
+
 // ChargeProofStoreKey normalizes a replay-protection key for a Tempo proof credential.
 func ChargeProofStoreKey(challengeID string) string {
 	return ReplayKeyPrefix + "proof:" + challengeID

--- a/pkg/tempo/store_test.go
+++ b/pkg/tempo/store_test.go
@@ -108,6 +108,11 @@ func TestStoreKeys(t *testing.T) {
 			got:  ChargeProofStoreKey("challenge-1"),
 			want: "mppx:charge:proof:challenge-1",
 		},
+		{
+			name: "sponsored key prefixes challenge id",
+			got:  ChargeSponsoredChallengeStoreKey("challenge-1"),
+			want: "mppx:charge:sponsor:challenge-1",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- consume sponsored challenges before co-signing and submission
- preflight sponsored transactions before sending them
- add regression coverage

## Testing
- go test ./...