### PR TITLE
fix: limit payment retries to the original origin

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -56,6 +57,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
+	origin := requestOrigin(req.URL)
+	req = req.WithContext(withPaymentOrigin(req.Context(), origin))
 
 	transport := &Transport{
 		methods: c.methods,
@@ -65,6 +68,16 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	// Use a copy of the http.Client with our payment-aware transport.
 	hc := *c.httpClient
 	hc.Transport = transport
+	priorCheckRedirect := hc.CheckRedirect
+	hc.CheckRedirect = func(redirectReq *http.Request, via []*http.Request) error {
+		if len(via) > 0 && !sameOriginURL(redirectReq.URL, origin) {
+			return fmt.Errorf("mpp: refusing cross-origin redirect from %q to %q", origin, requestOrigin(redirectReq.URL))
+		}
+		if priorCheckRedirect != nil {
+			return priorCheckRedirect(redirectReq, via)
+		}
+		return nil
+	}
 	return hc.Do(req)
 }
 

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -175,19 +175,5 @@ func validatePaymentOrigin(req *http.Request, challenge *mpp.Challenge) error {
 	if !sameOriginURL(req.URL, origin) {
 		return fmt.Errorf("mpp: refusing payment for redirected origin %q", requestOrigin(req.URL))
 	}
-	if challenge.Realm != "" && !challengeRealmMatchesRequest(challenge.Realm, req.URL) {
-		return fmt.Errorf("mpp: challenge realm %q does not match request host %q", challenge.Realm, req.URL.Host)
-	}
 	return nil
-}
-
-func challengeRealmMatchesRequest(realm string, requestURL *url.URL) bool {
-	parsedRealm, err := url.Parse(realm)
-	if err == nil && parsedRealm.Host != "" {
-		realm = parsedRealm.Host
-	}
-	if strings.EqualFold(realm, requestURL.Host) {
-		return true
-	}
-	return strings.EqualFold(realm, requestURL.Hostname())
 }

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -16,6 +18,8 @@ type Transport struct {
 	methods map[string]Method
 	inner   http.RoundTripper
 }
+
+type paymentOriginContextKey struct{}
 
 // NewTransport creates a payment-aware transport.
 func NewTransport(methods []Method, inner http.RoundTripper) *Transport {
@@ -75,6 +79,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if matched == nil {
 		// No matching method found — return original 402 response as-is.
 		return resp, nil
+	}
+	if err := validatePaymentOrigin(req, matched); err != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		return nil, err
 	}
 
 	// Drain and close the 402 response body so the connection can be reused.
@@ -136,4 +145,49 @@ func (t *Transport) parseChallenges(header http.Header) ([]mpp.Challenge, []erro
 		}
 	}
 	return challenges, errs
+}
+
+func withPaymentOrigin(ctx context.Context, origin string) context.Context {
+	return context.WithValue(ctx, paymentOriginContextKey{}, origin)
+}
+
+func paymentOrigin(ctx context.Context) string {
+	origin, _ := ctx.Value(paymentOriginContextKey{}).(string)
+	return origin
+}
+
+func requestOrigin(requestURL *url.URL) string {
+	if requestURL == nil {
+		return ""
+	}
+	return strings.ToLower(requestURL.Scheme) + "://" + strings.ToLower(requestURL.Host)
+}
+
+func sameOriginURL(requestURL *url.URL, origin string) bool {
+	return requestOrigin(requestURL) == origin
+}
+
+func validatePaymentOrigin(req *http.Request, challenge *mpp.Challenge) error {
+	origin := paymentOrigin(req.Context())
+	if origin == "" {
+		origin = requestOrigin(req.URL)
+	}
+	if !sameOriginURL(req.URL, origin) {
+		return fmt.Errorf("mpp: refusing payment for redirected origin %q", requestOrigin(req.URL))
+	}
+	if challenge.Realm != "" && !challengeRealmMatchesRequest(challenge.Realm, req.URL) {
+		return fmt.Errorf("mpp: challenge realm %q does not match request host %q", challenge.Realm, req.URL.Host)
+	}
+	return nil
+}
+
+func challengeRealmMatchesRequest(realm string, requestURL *url.URL) bool {
+	parsedRealm, err := url.Parse(realm)
+	if err == nil && parsedRealm.Host != "" {
+		realm = parsedRealm.Host
+	}
+	if strings.EqualFold(realm, requestURL.Host) {
+		return true
+	}
+	return strings.EqualFold(realm, requestURL.Hostname())
 }

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -287,26 +287,6 @@ func TestTransport_RoundTrip_NonPaymentAuthScheme(t *testing.T) {
 	}
 }
 
-func TestTransport_RoundTrip_RejectsRealmMismatch(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "other.example.com", "tempo", "payment", nil)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
-		w.WriteHeader(http.StatusPaymentRequired)
-	}))
-	defer srv.Close()
-
-	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
-	tr := NewTransport([]Method{method}, nil)
-	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
-	_, err := tr.RoundTrip(req)
-	if err == nil || !strings.Contains(err.Error(), "does not match request host") {
-		t.Fatalf("RoundTrip() error = %v, want realm mismatch", err)
-	}
-	if method.calls != 0 {
-		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
-	}
-}
-
 func TestTransport_RoundTrip_RejectsOriginMismatchFromContext(t *testing.T) {
 	var challenge *mpp.Challenge
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	urlpkg "net/url"
 	"strings"
 	"testing"
 
@@ -13,13 +14,15 @@ import (
 
 // mockMethod implements Method for testing.
 type mockMethod struct {
-	name string
-	cred *mpp.Credential
-	err  error
+	name  string
+	cred  *mpp.Credential
+	err   error
+	calls int
 }
 
 func (m *mockMethod) Name() string { return m.name }
 func (m *mockMethod) CreateCredential(_ context.Context, ch *mpp.Challenge) (*mpp.Credential, error) {
+	m.calls++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -35,6 +38,15 @@ func newTestCredential(method string) *mpp.Credential {
 		},
 		Source: "test",
 	}
+}
+
+func challengeForURL(t *testing.T, rawURL, method string, request map[string]any, opts ...mpp.ChallengeOption) *mpp.Challenge {
+	t.Helper()
+	parsedURL, err := urlpkg.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", rawURL, err)
+	}
+	return mpp.NewChallenge("secret", parsedURL.Host, method, "payment", request, opts...)
 }
 
 func TestTransport_RoundTrip_No402(t *testing.T) {
@@ -57,13 +69,13 @@ func TestTransport_RoundTrip_No402(t *testing.T) {
 }
 
 func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "test-realm", "tempo", "payment", nil)
 	callCount := 0
