### PR TITLE
fix(server): mark paid responses Cache-Control: private

### DIFF
--- a/.changelog/server-cache-private.md
+++ b/.changelog/server-cache-private.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Mark paid server responses that include `Payment-Receipt` as `Cache-Control: private`.

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"strings"
 
@@ -68,13 +70,30 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 
 	w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
 
+	vw := newVaryResponseWriter(w, "Authorization")
+	next.ServeHTTP(vw, r.WithContext(ctx))
+	if varyWriter, ok := vw.(interface{ wrote() bool }); ok && !varyWriter.wrote() {
+		appendVary(w.Header(), "Authorization")
+	}
+}
+
+func newVaryResponseWriter(w http.ResponseWriter, vary string) http.ResponseWriter {
 	vw := &varyResponseWriter{
 		ResponseWriter: w,
-		vary:           "Authorization",
+		vary:           vary,
 	}
-	next.ServeHTTP(vw, r.WithContext(ctx))
-	if !vw.wroteHeader {
-		appendVary(w.Header(), vw.vary)
+
+	_, hasFlusher := w.(http.Flusher)
+	_, hasHijacker := w.(http.Hijacker)
+	switch {
+	case hasFlusher && hasHijacker:
+		return &varyFlusherHijacker{varyResponseWriter: vw}
+	case hasFlusher:
+		return &varyFlusher{varyResponseWriter: vw}
+	case hasHijacker:
+		return &varyHijacker{varyResponseWriter: vw}
+	default:
+		return vw
 	}
 }
 
@@ -86,6 +105,10 @@ type varyResponseWriter struct {
 
 func (w *varyResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
+}
+
+func (w *varyResponseWriter) wrote() bool {
+	return w.wroteHeader
 }
 
 func (w *varyResponseWriter) WriteHeader(statusCode int) {
@@ -102,6 +125,40 @@ func (w *varyResponseWriter) Write(body []byte) (int, error) {
 		w.WriteHeader(http.StatusOK)
 	}
 	return w.ResponseWriter.Write(body)
+}
+
+type varyFlusher struct {
+	*varyResponseWriter
+}
+
+func (w *varyFlusher) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+type varyHijacker struct {
+	*varyResponseWriter
+}
+
+func (w *varyHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+type varyFlusherHijacker struct {
+	*varyResponseWriter
+}
+
+func (w *varyFlusherHijacker) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (w *varyFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
 }
 
 func appendVary(header http.Header, value string) {

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -1,12 +1,9 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
-	"net"
 	"net/http"
-	"strings"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
@@ -68,108 +65,13 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, credential *mpp.Credential, receipt *mpp.Receipt) {
 	ctx := ContextWithPayment(r.Context(), credential, receipt)
 
+	// Mark the paid response as private so shared caches never serve a
+	// Payment-Receipt to a different client. This mirrors the MPP spec
+	// (mpp.dev/protocol) and the rust reference implementation.
+	w.Header().Set("Cache-Control", "private")
 	w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
 
-	vw := newVaryResponseWriter(w, "Authorization")
-	next.ServeHTTP(vw, r.WithContext(ctx))
-	if varyWriter, ok := vw.(interface{ wrote() bool }); ok && !varyWriter.wrote() {
-		appendVary(w.Header(), "Authorization")
-	}
-}
-
-func newVaryResponseWriter(w http.ResponseWriter, vary string) http.ResponseWriter {
-	vw := &varyResponseWriter{
-		ResponseWriter: w,
-		vary:           vary,
-	}
-
-	_, hasFlusher := w.(http.Flusher)
-	_, hasHijacker := w.(http.Hijacker)
-	switch {
-	case hasFlusher && hasHijacker:
-		return &varyFlusherHijacker{varyResponseWriter: vw}
-	case hasFlusher:
-		return &varyFlusher{varyResponseWriter: vw}
-	case hasHijacker:
-		return &varyHijacker{varyResponseWriter: vw}
-	default:
-		return vw
-	}
-}
-
-type varyResponseWriter struct {
-	http.ResponseWriter
-	vary        string
-	wroteHeader bool
-}
-
-func (w *varyResponseWriter) Unwrap() http.ResponseWriter {
-	return w.ResponseWriter
-}
-
-func (w *varyResponseWriter) wrote() bool {
-	return w.wroteHeader
-}
-
-func (w *varyResponseWriter) WriteHeader(statusCode int) {
-	if w.wroteHeader {
-		return
-	}
-	appendVary(w.Header(), w.vary)
-	w.wroteHeader = true
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *varyResponseWriter) Write(body []byte) (int, error) {
-	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(body)
-}
-
-type varyFlusher struct {
-	*varyResponseWriter
-}
-
-func (w *varyFlusher) Flush() {
-	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
-	}
-	w.ResponseWriter.(http.Flusher).Flush()
-}
-
-type varyHijacker struct {
-	*varyResponseWriter
-}
-
-func (w *varyHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return w.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-type varyFlusherHijacker struct {
-	*varyResponseWriter
-}
-
-func (w *varyFlusherHijacker) Flush() {
-	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
-	}
-	w.ResponseWriter.(http.Flusher).Flush()
-}
-
-func (w *varyFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return w.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-func appendVary(header http.Header, value string) {
-	for _, existing := range header.Values("Vary") {
-		for _, part := range strings.Split(existing, ",") {
-			if strings.EqualFold(strings.TrimSpace(part), value) {
-				return
-			}
-		}
-	}
-	header.Add("Vary", value)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
@@ -67,7 +68,51 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 
 	w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
 
-	next.ServeHTTP(w, r.WithContext(ctx))
+	vw := &varyResponseWriter{
+		ResponseWriter: w,
+		vary:           "Authorization",
+	}
+	next.ServeHTTP(vw, r.WithContext(ctx))
+	if !vw.wroteHeader {
+		appendVary(w.Header(), vw.vary)
+	}
+}
+
+type varyResponseWriter struct {
+	http.ResponseWriter
+	vary        string
+	wroteHeader bool
+}
+
+func (w *varyResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *varyResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	appendVary(w.Header(), w.vary)
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *varyResponseWriter) Write(body []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(body)
+}
+
+func appendVary(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -162,4 +165,69 @@ func TestChargeMiddleware_PreservesExistingVary(t *testing.T) {
 	if len(got) != 2 || got[0] != "Accept-Encoding" || got[1] != "Authorization" {
 		t.Fatalf("Vary = %#v, want Accept-Encoding and Authorization", got)
 	}
+}
+
+func TestServeVerified_PreservesResponseWriterOptionalInterfaces(t *testing.T) {
+	w := newOptionalResponseWriter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatalf("wrapped ResponseWriter does not expose http.Flusher")
+		}
+		if _, ok := w.(http.Hijacker); !ok {
+			t.Fatalf("wrapped ResponseWriter does not expose http.Hijacker")
+		}
+		flusher.Flush()
+	})
+
+	serveVerified(
+		handler,
+		w,
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		&mpp.Credential{},
+		mpp.Success("0xreceipt"),
+	)
+
+	if !w.flushed {
+		t.Fatalf("Flush was not forwarded to the underlying ResponseWriter")
+	}
+	if got := w.header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Authorization", got)
+	}
+}
+
+type optionalResponseWriter struct {
+	header  http.Header
+	body    bytes.Buffer
+	status  int
+	flushed bool
+}
+
+func newOptionalResponseWriter() *optionalResponseWriter {
+	return &optionalResponseWriter{header: make(http.Header)}
+}
+
+func (w *optionalResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *optionalResponseWriter) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(body)
+}
+
+func (w *optionalResponseWriter) WriteHeader(statusCode int) {
+	if w.status == 0 {
+		w.status = statusCode
+	}
+}
+
+func (w *optionalResponseWriter) Flush() {
+	w.flushed = true
+}
+
+func (w *optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
 }

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -84,8 +84,8 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
 		return
 	}
