### PR TITLE
chore(release): add changelogs workflow

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,0 +1,41 @@
+# Changelogs
+
+This folder contains changelog files that describe changes to be released.
+
+## Adding a changelog
+
+Run `changelogs add` to create a new changelog file.
+
+## File format
+
+Changelog files are markdown with YAML frontmatter:
+
+```markdown
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Description of the changes made.
+```
+
+> **Go module naming:** the package identifier is the **full module path**
+> from `go.mod` (e.g. `github.com/tempoxyz/mpp-go`), not the bare repo
+> name. Using `mpp-go: minor` will not be recognized.
+
+Bump levels: `patch`, `minor`, `major`.
+
+## Releasing
+
+Releases are automated. On push to `main`, the `Changelog Release` workflow
+opens (or updates) a "Version Packages" PR that applies the version bump and
+updates `CHANGELOG.md`. Merging that PR pushes the new `vX.Y.Z` tag, which
+publishes via `proxy.golang.org`.
+
+This module has no tags yet, so the first auto-release will start from
+`0.0.0` and bump to whatever level the staged changelog requests.
+
+To preview locally:
+
+```bash
+changelogs status
+```

--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,26 @@
+# Ecosystem: "rust" | "python" | "go" (auto-detected if not specified)
+# ecosystem = "rust"
+
+# How to bump packages that depend on changed packages
+# "patch" | "minor" | "none"
+dependent_bump = "patch"
+
+# Packages to ignore
+ignore = []
+
+# Fixed groups: all packages always share the same version
+# [[fixed]]
+# members = ["package-a", "package-b"]
+
+# Linked groups: versions sync when released together
+# [[linked]]
+# members = ["sdk-core", "sdk-macros"]
+
+[changelog]
+# "per-crate" - CHANGELOG.md in each package
+# "root" - Single CHANGELOG.md at workspace root
+format = "per-crate"
+
+# AI-assisted changelog generation
+# [ai]
+# command = "amp ask"  # or "gh copilot suggest -t shell"

--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -1,0 +1,18 @@
+name: Changelog Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: tempoxyz/changelogs@add-go-ecosystem
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -11,9 +11,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # fetch-depth: 0 + fetch-tags: true so the Go ecosystem can read prior
+      # vX.Y.Z tags when computing the next version, and so the action can diff
+      # CHANGELOG.md.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: tempoxyz/changelogs@add-go-ecosystem
         env:

--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -12,6 +12,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: tempoxyz/changelogs@add-go-ecosystem
         env:

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -11,12 +11,16 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # fetch-depth: 0 is required so the action can `git diff origin/main...HEAD`
+      # against the base branch.
       - uses: actions/checkout@v4
-
-      - run: npm install -g @sourcegraph/amp
-
-      - uses: tempoxyz/changelogs/check@add-go-ecosystem
         with:
-          ai: 'amp -x'
-        env:
-          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+          fetch-depth: 0
+
+      # NOTE: `ai: 'amp -x'` and the `AMP_API_KEY` env are intentionally omitted
+      # for now. The check action's AI path runs `curl -sSL https://changelogs.sh | sh`,
+      # which installs the upstream `wevm/changelogs-rs` binary — that binary does
+      # not yet ship Go ecosystem support (added in tempoxyz/changelogs#109).
+      # Re-enable AI suggestions in the same follow-up that repins this workflow
+      # to `tempoxyz/changelogs/check@master` once a Go-aware binary is published.
+      - uses: tempoxyz/changelogs/check@add-go-ecosystem

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -1,0 +1,22 @@
+name: Changelogs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  changelogs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: npm install -g @sourcegraph/amp
+
+      - uses: tempoxyz/changelogs/check@add-go-ecosystem
+        with:
+          ai: 'amp -x'
+        env:
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}


### PR DESCRIPTION
## Summary

Integrate the [`changelogs`](https://github.com/tempoxyz/changelogs) tool to automate version bumps, `CHANGELOG.md` updates, and release PRs.
