### PR TITLE
fix: align Go protocol binding with conformance

### DIFF
--- a/pkg/mpp/challenge_vectors_test.go
+++ b/pkg/mpp/challenge_vectors_test.go
@@ -194,6 +194,25 @@ func TestGenerateChallengeIDGoldenVectors(t *testing.T) {
 			want: "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8",
 		},
 		{
+			name: "HTML-sensitive characters",
+			in: GenerateChallengeIDInput{
+				SecretKey: secret,
+				Realm:     "api.example.com",
+				Method:    "tempo",
+				Intent:    "charge",
+				Request: map[string]any{
+					"amount":      "100",
+					"description": "<tag>&value",
+					"items":       []any{"b", "a"},
+					"nested": map[string]any{
+						"a": 2,
+						"z": 1,
+					},
+				},
+			},
+			want: "7sN4-SNxjcU69yFUFT39nXXwvc9SRjod6WRoO_wmfgQ",
+		},
+		{
 			name: "empty request",
 			in:   GenerateChallengeIDInput{SecretKey: secret, Realm: "api.example.com", Method: "tempo", Intent: "charge", Request: map[string]any{}},
 			want: "yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU",

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -192,6 +192,36 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "receipt missing reference") {
 		t.Fatalf("ParseReceipt() error = %v, want missing reference error", err)
 	}
+
+	_, err = ParseReceipt(b64EncodeAny(map[string]any{
+		"status":    "success",
+		"method":    "Tempo",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
+		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	}
+
+	_, err = ParseReceipt(b64EncodeAny(map[string]any{
+		"status":    "success",
+		"method":    "tempo2",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
+		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	}
+
+	_, err = ParseReceipt(b64EncodeAny(map[string]any{
+		"status":    "success",
+		"method":    "tempo.pay",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
+		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	}
 }
 
 func TestChallengeVerifyAndToEcho(t *testing.T) {

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
-	"encoding/json"
 	"sort"
 	"strings"
 )
@@ -74,8 +73,8 @@ func b64EncodeSortedStringMap(m map[string]string) string {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		kb, _ := json.Marshal(k)
-		vb, _ := json.Marshal(m[k])
+		kb, _ := encodeStableJSON(k)
+		vb, _ := encodeStableJSON(m[k])
 		buf.Write(kb)
 		buf.WriteByte(':')
 		buf.Write(vb)

--- a/pkg/mpp/json.go
+++ b/pkg/mpp/json.go
@@ -8,15 +8,25 @@ import (
 
 // JSONEqual compares two JSON-like values using Go's stable JSON encoding.
 func JSONEqual(left, right any) bool {
-	leftJSON, err := json.Marshal(left)
+	leftJSON, err := encodeStableJSON(left)
 	if err != nil {
 		return false
 	}
-	rightJSON, err := json.Marshal(right)
+	rightJSON, err := encodeStableJSON(right)
 	if err != nil {
 		return false
 	}
 	return bytes.Equal(leftJSON, rightJSON)
+}
+
+func encodeStableJSON(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
 }
 
 // ExtractAuthorizationScheme returns the first authorization value that matches

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -197,6 +197,9 @@ func ParseChallenge(header string) (*Challenge, error) {
 	if id == "" || realm == "" || method == "" || intent == "" || requestB64 == "" {
 		return nil, fmt.Errorf("mpp: missing required challenge fields (id, realm, method, intent, request)")
 	}
+	if !isMethodName(method) {
+		return nil, fmt.Errorf("mpp: invalid challenge method %q", method)
+	}
 
 	request, err := B64Decode(requestB64)
 	if err != nil {
@@ -335,6 +338,9 @@ func ParseCredential(header string) (*Credential, error) {
 	if echo.Method == "" {
 		return nil, fmt.Errorf("mpp: credential challenge missing required field: method")
 	}
+	if !isMethodName(echo.Method) {
+		return nil, fmt.Errorf("mpp: invalid credential challenge method %q", echo.Method)
+	}
 	if echo.Intent == "" {
 		return nil, fmt.Errorf("mpp: credential challenge missing required field: intent")
 	}
@@ -445,6 +451,9 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	method := anyStr(data["method"])
+	if method != "" && !isMethodName(method) {
+		return nil, fmt.Errorf("mpp: invalid receipt method %q", method)
+	}
 
 	var externalID string
 	if v, ok := data["externalId"]; ok {
@@ -491,9 +500,18 @@ func FormatPaymentReceipt(r *Receipt) string {
 
 // b64EncodeAny encodes a value as compact JSON then base64url without padding.
 func b64EncodeAny(data map[string]any) string {
-	// json.Marshal sorts map keys by default in Go.
-	b, _ := json.Marshal(data)
+	b, _ := encodeStableJSON(data)
 	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func isMethodName(value string) bool {
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch < 'a' || ch > 'z' {
+			return false
+		}
+	}
+	return value != ""
 }
 
 // B64Decode decodes a base64url (no padding) string into a map.

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -138,6 +138,35 @@ func TestFindPaymentAuthorization(t *testing.T) {
 	}
 }
 
+func TestIsMethodName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "lowercase", value: "tempo", want: true},
+		{name: "empty", value: "", want: false},
+		{name: "uppercase", value: "Tempo", want: false},
+		{name: "digit", value: "tempo2", want: false},
+		{name: "hyphen", value: "tempo-pay", want: false},
+		{name: "underscore", value: "tempo_pay", want: false},
+		{name: "dot", value: "tempo.pay", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isMethodName(tt.value); got != tt.want {
+				t.Fatalf("isMethodName(%q) = %t, want %t", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseChallenge(t *testing.T) {
 	t.Parallel()
 
@@ -180,6 +209,21 @@ func TestParseChallenge(t *testing.T) {
 			name:    "missing required fields",
 			header:  `Payment id="abc", method="tempo", intent="charge"`,
 			wantErr: `missing required challenge fields`,
+		},
+		{
+			name:    "invalid uppercase method",
+			header:  `Payment id="abc", realm="api.example.com", method="Tempo", intent="charge", request="e30"`,
+			wantErr: `invalid challenge method`,
+		},
+		{
+			name:    "invalid method with digit",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo2", intent="charge", request="e30"`,
+			wantErr: `invalid challenge method`,
+		},
+		{
+			name:    "invalid punctuated method",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo-pay", intent="charge", request="e30"`,
+			wantErr: `invalid challenge method`,
 		},
 		{
 			name:    "duplicate auth params",
@@ -295,6 +339,21 @@ func TestParseCredential(t *testing.T) {
 			name:    "missing echoed challenge id",
 			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"method": "tempo", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
 			wantErr: `credential challenge missing required field: id`,
+		},
+		{
+			name:    "invalid uppercase method",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "Tempo", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
+			wantErr: `invalid credential challenge method`,
+		},
+		{
+			name:    "invalid method with digit",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo2", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
+			wantErr: `invalid credential challenge method`,
+		},
+		{
+			name:    "invalid punctuated method",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo-pay", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
+			wantErr: `invalid credential challenge method`,
 		},
 		{
 			name:    "invalid opaque encoding",


### PR DESCRIPTION
## Summary

Fixes two Go-side conformance gaps:

- encode base64url/HMAC JSON with HTML escaping disabled so challenge IDs bind the canonical request bytes for values containing `<`, `>`, or `&`
- enforce the active `payment-method-id = 1*LOWERALPHA` grammar while parsing challenges, credential challenge echoes, and receipts

Adds regression coverage for the JCS HTML-sensitive challenge ID vector and invalid method identifiers with uppercase letters, digits, and punctuation.