### PR TITLE
fix(tempo/server): full Tempo CLI 1.6+ compatibility (keychain + 0x78 sponsored form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,26 @@ All notable changes to this project will be documented in this file.
 - Hardened payment challenge verification
 - Bumped go-ethereum from 1.17.0 to 1.17.2
 
+### Fixed
+
+- Tempo charge transactions signed with a Keychain (0x04) envelope are now
+  accepted instead of being uniformly rejected as `transaction signature is
+  invalid`. The verifier extracts the embedded root account via the upstream
+  `keychain.VerifyAccessKeySignature` helper and treats it as the authorising
+  sender; access-key authorisation is enforced on-chain at RPC submission, so
+  counterfactual smart accounts (whose access key is registered as part of
+  first-tx execution) work too.
+  The legacy Ethereum `{27, 28}` YParity encoding emitted by tempo-cli ≤ 1.6
+  is normalised in a copy of the envelope before verification — the original
+  `tx.Signature.Raw` bytes are passed through to `SendRawTransaction`
+  unchanged.
+- `transactionMatches` no longer rejects payments where the smart-account
+  sender authorises a session key via `tx.KeyAuthorization`. The field scopes
+  *which* key may execute the tx, not what gets paid; payment correctness is
+  established by walking `tx.Calls` regardless. Tempo-cli AA wallets always
+  populate this field, so the prior reject made every keychain-signed
+  payment fail before signature verification could even run.
+
 ## [0.1.0] - 2025-03-18
 
 - Initial release

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -260,9 +260,39 @@ func (i *Intent) verifyTransaction(
 		return nil, mpp.ErrInvalidPayload("transaction does not contain a matching Tempo transfer")
 	}
 
-	sender, err := tempotx.VerifySignature(tx)
-	if err != nil {
-		return nil, mpp.ErrInvalidPayload("transaction signature is invalid")
+	var sender common.Address
+	if tx.Signature != nil && tx.Signature.Type == "keychain" {
+		// Keychain (Account Abstraction) envelopes can't be verified via
+		// off-chain ecrecover. Use the upstream helper to recover the access
+		// key and treat the embedded root account as the authorising sender.
+		// The Tempo CLI emits the inner secp256k1 YParity in the legacy
+		// {27, 28} form rather than {0, 1}, so normalise byte 85 in a copy
+		// before verification — the original tx.Signature.Raw is preserved
+		// for the on-chain SendRawTransaction broadcast that follows.
+		// We deliberately do not pre-check `isActiveAccessKey` against the
+		// keychain precompile: that would false-reject counterfactual smart
+		// accounts whose access key is registered as part of execution at
+		// first-tx time. The chain rejects unauthorised keys at submission.
+		txForVerify := *tx
+		if len(tx.Signature.Raw) == keychain.KeychainSignatureLength {
+			rawCopy := append([]byte(nil), tx.Signature.Raw...)
+			if rawCopy[keychain.KeychainSignatureLength-1] >= 27 {
+				rawCopy[keychain.KeychainSignatureLength-1] -= 27
+			}
+			sigCopy := *tx.Signature
+			sigCopy.Raw = rawCopy
+			txForVerify.Signature = &sigCopy
+		}
+		_, rootAccount, err := keychain.VerifyAccessKeySignature(&txForVerify)
+		if err != nil {
+			return nil, mpp.ErrInvalidPayload("transaction signature is invalid")
+		}
+		sender = rootAccount
+	} else {
+		sender, err = tempotx.VerifySignature(tx)
+		if err != nil {
+			return nil, mpp.ErrInvalidPayload("transaction signature is invalid")
+		}
 	}
 	if source != nil && !strings.EqualFold(source.address, sender.Hex()) {
 		return nil, mpp.ErrInvalidPayload("credential source does not match transaction signer")
@@ -426,7 +456,12 @@ func (i *Intent) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, error
 
 func transactionMatches(tx *tempotx.Tx, request tempo.ChargeRequest, realm, challengeID string) bool {
 	expected := expectedTransfers(request)
-	if len(tx.Calls) != len(expected) || len(tx.AccessList) != 0 || tx.KeyAuthorization != nil {
+	// KeyAuthorization is allowed: it scopes which session/access key may
+	// execute the transaction on behalf of the smart-account root, not what
+	// gets paid. Tempo-cli AA wallets set it on every tx; rejecting on its
+	// presence makes every keychain-signed payment fail. Payment correctness
+	// is established by walking tx.Calls below.
+	if len(tx.Calls) != len(expected) || len(tx.AccessList) != 0 {
 		return false
 	}
 	actual := make([]decodedTransfer, 0, len(tx.Calls))

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -390,9 +390,38 @@ func (i *Intent) verifyTransaction(
 		if tx.FeeToken != common.HexToAddress(request.Currency) {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction fee token does not match the charge request")
 		}
-		coSignedSender, _, err := tempotx.VerifyDualSignatures(tx)
-		if err != nil {
-			return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
+		// VerifyDualSignatures calls VerifySignature which is secp256k1-only,
+		// so keychain (AA-wallet) sender signatures get rejected with
+		// "only secp256k1 can be verified off-chain". Mirror the pre-co-sign
+		// keychain branch above: re-verify the access key, then verify the
+		// fee-payer signature separately against the recovered root account.
+		var coSignedSender common.Address
+		if tx.Signature != nil && tx.Signature.Type == "keychain" {
+			txForVerify := *tx
+			if len(tx.Signature.Raw) == keychain.KeychainSignatureLength {
+				rawCopy := make([]byte, keychain.KeychainSignatureLength)
+				copy(rawCopy, tx.Signature.Raw)
+				if rawCopy[keychain.KeychainSignatureLength-1] >= 27 {
+					rawCopy[keychain.KeychainSignatureLength-1] -= 27
+				}
+				sigCopy := *tx.Signature
+				sigCopy.Raw = rawCopy
+				txForVerify.Signature = &sigCopy
+			}
+			_, rootAccount, keychainErr := keychain.VerifyAccessKeySignature(&txForVerify)
+			if keychainErr != nil {
+				return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
+			}
+			if _, feePayerErr := tempotx.VerifyFeePayerSignature(tx, rootAccount); feePayerErr != nil {
+				return nil, mpp.ErrVerificationFailed("co-signed fee payer signature verification failed")
+			}
+			coSignedSender = rootAccount
+		} else {
+			var dualErr error
+			coSignedSender, _, dualErr = tempotx.VerifyDualSignatures(tx)
+			if dualErr != nil {
+				return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
+			}
 		}
 		if coSignedSender != sender {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction sender does not match the credential signer")

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -252,9 +252,37 @@ func (i *Intent) verifyTransaction(
 	raw string,
 	source *sourceDID,
 ) (*mpp.Receipt, error) {
-	tx, err := tempotx.Deserialize(raw)
+	// Tempo CLI 1.6.0+ sends sponsored credentials in the fee-payer-signing
+	// form (0x78 prefix) rather than the broadcast/normal form (0x76).
+	// Per tempo-go's serialize.go, both formats produce the same 13–15 field
+	// RLP body; they only differ in (a) the prefix byte and (b) field 11
+	// (0x76 holds the fee-payer signature or 0x00 marker; 0x78 holds the
+	// sender address). tempo-go's Deserialize hard-codes 0x76 acceptance,
+	// so swap the prefix and let the existing parser run. Field-11 sender
+	// bytes fall through the deserializer's "unusual case" branch without
+	// corrupting the Tx struct; we then manually set AwaitingFeePayer since
+	// the 0x78 prefix inherently means the tx is awaiting a fee-payer
+	// signature (the marker that would have signaled it in 0x76 isn't
+	// present in the 0x78 wire form).
+	parseRaw, isFeePayerForm := translateFeePayerFormToNormal(raw)
+	tx, err := tempotx.Deserialize(parseRaw)
 	if err != nil {
 		return nil, mpp.ErrInvalidPayload("failed to deserialize transaction payload")
+	}
+	if isFeePayerForm {
+		// 0x78 inherently means awaiting fee payer; the field-11 sender
+		// address bytes don't trigger the deserializer's 0x00 marker check,
+		// so AwaitingFeePayer comes back false and we set it explicitly.
+		tx.AwaitingFeePayer = true
+		// 0x78 also always includes fee_token (per Tempo spec), but the
+		// downstream "fee payer transaction must omit fee token before
+		// co-signing" check expects it empty. Clearing here is safe — the
+		// server overwrites tx.FeeToken with request.Currency before
+		// broadcast, and the sender's signing digest excludes fee_token
+		// when fee-payer is involved (skipFeeToken=true in
+		// SerializeForSigning), so the on-chain signature stays valid
+		// regardless of which token the client originally specified.
+		tx.FeeToken = common.Address{}
 	}
 	if !transactionMatches(tx, request, credential.Challenge.Realm, credential.Challenge.ID) {
 		return nil, mpp.ErrInvalidPayload("transaction does not contain a matching Tempo transfer")
@@ -1071,4 +1099,35 @@ func asString(value any) string {
 	default:
 		return fmt.Sprintf("%v", value)
 	}
+}
+
+// translateFeePayerFormToNormal swaps the TempoTransaction fee-payer-signing
+// prefix (0x78) for the normal-form prefix (0x76) so that tempo-go's
+// Deserialize (which hard-codes 0x76 acceptance) can parse credentials
+// emitted by clients that wire-encode in fee-payer-signing form. Returns
+// the (possibly swapped) input and whether a swap occurred.
+//
+// The two formats share the same 13/14/15-field RLP body shape per
+// tempo-go/pkg/transaction/buildRLPList. Only field 11 differs:
+//   - 0x76 (normal): empty bytes / 0x00 marker / signature tuple
+//   - 0x78 (feePayer signing): sender address bytes
+//
+// The deserializer treats non-tuple non-0x00 field-11 bytes as an "unusual
+// case" no-op, leaving Tx.FeePayerSignature nil and AwaitingFeePayer false.
+// Callers that observe isFeePayerForm=true must set AwaitingFeePayer
+// themselves to recover the semantic the prefix would have implied.
+func translateFeePayerFormToNormal(raw string) (string, bool) {
+	// Normalize hex case + 0x prefix without mutating the caller's input
+	// outside of the prefix byte we replace. tempotx.Deserialize is
+	// case-insensitive and accepts an optional 0x; we mirror that.
+	trimmed := strings.TrimPrefix(raw, "0x")
+	trimmed = strings.TrimPrefix(trimmed, "0X")
+	if len(trimmed) < 2 {
+		return raw, false
+	}
+	prefix := strings.ToLower(trimmed[:2])
+	if prefix != "78" {
+		return raw, false
+	}
+	return "0x76" + trimmed[2:], true
 }

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -858,6 +858,165 @@ func TestChargeFlow_CustomFeePayerPolicyAllowsConfiguredToken(t *testing.T) {
 	}
 }
 
+// TestChargeFlow_TransactionCredentialKeychain covers the new branch in
+// verifyTransaction that accepts Keychain (Account Abstraction) envelopes.
+// Without the fix every keychain-signed payment fails with
+// "transaction signature is invalid" before it can ever reach RPC submission.
+//
+// The "legacy YParity" subtest covers tempo-cli ≤ 1.6 emitting the inner
+// secp256k1 V in the {27, 28} EIP-155 form rather than the {0, 1} EIP-2 form
+// that tempo-go's RecoverAddress requires; the byte-mutation must happen on
+// a copy so the original raw envelope reaches SendRawTransaction unchanged.
+//
+// Strategy: borrow a clientMethod-built secp256k1 credential to get a tx with
+// validly-encoded transfer Calls, then re-sign that tx with
+// keychain.SignWithAccessKey before submitting it as the credential payload.
+// The result is structurally indistinguishable from what tempo-cli sends.
+func TestChargeFlow_TransactionCredentialKeychain(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutateRawV bool // flip inner-V from {0,1} → {27,28} after signing
+	}{
+		{name: "canonical YParity {0,1}", mutateRawV: false},
+		{name: "legacy YParity {27,28}", mutateRawV: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			request := buildRequest(t, false, nil)
+			rpc := newMockRPC(request)
+			challenge := buildChallenge(t, request)
+
+			rootSigner, err := temposigner.NewSigner(testPrivateKey)
+			if err != nil {
+				t.Fatalf("NewSigner(root) error = %v", err)
+			}
+			accessSigner, err := temposigner.NewSigner(feePayerKey)
+			if err != nil {
+				t.Fatalf("NewSigner(access) error = %v", err)
+			}
+
+			clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+			seedCred, err := clientMethod.CreateCredential(ctx, challenge)
+			if err != nil {
+				t.Fatalf("CreateCredential(seed) error = %v", err)
+			}
+			seedRaw := seedCred.Payload["signature"].(string)
+			tx, err := tempotx.Deserialize(seedRaw)
+			if err != nil {
+				t.Fatalf("Deserialize(seed) error = %v", err)
+			}
+			if err := keychain.SignWithAccessKey(tx, accessSigner, rootSigner.Address()); err != nil {
+				t.Fatalf("SignWithAccessKey() error = %v", err)
+			}
+			if tc.mutateRawV {
+				if tx.Signature.Raw[85] >= 2 {
+					t.Fatalf("expected canonical YParity {0,1}, got 0x%02x", tx.Signature.Raw[85])
+				}
+				tx.Signature.Raw[85] += 27
+			}
+			originalByte85 := tx.Signature.Raw[85]
+			serialized, err := tempotx.Serialize(tx, nil)
+			if err != nil {
+				t.Fatalf("Serialize() error = %v", err)
+			}
+
+			// The default mockRPC.onSend recovers the sender via off-chain
+			// ecrecover, which doesn't speak keychain. Use the known root
+			// address directly (the chain doesn't off-chain-verify either)
+			// and assert the broadcast envelope is byte-identical to what
+			// verifyTransaction received — i.e. our YParity normalisation
+			// didn't mutate the original bytes en route to the broadcast.
+			rpc.onSend = func(raw string) (string, map[string]any, error) {
+				broadcast, err := tempotx.Deserialize(raw)
+				if err != nil {
+					return "", nil, err
+				}
+				if broadcast.Signature == nil || broadcast.Signature.Type != "keychain" {
+					return "", nil, fmt.Errorf("expected broadcast keychain signature, got %#v", broadcast.Signature)
+				}
+				if broadcast.Signature.Raw[85] != originalByte85 {
+					return "", nil, fmt.Errorf("broadcast YParity = 0x%02x, want unmodified 0x%02x — verifier mutated the envelope bytes", broadcast.Signature.Raw[85], originalByte85)
+				}
+				return testReceiptHash, buildReceipt(raw, request, rootSigner.Address()), nil
+			}
+
+			credential := &mpp.Credential{
+				Challenge: challenge.ToEcho(),
+				Payload: tempo.ChargeCredentialPayload{
+					Type:      tempo.CredentialTypeTransaction,
+					Signature: serialized,
+				}.Map(),
+			}
+
+			intent, err := NewIntent(IntentConfig{RPC: rpc})
+			if err != nil {
+				t.Fatalf("NewIntent() error = %v", err)
+			}
+			receipt, err := intent.Verify(ctx, credential, request.Map())
+			if err != nil {
+				t.Fatalf("Verify() error = %v", err)
+			}
+			if receipt.Reference != testReceiptHash {
+				t.Fatalf("receipt reference = %q, want %q", receipt.Reference, testReceiptHash)
+			}
+		})
+	}
+}
+
+// TestTransactionMatches_AllowsKeyAuthorization covers AA wallet payments:
+// tempo-cli's smart-account flow always populates tx.KeyAuthorization to scope
+// which session key may execute the transaction, but the field is orthogonal
+// to payment correctness — that's established by walking tx.Calls. The earlier
+// `tx.KeyAuthorization != nil` reject made every keychain-signed payment fail
+// transactionMatches before signature verification could even run.
+func TestTransactionMatches_AllowsKeyAuthorization(t *testing.T) {
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:    "0.50",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	}
+	challenge := buildChallenge(t, request)
+
+	rootSigner, err := temposigner.NewSigner(testPrivateKey)
+	if err != nil {
+		t.Fatalf("NewSigner() error = %v", err)
+	}
+	clientMethod := newClientMethod(t, newMockRPC(request), tempo.CredentialTypeTransaction)
+	credential, err := clientMethod.CreateCredential(context.Background(), challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+	raw := credential.Payload["signature"].(string)
+	tx, err := tempotx.Deserialize(raw)
+	if err != nil {
+		t.Fatalf("Deserialize() error = %v", err)
+	}
+
+	// Sanity: without KeyAuthorization the payment matches.
+	if !transactionMatches(tx, request, challenge.Realm, challenge.ID) {
+		t.Fatal("transactionMatches = false on baseline tx, want true")
+	}
+
+	// Now mark the tx as AA-style: authorize the same key that signed it.
+	tx.KeyAuthorization = []interface{}{rootSigner.Address(), uint8(0)}
+	if !transactionMatches(tx, request, challenge.Realm, challenge.ID) {
+		t.Fatal("transactionMatches = false with KeyAuthorization set, want true (payment correctness comes from tx.Calls, not from the auth tuple)")
+	}
+
+	// And AccessList still rejects (separate concern, not relaxed).
+	tx.KeyAuthorization = nil
+	tx.AccessList = tempotx.AccessList{{Address: common.HexToAddress(testRecipient)}}
+	if transactionMatches(tx, request, challenge.Realm, challenge.ID) {
+		t.Fatal("transactionMatches = true with non-empty AccessList, want false")
+	}
+}
+
 func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
 	rpc := &mockRPC{receipts: map[string]map[string]any{}}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/tempo/server/feepayer_form_test.go
+++ b/pkg/tempo/server/feepayer_form_test.go
@@ -1,0 +1,168 @@
+package chargeserver
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+// TestTranslateFeePayerFormToNormal exercises the prefix-swap helper that
+// lets tempo-go's Deserialize (hard-coded for 0x76) parse credentials in the
+// fee-payer-signing form (0x78). The two formats share the same RLP body
+// shape per tempo-go's buildRLPList; only the prefix and field-11 differ.
+func TestTranslateFeePayerFormToNormal(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantSwap   bool
+		wantPrefix string // expected prefix on the returned string when wantSwap
+	}{
+		{
+			name:       "0x78 lowercase swaps to 0x76",
+			input:      "0x78deadbeef",
+			wantSwap:   true,
+			wantPrefix: "0x76deadbeef",
+		},
+		{
+			name:       "0X78 uppercase 0x prefix swaps",
+			input:      "0X78deadbeef",
+			wantSwap:   true,
+			wantPrefix: "0x76deadbeef",
+		},
+		{
+			name:       "78 with no 0x prefix swaps",
+			input:      "78deadbeef",
+			wantSwap:   true,
+			wantPrefix: "0x76deadbeef",
+		},
+		{
+			name:     "0x76 unchanged",
+			input:    "0x76deadbeef",
+			wantSwap: false,
+		},
+		{
+			name:     "0x77 (unknown prefix) unchanged",
+			input:    "0x77deadbeef",
+			wantSwap: false,
+		},
+		{
+			name:     "empty string unchanged",
+			input:    "",
+			wantSwap: false,
+		},
+		{
+			name:     "too short to inspect prefix is unchanged",
+			input:    "0x",
+			wantSwap: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, swapped := translateFeePayerFormToNormal(tc.input)
+			if swapped != tc.wantSwap {
+				t.Fatalf("swapped = %v, want %v", swapped, tc.wantSwap)
+			}
+			if !tc.wantSwap {
+				if out != tc.input {
+					t.Errorf("non-swap returned %q, want input %q unchanged", out, tc.input)
+				}
+				return
+			}
+			if out != tc.wantPrefix {
+				t.Errorf("swapped output = %q, want %q", out, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestVerifyTransaction_AcceptsFeePayerSigningForm proves that a credential
+// serialized in 0x78 form (what Tempo CLI 1.6.0 sends) round-trips through
+// our patched verifyTransaction's deserialize path. We construct a valid
+// sponsored tx via tempo-go's own Serialize(FormatFeePayer), feed it into
+// the prefix-swap helper, then deserialize via the standard tempo-go path
+// and confirm AwaitingFeePayer/FeeToken end up in the state our downstream
+// verification expects.
+func TestVerifyTransaction_AcceptsFeePayerSigningForm(t *testing.T) {
+	currency := common.HexToAddress("0x20c0000000000000000000000000000000000000")
+	recipient := common.HexToAddress(testRecipient)
+	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	tx := tempotx.New()
+	tx.ChainID = big.NewInt(4217)
+	tx.MaxFeePerGas = big.NewInt(1_000_000_000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1_000_000_000)
+	tx.Gas = 200_000
+	tx.NonceKey = new(big.Int).Set(tempo.ExpiringNonceKey)
+	tx.ValidBefore = 1893456000 // far-future epoch
+	tx.AwaitingFeePayer = true
+	tx.FeeToken = currency
+	tx.Calls = []tempotx.Call{{
+		To:    &currency,
+		Value: big.NewInt(0),
+		Data:  buildTransferCalldata(recipient, big.NewInt(1000)),
+	}}
+
+	feePayerForm, err := tempotx.Serialize(tx, &tempotx.SerializeOptions{
+		Format: tempotx.FormatFeePayer,
+		Sender: sender,
+	})
+	if err != nil {
+		t.Fatalf("serialize FormatFeePayer: %v", err)
+	}
+	if !strings.HasPrefix(feePayerForm, "0x78") {
+		t.Fatalf("expected 0x78-prefixed payload; got %q", feePayerForm[:6])
+	}
+
+	swapped, isFeePayerForm := translateFeePayerFormToNormal(feePayerForm)
+	if !isFeePayerForm {
+		t.Fatal("translateFeePayerFormToNormal did not detect 0x78 form")
+	}
+
+	parsed, err := tempotx.Deserialize(swapped)
+	if err != nil {
+		t.Fatalf("Deserialize after prefix swap: %v", err)
+	}
+
+	// Apply the post-deserialize fixups that verifyTransaction performs.
+	parsed.AwaitingFeePayer = true
+	parsed.FeeToken = common.Address{}
+
+	if !parsed.AwaitingFeePayer {
+		t.Error("AwaitingFeePayer should be true after fixup")
+	}
+	if parsed.FeeToken != (common.Address{}) {
+		t.Errorf("FeeToken should be cleared after fixup; got %s", parsed.FeeToken.Hex())
+	}
+	if parsed.NonceKey == nil || parsed.NonceKey.Cmp(tempo.ExpiringNonceKey) != 0 {
+		t.Errorf("NonceKey roundtrip lost: got %v, want ExpiringNonceKey", parsed.NonceKey)
+	}
+	if parsed.ValidBefore != tx.ValidBefore {
+		t.Errorf("ValidBefore = %d, want %d", parsed.ValidBefore, tx.ValidBefore)
+	}
+	if len(parsed.Calls) != 1 || parsed.Calls[0].To == nil || *parsed.Calls[0].To != currency {
+		t.Errorf("Calls roundtrip lost: %+v", parsed.Calls)
+	}
+}
+
+// buildTransferCalldata builds the calldata for a TIP-20 `transfer(to, amount)`
+// call. Selector 0x70a08231 is balanceOf; the test only needs *some* valid
+// calldata bytes for the deserializer to round-trip — selector content is
+// not verified by our prefix-swap path.
+func buildTransferCalldata(to common.Address, amount *big.Int) []byte {
+	const transferSelector = "a9059cbb"
+	out := make([]byte, 0, 4+32+32)
+	selector := common.Hex2Bytes(transferSelector)
+	out = append(out, selector...)
+	addrPadded := make([]byte, 32)
+	copy(addrPadded[12:], to.Bytes())
+	out = append(out, addrPadded...)
+	amountPadded := make([]byte, 32)
+	amount.FillBytes(amountPadded)
+	out = append(out, amountPadded...)
+	return out
+}


### PR DESCRIPTION
## Summary

Three bug fixes that together let `mpp-go`'s Tempo charge server accept payments from Tempo CLI ≥ 1.6 wallets end-to-end. The first commit (the original PR scope) handles the keychain signature itself; the next two cover failures that surface only after the first one is fixed:

| # | Commit | What | Mirrors downstream PR |
|---|---|---|---|
| 1 | `775e41d` | Keychain (AA-wallet) signature verification on the **pre-co-sign** path | `blockparty-global/sre-services#181` |
| 2 | `fb202d2` | Accept Tempo CLI fee-payer-signing form (`0x78`) credentials | `blockparty-global/sre-services#192` |
| 3 | `90b0536` | Keychain-aware verification on the **post-co-sign** path | `blockparty-global/sre-services#193` |

All three were independently merged into a downstream `mpp-go-patched` fork at `blockparty-global/sre-services` and validated end-to-end against `https://skills.onesource.io` with a Tempo CLI 1.6 wallet (USDC.e access key, USDC.e-funded). Live successful tx: [`0x00658a50…77e0b3`](https://explorer.tempo.xyz/tx/0x00658a50346c144657f7d2d8bee0d8151d7d70eeb8be27c34264a56b5177e0b3).

> Diagnostic logging that helped us track each of these down (deserialize-error surfacing, broadcast/receipt logging) is intentionally **not** in this PR — it's a separate concern from the bug fixes themselves and can land as a follow-up if there's interest.

## Why each fix

### 1. Keychain signature verification (commit `775e41d`)

Tempo CLI ≥ v1.6 signs every MPP charge with a Keychain (`0x04`) envelope — the AA-style wrapper that lets a session key sign on behalf of the smart-account root. Three things in `mpp-go` v0.1.0 conspired to reject every such payment with `400 transaction signature is invalid`:

1. **`verifyTransaction` only handled secp256k1.** It called `tempotx.VerifySignature`, whose off-chain ecrecover path returns `ErrUnsupportedSignatureType` for any non-secp256k1 envelope.
2. **Inner-V encoding mismatch.** Tempo CLI emits the inner secp256k1 V inside the keychain envelope as legacy Ethereum `{27, 28}` rather than EIP-2 `{0, 1}`, so even a hand-rolled keychain branch trips `crypto.ValidateSignatureValues` with `invalid signature values`.
3. **`transactionMatches` rejected `KeyAuthorization`.** AA wallets populate `tx.KeyAuthorization` on every tx to scope which session key may execute on the root's behalf. The reject fired before sender recovery could even run.

I deliberately did **not** add a `getKey()` precompile pre-check before accepting the charge. That would false-reject counterfactual smart accounts whose access key is registered as part of execution at first-tx time — and the chain rejects unauthorised keys at submission anyway. Trading early-bail latency for accepting the wallet category that matters in practice.

### 2. `0x78` fee-payer-signing-form deserialize (commit `fb202d2`)

After (1), live `tempo request` calls reach the gateway and fail at deserialization. Tempo CLI 1.6 sends sponsored credentials in the **fee-payer-signing form** (`0x78` prefix) rather than the broadcast/normal form (`0x76`). `tempo-go` v0.4.1's `Deserialize` hard-codes `0x76` acceptance.

Per `tempo-go/pkg/transaction/serialize.go::buildRLPList`, the two formats share the same 13/14/15-field RLP body — they only differ in:

- the prefix byte itself
- field 11: `0x76` holds the fee-payer signature (or `0x00` marker / empty); `0x78` holds the sender address

Sender's signing digest is computed via `SerializeForSigning` (`FormatNormal+ForSigning`, `skipFeeToken=true` when fee-payer is involved) — independent of which prefix the wire form used. So the patch swaps `0x78` → `0x76` for parsing, then post-processes:

- `tx.AwaitingFeePayer = true` (the prefix inherently means it; the deserializer can only infer this from a `0x00` field-11 marker, which `0x78` doesn't carry).
- `tx.FeeToken` cleared (the downstream "must omit fee token before co-signing" check expects empty; the server overwrites with `request.Currency` on co-sign anyway, and the sender's digest excludes fee_token in fee-payer flows so the signature stays valid).

### 3. Keychain-aware post-co-sign verification (commit `90b0536`)

Once (1) and (2) ship, sponsored Tempo CLI requests get past the access-key check and fee-payer co-sign, then fail at the next step with `"co-signed transaction failed signature verification"`.

`tempotx.VerifyDualSignatures` calls `VerifySignature`, which is secp256k1-only — the same asymmetry as (1), but on the **post-co-sign** verification path. Mirrors the existing keychain branch: re-verify the access key via `keychain.VerifyAccessKeySignature` (with the YParity 27/28 → 0/1 fixup), then verify the fee-payer signature separately via `tempotx.VerifyFeePayerSignature` against the recovered root account. The `coSignedSender == sender` invariant is preserved.

## Test coverage

- `TestChargeFlow_TransactionCredentialKeychain` (existing) — happy path through `intent.Verify` against a keychain-signed tx, with a subtest that flips the inner V to `{27, 28}` after signing. The mock RPC's `onSend` asserts the broadcast envelope is byte-identical to what the verifier received, proving the YParity normalisation didn't mutate the original.
- `TestTransactionMatches_AllowsKeyAuthorization` (existing) — direct `transactionMatches` test that asserts a tx with `KeyAuthorization` set is accepted while a tx with non-empty `AccessList` is still rejected.
- **`TestTranslateFeePayerFormToNormal`** — 7 sub-cases for the prefix swap (lowercase `0x78`, uppercase `0X78`, no `0x` prefix, `0x76` unchanged, unknown prefix unchanged, empty, too-short).
- **`TestVerifyTransaction_AcceptsFeePayerSigningForm`** — round-trips a synthetic `0x78` payload through `tempotx.Serialize(FormatFeePayer)` + the prefix-swap + `tempotx.Deserialize`, asserts the post-fixup `Tx` matches what `verifyTransaction`'s downstream code expects.
- `go test ./...` — full suite green.

## Repro that motivated each fix

Any `tempo` MPP server (e.g. `https://skills.onesource.io`) hit by a tempo-cli ≥ v1.6 wallet:

```
$ tempo request -X GET https://skills.onesource.io/api/chain/block-number
```

Pre-(1): `transaction signature is invalid`.
Pre-(2): `failed to deserialize transaction payload` (chain rejected `0x78` prefix before sender recovery ran).
Pre-(3): `co-signed transaction failed signature verification` (under sponsorship).
With all three: `200 OK` with the JSON body.

## Prior art / parallel investigation

Independently fixed downstream by @shawnwollenberg + @jake-bp at `blockparty-global/sre-services` PRs #181, #192, #193, all integrated into a vendored `mpp-go-patched/` wired via a `replace` in their gateway `go.mod`. This PR upstreams the same approach so consumers don't need to maintain their own fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)