### PR TITLE
fix(server): require default challenge expiry

### DIFF
--- a/.changelog/default-expires-verification.md
+++ b/.changelog/default-expires-verification.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject credentials that omit `expires` when verifying challenges with the default expiry policy.

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -161,6 +161,37 @@ func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 
 }
 
+func TestVerifyOrChallenge_RejectsMissingDefaultExpires(t *testing.T) {
+	request := map[string]any{
+		"amount":    "100",
+		"currency":  "0xabc",
+		"recipient": "0xdef",
+	}
+	tampered := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+	)
+	credential := &mpp.Credential{
+		Challenge: tampered.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing required expires") {
+		t.Fatalf("VerifyOrChallenge() error = %v, want missing required expires", err)
+	}
+}
+
 func TestVerifyOrChallenge_AllowsDynamicExpiresOverrides(t *testing.T) {
 	request := map[string]any{
 		"amount":    "100",


### PR DESCRIPTION
## Summary
- enforce the effective default challenge expiry when verifying credentials
- reject credentials that omit `expires` even when `VerifyParams.Expires` was not explicitly set
- add a regression test for the default-expiry path

## Why
`VerifyOrChallenge` issues challenges with a default five-minute expiry when `VerifyParams.Expires` is empty. Verification should enforce that same effective expiry policy. Previously the missing-expires check only ran when `params.Expires` was explicitly set, so credentials without an `expires` field could pass the default-expiry path.

## Verification
- `go test ./pkg/server -run TestVerifyOrChallenge_RejectsMissingDefaultExpires -count=1` failed before the fix
- `go test ./pkg/server -run TestVerifyOrChallenge -count=1`
- `go test ./...`