### PR TITLE
chore(release): stage v0.1.0 initial release changelog

### DIFF
--- a/.changelog/initial-release-v0-1-0.md
+++ b/.changelog/initial-release-v0-1-0.md
@@ -1,0 +1,21 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Initial public release of `mpp-go`, the Go SDK for the [Machine Payments Protocol](https://mpp.dev).
+
+### Added
+
+- `ComposeMiddleware` for multi-method routes with automatic method selection
+- Web framework adapters for Gin, Echo, and Chi
+- JSON codecs for challenges and credentials
+- Tempo charge proof support and hardened charge flow
+- Cross-SDK challenge test vectors and example parity tests
+- Integration tests against a live Tempo container in CI
+
+### Changed
+
+- Streamlined Tempo charge setup with config-based constructors
+- Simplified public API and tooling
+- Hardened payment challenge verification
+- Bumped go-ethereum from 1.17.0 to 1.17.2


### PR DESCRIPTION
## Summary

Stage the initial public release of `mpp-go` (v0.1.0).