-	if got := paidResponse.Header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Authorization", got)
+	if got := paidResponse.Header.Get("Cache-Control"); got != "private" {
+		t.Fatalf("Cache-Control = %q, want private", got)
 	}
 
 	body, err := io.ReadAll(paidResponse.Body)
@@ -124,58 +124,15 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	assert.Equal(t, string(mpp.ErrorTypeInvalidChallenge), problem.Type)
 }
 
-func TestChargeMiddleware_PreservesExistingVary(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
-	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Vary", "Accept-Encoding")
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	challengeResponse, err := http.Get(server.URL)
-	if err != nil {
-		t.Fatalf("http.Get() error = %v", err)
-	}
-	defer challengeResponse.Body.Close()
-
-	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
-	}
-	credential := &mpp.Credential{
-		Challenge: challenge.ToEcho(),
-		Source:    "did:key:z6Mkrdemo",
-		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
-	}
-
-	retry, err := http.NewRequest(http.MethodGet, server.URL, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v", err)
-	}
-	retry.Header.Set("Authorization", credential.ToAuthorization())
-
-	paidResponse, err := http.DefaultClient.Do(retry)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
-	}
-	defer paidResponse.Body.Close()
-
-	got := paidResponse.Header.Values("Vary")
-	if len(got) != 2 || got[0] != "Accept-Encoding" || got[1] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Accept-Encoding and Authorization", got)
-	}
-}
-
 func TestServeVerified_PreservesResponseWriterOptionalInterfaces(t *testing.T) {
 	w := newOptionalResponseWriter()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			t.Fatalf("wrapped ResponseWriter does not expose http.Flusher")
+			t.Fatalf("ResponseWriter does not expose http.Flusher")
 		}
 		if _, ok := w.(http.Hijacker); !ok {
-			t.Fatalf("wrapped ResponseWriter does not expose http.Hijacker")
+			t.Fatalf("ResponseWriter does not expose http.Hijacker")
 		}
 		flusher.Flush()
 	})
