### PR TITLE
fix(adapters): mark paid responses Cache-Control: private

### DIFF
--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -1,6 +1,9 @@
 package echoadapter
 
 import (
+	"net/http"
+	"strings"
+
 	echofw "github.com/labstack/echo/v4"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -48,7 +51,19 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 			c.Set(credentialKey, result.Credential)
 			c.Set(receiptKey, result.Receipt)
 			c.Response().Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+			appendVary(c.Response().Header(), "Authorization")
 			return next(c)
 		}
 	}
+}
+
+func appendVary(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
 }

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -1,9 +1,6 @@
 package echoadapter
 
 import (
-	"net/http"
-	"strings"
-
 	echofw "github.com/labstack/echo/v4"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -51,19 +48,8 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 			c.Set(credentialKey, result.Credential)
 			c.Set(receiptKey, result.Receipt)
 			c.Response().Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
-			appendVary(c.Response().Header(), "Authorization")
+			c.Response().Header().Set("Cache-Control", "private")
 			return next(c)
 		}
 	}
-}
-
-func appendVary(header http.Header, value string) {
-	for _, existing := range header.Values("Vary") {
-		for _, part := range strings.Split(existing, ",") {
-			if strings.EqualFold(strings.TrimSpace(part), value) {
-				return
-			}
-		}
-	}
-	header.Add("Vary", value)
 }

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -101,8 +101,8 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
-	if got := paidResponse.Header().Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Authorization", got)
+	if got := paidResponse.Header().Get("Cache-Control"); got != "private" {
+		t.Fatalf("Cache-Control = %q, want private", got)
 	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -101,6 +101,9 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
+	if got := paidResponse.Header().Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Authorization", got)
+	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {
 		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -2,6 +2,7 @@ package fiberadapter
 
 import (
 	"encoding/json"
+	"strings"
 
 	fiberfw "github.com/gofiber/fiber/v2"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -49,8 +50,18 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.Locals(credentialKey, result.Credential)
 		c.Locals(receiptKey, result.Receipt)
 		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+		appendVary(c, "Authorization")
 		return c.Next()
 	}
+}
+
+func appendVary(c *fiberfw.Ctx, value string) {
+	for _, part := range strings.Split(c.GetRespHeader("Vary"), ",") {
+		if strings.EqualFold(strings.TrimSpace(part), value) {
+			return
+		}
+	}
+	c.Append("Vary", value)
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -2,7 +2,6 @@ package fiberadapter
 
 import (
 	"encoding/json"
-	"strings"
 
 	fiberfw "github.com/gofiber/fiber/v2"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -50,18 +49,9 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.Locals(credentialKey, result.Credential)
 		c.Locals(receiptKey, result.Receipt)
 		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
-		appendVary(c, "Authorization")
+		c.Set("Cache-Control", "private")
 		return c.Next()
 	}
-}
-
-func appendVary(c *fiberfw.Ctx, value string) {
-	for _, part := range strings.Split(c.GetRespHeader("Vary"), ",") {
-		if strings.EqualFold(strings.TrimSpace(part), value) {
-			return
-		}
-	}
-	c.Append("Vary", value)
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -89,6 +89,9 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
+	if got := paidResponse.Header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Authorization", got)
+	}
 
 	body, err := io.ReadAll(paidResponse.Body)
 	if err != nil {

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -89,8 +89,8 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
-	if got := paidResponse.Header.Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Authorization", got)
+	if got := paidResponse.Header.Get("Cache-Control"); got != "private" {
+		t.Fatalf("Cache-Control = %q, want private", got)
 	}
 
 	body, err := io.ReadAll(paidResponse.Body)

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -1,6 +1,9 @@
 package ginadapter
 
 import (
+	"net/http"
+	"strings"
+
 	ginfw "github.com/gin-gonic/gin"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -49,6 +52,18 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 		c.Set(credentialKey, result.Credential)
 		c.Set(receiptKey, result.Receipt)
 		c.Writer.Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+		appendVary(c.Writer.Header(), "Authorization")
 		c.Next()
 	}
+}
+
+func appendVary(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
 }

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -1,9 +1,6 @@
 package ginadapter
 
 import (
-	"net/http"
-	"strings"
-
 	ginfw "github.com/gin-gonic/gin"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -52,18 +49,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 		c.Set(credentialKey, result.Credential)
 		c.Set(receiptKey, result.Receipt)
 		c.Writer.Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
-		appendVary(c.Writer.Header(), "Authorization")
+		c.Header("Cache-Control", "private")
 		c.Next()
 	}
-}
-
-func appendVary(header http.Header, value string) {
-	for _, existing := range header.Values("Vary") {
-		for _, part := range strings.Split(existing, ",") {
-			if strings.EqualFold(strings.TrimSpace(part), value) {
-				return
-			}
-		}
-	}
-	header.Add("Vary", value)
 }

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -84,8 +84,8 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
-	if got := paidResponse.Header().Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
-		t.Fatalf("Vary = %#v, want Authorization", got)
+	if got := paidResponse.Header().Get("Cache-Control"); got != "private" {
+		t.Fatalf("Cache-Control = %q, want private", got)
 	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -84,6 +84,9 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	if receipt.Reference != "0xreceipt" {
 		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
 	}
+	if got := paidResponse.Header().Values("Vary"); len(got) != 1 || got[0] != "Authorization" {
+		t.Fatalf("Vary = %#v, want Authorization", got)
+	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {
 		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")


### PR DESCRIPTION
## Summary
- Set `Cache-Control: private` on successful paid responses (the ones carrying `Payment-Receipt`) in the Gin, Echo, and Fiber adapters.
- Replaces the earlier `Vary: Authorization` approach and removes the per-adapter `appendVary` helpers.

## Why
A paid response carries a `Payment-Receipt` and its body depends on the submitted credential, so it must not be cached or served to another caller. The MPP spec prescribes `Cache-Control: private` on `Payment-Receipt` responses (and `no-store` on 402 challenges, which these adapters already set).

`Vary: Authorization` was the wrong tool: shared caches already refuse to store an `Authorization`-bearing response unless it opts in with `public`/`s-maxage`/`must-revalidate` (RFC 9111 section 3.5), and most CDNs do not key on arbitrary `Vary` (Cloudflare ignores it outside images and `accept-encoding`). `Cache-Control: private` is the spec-aligned mitigation and matches the rust reference impl, which uses `Cache-Control` and never `Vary`.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test ./...`, `go test -race ./pkg/server/gin ./pkg/server/echo ./pkg/server/fiber` all pass.
