### PR TITLE
fix: reject CRLF in challenge formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `github.com/tempoxyz/mpp-go@0.1.2`
+
+### Patch Changes
+
+- Reject CR/LF in `WWW-Authenticate` challenge formatting and built-in server challenge responses. (by @EmmaJamieson-Hoare, [#46](https://github.com/tempoxyz/mpp-go/pull/46))
+
 ## `github.com/tempoxyz/mpp-go@0.1.1`
 
 ### Patch Changes

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -181,6 +181,12 @@ func (c *Challenge) ToAuthenticate(realm string) string {
 	return FormatAuthenticate(c, realm)
 }
 
+// ToAuthenticateStrict formats this Challenge as an authentication header value
+// and rejects values that cannot be safely represented in quoted auth-params.
+func (c *Challenge) ToAuthenticateStrict(realm string) (string, error) {
+	return FormatAuthenticateStrict(c, realm)
+}
+
 // Verify checks whether the challenge ID matches the expected HMAC for the
 // given secretKey and realm. Uses constant-time comparison.
 func (c *Challenge) Verify(secretKey, realm string) bool {

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -240,32 +240,68 @@ func ParseChallenge(header string) (*Challenge, error) {
 //
 // Output format: Payment id="...", realm="...", method="...", intent="...", request="..."
 func FormatAuthenticate(c *Challenge, realm string) string {
+	header, _ := formatAuthenticate(c, realm, false)
+	return header
+}
+
+// FormatAuthenticateStrict formats a Challenge as an authentication header value
+// and rejects values that cannot be safely represented in quoted auth-params.
+func FormatAuthenticateStrict(c *Challenge, realm string) (string, error) {
+	return formatAuthenticate(c, realm, true)
+}
+
+func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, error) {
 	var parts []string
-	add := func(k, v string) {
-		if v != "" {
-			parts = append(parts, fmt.Sprintf(`%s="%s"`, k, escapeQuoted(v)))
+	add := func(k, v string) error {
+		if v == "" {
+			return nil
 		}
+		if rejectCRLF && strings.ContainsAny(v, "\r\n") {
+			return fmt.Errorf("mpp: invalid %s auth-param: contains CR or LF", k)
+		}
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, escapeQuoted(v)))
+		return nil
 	}
 
-	add("id", c.ID)
-	add("realm", realm)
-	add("method", c.Method)
-	add("intent", c.Intent)
+	for _, param := range []struct {
+		key   string
+		value string
+	}{
+		{key: "id", value: c.ID},
+		{key: "realm", value: realm},
+		{key: "method", value: c.Method},
+		{key: "intent", value: c.Intent},
+	} {
+		if err := add(param.key, param.value); err != nil {
+			return "", err
+		}
+	}
 
 	reqB64 := c.RequestB64
 	if reqB64 == "" {
 		reqB64 = b64EncodeRequest(c.Request)
 	}
-	add("request", reqB64)
-	add("digest", c.Digest)
-	add("expires", c.Expires)
-	add("description", c.Description)
-
-	if c.Opaque != nil {
-		add("opaque", b64EncodeSortedStringMap(c.Opaque))
+	for _, param := range []struct {
+		key   string
+		value string
+	}{
+		{key: "request", value: reqB64},
+		{key: "digest", value: c.Digest},
+		{key: "expires", value: c.Expires},
+		{key: "description", value: c.Description},
+	} {
+		if err := add(param.key, param.value); err != nil {
+			return "", err
+		}
 	}
 
-	return "Payment " + strings.Join(parts, ", ")
+	if c.Opaque != nil {
+		if err := add("opaque", b64EncodeSortedStringMap(c.Opaque)); err != nil {
+			return "", err
+		}
+	}
+
+	return "Payment " + strings.Join(parts, ", "), nil
 }
 
 func b64EncodeRequest(request map[string]any) string {

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -167,6 +167,85 @@ func TestIsMethodName(t *testing.T) {
 	}
 }
 
+func TestFormatAuthenticateStrict(t *testing.T) {
+	t.Parallel()
+
+	challenge := NewChallenge(
+		"secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": "100"},
+		WithDescription(`Pay "premium" path C:\tempo\api`),
+	)
+
+	got, err := challenge.ToAuthenticateStrict("api.example.com")
+	if err != nil {
+		t.Fatalf("ToAuthenticateStrict() unexpected error: %v", err)
+	}
+	if want := challenge.ToAuthenticate("api.example.com"); got != want {
+		t.Fatalf("ToAuthenticateStrict() = %q, want %q", got, want)
+	}
+	if want := `description="Pay \"premium\" path C:\\tempo\\api"`; !strings.Contains(got, want) {
+		t.Fatalf("ToAuthenticateStrict() = %q, want escaped description containing %q", got, want)
+	}
+}
+
+func TestFormatAuthenticateStrictRejectsCRLF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		realm   string
+		mutate  func(*Challenge)
+		wantErr string
+	}{
+		{
+			name:    "realm line feed",
+			realm:   "api.example.com\nnext",
+			wantErr: "realm auth-param",
+		},
+		{
+			name: "id carriage return",
+			mutate: func(c *Challenge) {
+				c.ID = "challenge\rid"
+			},
+			wantErr: "id auth-param",
+		},
+		{
+			name: "description crlf",
+			mutate: func(c *Challenge) {
+				c.Description = "Line one\r\nLine two"
+			},
+			wantErr: "description auth-param",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			challenge := NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{"amount": "100"})
+			if tt.mutate != nil {
+				tt.mutate(challenge)
+			}
+			realm := "api.example.com"
+			if tt.realm != "" {
+				realm = tt.realm
+			}
+
+			got, err := challenge.ToAuthenticateStrict(realm)
+			if err == nil {
+				t.Fatalf("ToAuthenticateStrict() = %q, want error", got)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) || !strings.Contains(err.Error(), "CR or LF") {
+				t.Fatalf("ToAuthenticateStrict() error = %v, want %q and CR/LF detail", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestParseChallenge(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -131,8 +131,18 @@ func composeChallenges(w http.ResponseWriter, r *http.Request, entries []compose
 		return
 	}
 
+	var headers []string
 	for _, challenge := range challenges {
-		w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(realm))
+		header, err := challenge.ToAuthenticateStrict(realm)
+		if err != nil {
+			WritePaymentError(w, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+			return
+		}
+		headers = append(headers, header)
+	}
+
+	for _, header := range headers {
+		w.Header().Add("WWW-Authenticate", header)
 	}
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -410,6 +410,45 @@ func TestComposeMiddleware_SingleMethod(t *testing.T) {
 	}
 }
 
+func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{
+			Mpp: methodA,
+			Params: ChargeParams{
+				Amount:      "1.00",
+				Description: "Line one\r\nLine two",
+			},
+		},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d; body = %s", resp.StatusCode, http.StatusBadRequest, body)
+	}
+	if got := resp.Header.Values("WWW-Authenticate"); len(got) != 0 {
+		t.Fatalf("WWW-Authenticate = %#v, want empty", got)
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem) error = %v", err)
+	}
+	if problem.Type != string(mpp.ErrorTypeInvalidChallenge) {
+		t.Fatalf("problem type = %q, want %q", problem.Type, mpp.ErrorTypeInvalidChallenge)
+	}
+}
+
 func TestComposeMiddleware_PanicsOnEmptyConfigs(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -58,7 +58,13 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 // This is the Fiber equivalent of [server.WriteChallenge]. Fiber is built on
 // fasthttp and cannot use http.ResponseWriter directly.
 func WriteChallenge(c *fiberfw.Ctx, challenge *mpp.Challenge, realm string) {
-	c.Set("WWW-Authenticate", challenge.ToAuthenticate(realm))
+	header, err := challenge.ToAuthenticateStrict(realm)
+	if err != nil {
+		WritePaymentError(c, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+		return
+	}
+
+	c.Set("WWW-Authenticate", header)
 	c.Set("Content-Type", "application/problem+json")
 	c.Set("Cache-Control", "no-store")
 

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -2,6 +2,7 @@ package fiberadapter
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -96,5 +97,44 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 	if got := string(body); got != "did:key:z6Mkrdemo:0xreceipt" {
 		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+	}
+}
+
+func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
+	t.Parallel()
+
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+
+	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{
+		Amount:      "0.50",
+		Description: "Line one\r\nLine two",
+	}), func(c *fiberfw.Ctx) error {
+		t.Fatal("handler should not be called")
+		return nil
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResponse, err := app.Test(challengeRequest)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer challengeResponse.Body.Close()
+
+	if challengeResponse.StatusCode != http.StatusBadRequest {
+		t.Fatalf("challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusBadRequest)
+	}
+	if got := challengeResponse.Header.Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("WWW-Authenticate = %q, want empty", got)
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(challengeResponse.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem) error = %v", err)
+	}
+	if problem.Type != string(mpp.ErrorTypeInvalidChallenge) {
+		t.Fatalf("problem type = %q, want %q", problem.Type, mpp.ErrorTypeInvalidChallenge)
 	}
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -72,7 +72,13 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.
 func WriteChallenge(w http.ResponseWriter, challenge *mpp.Challenge, realm string) {
-	w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(realm))
+	header, err := challenge.ToAuthenticateStrict(realm)
+	if err != nil {
+		WritePaymentError(w, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+		return
+	}
+
+	w.Header().Set("WWW-Authenticate", header)
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusPaymentRequired)

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -76,5 +77,36 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 	if got := string(body); got != "did:key:z6Mkrdemo:0xreceipt" {
 		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+	}
+}
+
+func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{
+		Amount:      "0.50",
+		Description: "Line one\r\nLine two",
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusBadRequest)
+	}
+	if got := resp.Header().Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("WWW-Authenticate = %q, want empty", got)
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem) error = %v", err)
+	}
+	if problem.Type != string(mpp.ErrorTypeInvalidChallenge) {
+		t.Fatalf("problem type = %q, want %q", problem.Type, mpp.ErrorTypeInvalidChallenge)
 	}
 }


### PR DESCRIPTION
## Summary

- Add checked WWW-Authenticate challenge formatting that rejects CR/LF in quoted auth-param values.
- Keep the existing string-only formatter for compatibility.
- Add unit coverage for quote/backslash escaping and CRLF rejection.

Ran `go test ./pkg/mpp` and `go test ./...`.