@@ -191,8 +148,8 @@ func TestServeVerified_PreservesResponseWriterOptionalInterfaces(t *testing.T) {
 	if !w.flushed {
 		t.Fatalf("Flush was not forwarded to the underlying ResponseWriter")
 	}
-	if got := w.header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Authorization", got)
+	if got := w.header.Get("Cache-Control"); got != "private" {
+		t.Fatalf("Cache-Control = %q, want private", got)
 	}
 }
 

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -81,6 +81,9 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
 		return
 	}
+	if got := paidResponse.Header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Authorization", got)
+	}
 
 	body, err := io.ReadAll(paidResponse.Body)
 	if !assert.NoErrorf(t, err,
@@ -116,4 +119,47 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&problem))
 	assert.Equal(t, string(mpp.ErrorTypeInvalidChallenge), problem.Type)
+}
+
+func TestChargeMiddleware_PreservesExistingVary(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Vary", "Accept-Encoding")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	challengeResponse, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer challengeResponse.Body.Close()
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	if err != nil {
+		t.Fatalf("ParseChallenge() error = %v", err)
+	}
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	retry, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	retry.Header.Set("Authorization", credential.ToAuthorization())
+
+	paidResponse, err := http.DefaultClient.Do(retry)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer paidResponse.Body.Close()
+
+	got := paidResponse.Header.Values("Vary")
+	if len(got) != 2 || got[0] != "Accept-Encoding" || got[1] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Accept-Encoding and Authorization", got)
+	}
 }


### PR DESCRIPTION
## Summary
- Set `Cache-Control: private` on successful paid responses (the ones carrying `Payment-Receipt`) in the core server middleware.
- Replaces the earlier `Vary: Authorization` approach (and removes the response-writer wrapping it required).

## Why
A paid response carries a `Payment-Receipt` and its body depends on the submitted credential, so it must not be cached or served to another caller. The MPP spec prescribes `Cache-Control: private` on `Payment-Receipt` responses (and `no-store` on 402 challenges, which the axum reference adapter already sets).

`Vary: Authorization` was the wrong tool for this: shared caches already refuse to store an `Authorization`-bearing response unless it opts in with `public`/`s-maxage`/`must-revalidate` (RFC 9111 section 3.5), and most CDNs do not key on arbitrary `Vary` (Cloudflare ignores it outside images and `accept-encoding`), so it does little on real proxies. `Cache-Control: private` is the spec-aligned mitigation and closes the cross-user path directly.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test ./...`, `go test -race ./pkg/server/...` all pass.
