### PR TITLE
chore: repin changelogs action from @add-go-ecosystem to @master

### DIFF
--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: tempoxyz/changelogs@add-go-ecosystem
+      - uses: tempoxyz/changelogs@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -17,10 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # NOTE: `ai: 'amp -x'` and the `AMP_API_KEY` env are intentionally omitted
-      # for now. The check action's AI path runs `curl -sSL https://changelogs.sh | sh`,
-      # which installs the upstream `wevm/changelogs-rs` binary — that binary does
-      # not yet ship Go ecosystem support (added in tempoxyz/changelogs#109).
-      # Re-enable AI suggestions in the same follow-up that repins this workflow
-      # to `tempoxyz/changelogs/check@master` once a Go-aware binary is published.
-      - uses: tempoxyz/changelogs/check@add-go-ecosystem
+      # NOTE: `ai: 'amp -x'` and the `AMP_API_KEY` env are still intentionally
+      # omitted. The check action's AI path runs
+      # `curl -sSL https://changelogs.sh | sh`, which installs the upstream
+      # `wevm/changelogs-rs` binary — that binary does not yet ship Go
+      # ecosystem support, so the AI generation step would error out with
+      # `could not detect workspace`. Re-enable AI suggestions once a
+      # Go-aware binary is published to `wevm/changelogs-rs/releases`.
+      - uses: tempoxyz/changelogs/check@master


### PR DESCRIPTION
## Summary

Repin both `tempoxyz/changelogs` workflow refs from the temporary `@add-go-ecosystem` feature branch to `@master`, now that the Go ecosystem support is merged upstream.