+	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("test-realm"))
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			w.Write([]byte("pay me"))
 			return
@@ -77,6 +89,7 @@ func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
 		w.Write([]byte("paid"))
 	}))
 	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -149,8 +162,8 @@ func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
 }
 
 func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil)
 	callCount := 0
+	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
@@ -159,7 +172,7 @@ func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 			if string(body) != "request-body" {
 				t.Errorf("first request body = %q, want %q", string(body), "request-body")
 			}
-			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
@@ -170,6 +183,7 @@ func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -193,19 +207,21 @@ func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 }
 
 func TestTransport_RoundTrip_MultipleWWWAuthenticate(t *testing.T) {
-	stripeChallenge := mpp.NewChallenge("secret", "realm", "stripe", "payment", map[string]any{"amount": "100"})
-	tempoChallenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", map[string]any{"amount": "100"})
+	var stripeChallenge *mpp.Challenge
+	var tempoChallenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
-			w.Header().Add("WWW-Authenticate", stripeChallenge.ToAuthenticate("realm"))
-			w.Header().Add("WWW-Authenticate", tempoChallenge.ToAuthenticate("realm"))
+			w.Header().Add("WWW-Authenticate", stripeChallenge.ToAuthenticate(stripeChallenge.Realm))
+			w.Header().Add("WWW-Authenticate", tempoChallenge.ToAuthenticate(tempoChallenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+	stripeChallenge = challengeForURL(t, srv.URL, "stripe", map[string]any{"amount": "100"})
+	tempoChallenge = challengeForURL(t, srv.URL, "tempo", map[string]any{"amount": "100"})
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -222,17 +238,18 @@ func TestTransport_RoundTrip_MultipleWWWAuthenticate(t *testing.T) {
 }
 
 func TestTransport_RoundTrip_MergedWWWAuthenticate(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", map[string]any{"amount": "100"})
+	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="example", `+challenge.ToAuthenticate("realm"))
+			w.Header().Set("WWW-Authenticate", `Bearer realm="example", `+challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", map[string]any{"amount": "100"})
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -270,12 +287,54 @@ func TestTransport_RoundTrip_NonPaymentAuthScheme(t *testing.T) {
 	}
 }
 
+func TestTransport_RoundTrip_RejectsRealmMismatch(t *testing.T) {
+	challenge := mpp.NewChallenge("secret", "other.example.com", "tempo", "payment", nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer srv.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	_, err := tr.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "does not match request host") {
+		t.Fatalf("RoundTrip() error = %v, want realm mismatch", err)
+	}
+	if method.calls != 0 {
+		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
+	}
+}
+
+func TestTransport_RoundTrip_RejectsOriginMismatchFromContext(t *testing.T) {
+	var challenge *mpp.Challenge
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req = req.WithContext(withPaymentOrigin(req.Context(), "https://api.example.com"))
+	_, err := tr.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "refusing payment for redirected origin") {
+		t.Fatalf("RoundTrip() error = %v, want origin mismatch", err)
+	}
+	if method.calls != 0 {
+		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
+	}
+}
+
 func TestClient_Get(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil)
+	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
@@ -283,6 +342,7 @@ func TestClient_Get(t *testing.T) {
 		w.Write([]byte("hello"))
 	}))
 	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -298,7 +358,7 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_Post(t *testing.T) {
-	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil)
+	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -308,13 +368,14 @@ func TestClient_Post(t *testing.T) {
 			t.Errorf("content-type = %q, want application/json", r.Header.Get("Content-Type"))
 		}
 		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
 
 	cred := newTestCredential("tempo")
 	method := &mockMethod{name: "tempo", cred: cred}
@@ -335,5 +396,30 @@ func TestClient_WithHTTPClient(t *testing.T) {
 	c := New(nil, WithHTTPClient(custom))
 	if c.httpClient != custom {
 		t.Fatal("expected custom http client to be set")
+	}
+}
+
+func TestClient_Do_RejectsCrossOriginRedirect(t *testing.T) {
+	var challenge *mpp.Challenge
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer attacker.Close()
+	challenge = challengeForURL(t, attacker.URL, "tempo", nil)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	c := New([]Method{method})
+	_, err := c.Get(context.Background(), origin.URL)
+	if err == nil || !strings.Contains(err.Error(), "refusing cross-origin redirect") {
+		t.Fatalf("Get() error = %v, want cross-origin redirect rejection", err)
+	}
+	if method.calls != 0 {
+		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
 	}
 }


### PR DESCRIPTION
## Summary
- pin automatic payment retries to the original origin
- reject cross-origin redirects before retrying with credentials
- require challenge realms to match the request host

## Testing
- go test ./...