### PR TITLE
ci: add conformance gate

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,37 @@
+name: Conformance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  conformance-policy:
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    with:
+      protocol-paths: |
+        pkg/**
+        go.mod
+        go.sum
+
+  conformance:
+    needs: conformance-policy
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    with:
+      adapter: go
+      conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}


### PR DESCRIPTION
## Summary
- Add the reusable mpp-tools SDK conformance workflow for the Go adapter.
- Add the mpp-tools conformance policy gate for protocol-sensitive Go SDK paths.
- Confirmed local Go vector and flow conformance pass against this SDK checkout.