### PR TITLE
fix: harden Tempo charge verification

### DIFF
--- a/.changelog/patch-protocol-hardening.md
+++ b/.changelog/patch-protocol-hardening.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Harden Tempo charge verification by rejecting mismatched challenge chain IDs, requiring expiring challenge echoes, and reserving transaction hashes before non-sponsored broadcasts.

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -140,7 +140,7 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 			"credential request does not match this route's requirements",
 		)
 	}
-	if params.Expires != "" && echoed.Expires == "" {
+	if echoed.Expires == "" {
 		return nil, mpp.ErrInvalidChallenge(echoed.ID, "missing required expires")
 	}
 	if !reflect.DeepEqual(echoed.Opaque, challenge.Opaque) {

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -125,14 +125,6 @@ func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 		"currency":  "0xabc",
 		"recipient": "0xdef",
 	}
-	issued := mpp.NewChallenge(
-		"secret-key",
-		"api.example.com",
-		"tempo",
-		"charge",
-		request,
-		mpp.WithExpires(mpp.Expires.Minutes(5)),
-	)
 	tampered := mpp.NewChallenge(
 		"secret-key",
 		"api.example.com",
@@ -152,7 +144,6 @@ func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 		Realm:         "api.example.com",
 		SecretKey:     "secret-key",
 		Method:        "tempo",
-		Expires:       issued.Expires,
 	})
 	if err == nil || !strings.Contains(err.Error(), "missing required expires") {
 		t.Fatalf("VerifyOrChallenge() error = %v, want missing required expires", err)

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -104,6 +104,10 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 	if credentialType == "" {
 		credentialType = tempo.CredentialTypeTransaction
 	}
+	expectedChainID, err := m.expectedChainID(request)
+	if err != nil {
+		return nil, err
+	}
 
 	rpc, rpcURL, err := m.resolveRPC(request)
 	if err != nil {
@@ -117,8 +121,8 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 	if err != nil {
 		return nil, fmt.Errorf("tempo client: get chain id: %w", err)
 	}
-	if expected := m.expectedChainID(request); expected != 0 && int64(chainID) != expected {
-		return nil, fmt.Errorf("tempo client: chain id mismatch (rpc=%d, expected=%d)", chainID, expected)
+	if expectedChainID != 0 && int64(chainID) != expectedChainID {
+		return nil, fmt.Errorf("tempo client: chain id mismatch (rpc=%d, expected=%d)", chainID, expectedChainID)
 	}
 	if request.Amount == "0" {
 		signature, err := m.signProof(int64(chainID), challenge.ID, challenge.Realm)
@@ -343,11 +347,15 @@ func (m *Method) estimateGas(
 	return tempo.ParseHexUint64(value)
 }
 
-func (m *Method) expectedChainID(request tempo.ChargeRequest) int64 {
+func (m *Method) expectedChainID(request tempo.ChargeRequest) (int64, error) {
 	if request.MethodDetails.ChainID != nil {
-		return *request.MethodDetails.ChainID
+		challengeChainID := *request.MethodDetails.ChainID
+		if m.chainID != 0 && challengeChainID != m.chainID {
+			return 0, fmt.Errorf("tempo client: challenge chain id mismatch (challenge=%d, expected=%d)", challengeChainID, m.chainID)
+		}
+		return challengeChainID, nil
 	}
-	return m.chainID
+	return m.chainID, nil
 }
 
 func (m *Method) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, string, error) {

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -115,6 +115,22 @@ func TestCreateCredentialScenarios(t *testing.T) {
 			wantErr:        "chain id mismatch",
 			wantBroadcasts: 0,
 		},
+		{
+			name: "challenge chain id conflicts with client pin",
+			config: Config{
+				ChainID: 42431,
+			},
+			rpc: &mockRPC{chainID: 42431},
+			params: tempo.ChargeRequestParams{
+				Amount:    "0.50",
+				Currency:  testCurrency,
+				Recipient: testRecipient,
+				Decimals:  6,
+				ChainID:   1,
+			},
+			wantErr:        "challenge chain id mismatch",
+			wantBroadcasts: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -350,10 +350,36 @@ func (i *Intent) verifyTransaction(
 		return nil, mpp.ErrVerificationFailed("failed to serialize transaction")
 	}
 
-	txHash, err := rpc.SendRawTransaction(ctx, serialized)
-	if err != nil {
-		return nil, mpp.ErrVerificationFailed("transaction submission failed")
+	reservedHash := ""
+	txHash := ""
+	shouldBroadcast := true
+	if !request.MethodDetails.FeePayer {
+		computedHash, err := tempotx.ComputeHash(serialized)
+		if err != nil {
+			return nil, mpp.ErrVerificationFailed("failed to compute transaction hash")
+		}
+		reservedHash = computedHash.Hex()
+		txHash = reservedHash
+		accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeStoreKey(reservedHash), reservedHash)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			shouldBroadcast = false
+		}
 	}
+
+	if shouldBroadcast {
+		var err error
+		txHash, err = rpc.SendRawTransaction(ctx, serialized)
+		if err != nil {
+			if reservedHash != "" {
+				_ = i.store.Delete(ctx, tempo.ChargeStoreKey(reservedHash))
+			}
+			return nil, mpp.ErrVerificationFailed("transaction submission failed")
+		}
+	}
+
 	receiptMap, err := fetchReceipt(ctx, rpc, txHash)
 	if err != nil {
 		return nil, err
@@ -361,12 +387,14 @@ func (i *Intent) verifyTransaction(
 	if !receiptMatches(receiptMap, credential, request, sender.Hex()) {
 		return nil, mpp.ErrVerificationFailed("transaction receipt does not satisfy the charge request")
 	}
-	accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeStoreKey(txHash), txHash)
-	if err != nil {
-		return nil, err
-	}
-	if !accepted {
-		return nil, mpp.ErrVerificationFailed("transaction hash already used")
+	if request.MethodDetails.FeePayer {
+		accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeStoreKey(txHash), txHash)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			return nil, mpp.ErrVerificationFailed("transaction hash already used")
+		}
 	}
 	return mpp.Success(
 		txHash,

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -45,6 +45,7 @@ type mockRPC struct {
 	estimateGasCalls []map[string]any
 	onSend           func(raw string) (string, map[string]any, error)
 	onEstimateGas    func(params ...interface{}) (*temporpc.JSONRPCResponse, error)
+	onGetReceipt     func(hash string) (*temporpc.JSONRPCResponse, error)
 }
 
 func (m *mockRPC) GetChainID(context.Context) (uint64, error) {
@@ -88,6 +89,9 @@ func (m *mockRPC) SendRequest(_ context.Context, method string, params ...interf
 		return &temporpc.JSONRPCResponse{Result: m.callResult}, nil
 	case "eth_getTransactionReceipt":
 		hash := params[0].(string)
+		if m.onGetReceipt != nil {
+			return m.onGetReceipt(hash)
+		}
 		return &temporpc.JSONRPCResponse{Result: m.receipts[hash]}, nil
 	default:
 		return nil, fmt.Errorf("unexpected rpc method %q", method)
@@ -522,6 +526,149 @@ func TestChargeFlow_ProofCredentialRejectsDifferentRealm(t *testing.T) {
 	}
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "proof signature does not match source") {
 		t.Fatalf("Verify() error = %v, want proof signature mismatch", err)
+	}
+}
+
+func TestChargeFlow_TransactionCredentialReservesHashBeforeBroadcast(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, nil)
+	rpc := newMockRPC(request)
+	rpc.onSend = func(raw string) (string, map[string]any, error) {
+		tx, err := tempotx.Deserialize(raw)
+		if err != nil {
+			return "", nil, err
+		}
+		sender, err := tempotx.VerifySignature(tx)
+		if err != nil {
+			return "", nil, err
+		}
+		hash, err := tempotx.ComputeHash(raw)
+		if err != nil {
+			return "", nil, err
+		}
+		return hash.Hex(), buildReceipt(raw, request, sender), nil
+	}
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
+		t.Fatalf("first Verify() error = %v", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs))
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
+		t.Fatalf("second Verify() error = %v", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected no second broadcast, got %d", len(rpc.sentRawTxs))
+	}
+}
+
+func TestChargeFlow_TransactionCredentialRefetchesReservedHashAfterReceiptFailure(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, nil)
+	rpc := newMockRPC(request)
+	failReceiptFetch := true
+	rpc.onSend = func(raw string) (string, map[string]any, error) {
+		tx, err := tempotx.Deserialize(raw)
+		if err != nil {
+			return "", nil, err
+		}
+		sender, err := tempotx.VerifySignature(tx)
+		if err != nil {
+			return "", nil, err
+		}
+		hash, err := tempotx.ComputeHash(raw)
+		if err != nil {
+			return "", nil, err
+		}
+		return hash.Hex(), buildReceipt(raw, request, sender), nil
+	}
+	rpc.onGetReceipt = func(hash string) (*temporpc.JSONRPCResponse, error) {
+		if failReceiptFetch {
+			failReceiptFetch = false
+			return nil, fmt.Errorf("temporary receipt rpc failure")
+		}
+		return &temporpc.JSONRPCResponse{Result: rpc.receipts[hash]}, nil
+	}
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "failed to fetch transaction receipt") {
+		t.Fatalf("first Verify() error = %v, want receipt fetch failure", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs))
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
+		t.Fatalf("second Verify() error = %v", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected retry to refetch without rebroadcast, got %d broadcasts", len(rpc.sentRawTxs))
+	}
+}
+
+func TestChargeFlow_TransactionCredentialReleasesReservationAfterBroadcastFailure(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, nil)
+	rpc := newMockRPC(request)
+	rpc.onSend = func(raw string) (string, map[string]any, error) {
+		return "", nil, fmt.Errorf("network down")
+	}
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
+	if err != nil {
+		t.Fatalf("NewIntent() error = %v", err)
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction submission failed") {
+		t.Fatalf("first Verify() error = %v, want submission failure", err)
+	}
+	if len(rpc.sentRawTxs) != 1 {
+		t.Fatalf("expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs))
+	}
+
+	rpc.onSend = func(raw string) (string, map[string]any, error) {
+		tx, err := tempotx.Deserialize(raw)
+		if err != nil {
+			return "", nil, err
+		}
+		sender, err := tempotx.VerifySignature(tx)
+		if err != nil {
+			return "", nil, err
+		}
+		return testReceiptHash, buildReceipt(raw, request, sender), nil
+	}
+	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
+		t.Fatalf("second Verify() error = %v", err)
+	}
+	if len(rpc.sentRawTxs) != 2 {
+		t.Fatalf("expected second Verify() to broadcast after release, got %d broadcasts", len(rpc.sentRawTxs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject Tempo charge challenges whose `chainId` conflicts with the client configured chain pin
- require verified credential echoes to carry `expires`, including default-expiry challenges
- reserve non-sponsored transaction hashes before broadcast and release the reservation only when submission fails
- add a patch changelog fragment for the batch release