### PR TITLE
docs: describe idempotent POST charge external IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ func main() {
 For paid POST routes or agent tool calls, bind each logical operation to a
 stable `ExternalID`. The value is included in the MPP charge request and echoed
 back in the `Payment-Receipt`, so servers can distinguish a safe retry from a
-different paid operation.
+different paid operation. `ExternalID` is receipt metadata; it does not by
+itself persist or reject duplicate operations. Your application must keep its
+own idempotency record or response cache keyed by the client idempotency value
+before running the paid side effect.
 
 If your API already accepts an `Idempotency-Key` header, pass that value through
 as `ChargeParams.ExternalID` when constructing the charge:
@@ -159,7 +162,8 @@ result, err := payment.Charge(r.Context(), server.ChargeParams{
 
 Use the same `ExternalID` for retries of the same operation. Do not generate a
 new value for each retry, and avoid reusing one value across different paid
-operations.
+operations. On retry, check the stored idempotency result first and return the
+cached response or receipt instead of executing the POST operation again.
 
 ## Web Frameworks
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,35 @@ func main() {
 | [charge-hash](./examples/charge-hash/) | Push-mode charge flow with a hash credential, available in both one-command and separate-process layouts |
 | [charge-fee-payer](./examples/charge-fee-payer/) | Sponsored Tempo charge flow where the server co-signs as a fee payer, available in both one-command and separate-process layouts |
 
+## Idempotent POST Charges
+
+For paid POST routes or agent tool calls, bind each logical operation to a
+stable `ExternalID`. The value is included in the MPP charge request and echoed
+back in the `Payment-Receipt`, so servers can distinguish a safe retry from a
+different paid operation.
+
+If your API already accepts an `Idempotency-Key` header, pass that value through
+as `ChargeParams.ExternalID` when constructing the charge:
+
+```go
+externalID := r.Header.Get("Idempotency-Key")
+if externalID == "" {
+	http.Error(w, "missing Idempotency-Key", http.StatusBadRequest)
+	return
+}
+
+result, err := payment.Charge(r.Context(), server.ChargeParams{
+	Authorization: r.Header.Get("Authorization"),
+	Amount:        "0.50",
+	Description:   "Create report",
+	ExternalID:    externalID,
+})
+```
+
+Use the same `ExternalID` for retries of the same operation. Do not generate a
+new value for each retry, and avoid reusing one value across different paid
+operations.
+
 ## Web Frameworks
 
 The most common Go HTTP stacks today are `net/http`, Gin, Echo, Chi, and Fiber.


### PR DESCRIPTION
## Summary

Documents how to use `ChargeParams.ExternalID` for idempotent paid POST routes and agent tool calls.

The Go SDK already includes `ExternalID` in the charge request and echoes it back in the `Payment-Receipt`. This README section shows how to pass an existing `Idempotency-Key` header through as the stable operation ID so retries can be distinguished from different paid operations.

## Changes

- Add an `Idempotent POST Charges` section to the README
- Show `Idempotency-Key` mapped into `ChargeParams.ExternalID`
- Clarify that retries should reuse the same value and different operations should not share one value

## Verification

- `git diff --check`
- `go test ./...`
