### PR TITLE
test: convert tests to testify assertions

### DIFF
--- a/.changelog/assert-test-refactor.md
+++ b/.changelog/assert-test-refactor.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Convert Go tests to use testify assertions.

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
@@ -43,9 +44,11 @@ func newTestCredential(method string) *mpp.Credential {
 func challengeForURL(t *testing.T, rawURL, method string, request map[string]any, opts ...mpp.ChallengeOption) *mpp.Challenge {
 	t.Helper()
 	parsedURL, err := urlpkg.Parse(rawURL)
-	if err != nil {
-		t.Fatalf("url.Parse(%q) error = %v", rawURL, err)
+	if !assert.NoErrorf(t, err,
+		"url.Parse(%q) error = %v", rawURL, err) {
+		return *new(*mpp.Challenge)
 	}
+
 	return mpp.NewChallenge("secret", parsedURL.Host, method, "payment", request, opts...)
 }
 
@@ -59,13 +62,17 @@ func TestTransport_RoundTrip_No402(t *testing.T) {
 	tr := NewTransport(nil, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
@@ -82,9 +89,9 @@ func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
 		}
 		// Verify we got a Payment authorization header.
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Payment ") {
-			t.Errorf("expected Payment auth scheme, got %q", auth)
-		}
+		assert.Truef(t, strings.HasPrefix(auth, "Payment "),
+			"expected Payment auth scheme, got %q", auth)
+
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("paid"))
 	}))
@@ -96,20 +103,27 @@ func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 	body, _ := io.ReadAll(resp.Body)
-	if string(body) != "paid" {
-		t.Fatalf("expected body 'paid', got %q", string(body))
+	if !assert.Equalf(t, "paid", string(body),
+		"expected body 'paid', got %q", string(body)) {
+		return
 	}
-	if callCount != 2 {
-		t.Fatalf("expected 2 calls to server, got %d", callCount)
+	if !assert.EqualValuesf(t, 2, callCount,
+		"expected 2 calls to server, got %d", callCount) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {
@@ -126,13 +140,17 @@ func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("expected 402, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected 402, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
@@ -151,14 +169,19 @@ func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
+	if !
 	// Expired challenge → no matching method → return original 402.
-	if resp.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("expected 402 for expired challenge, got %d", resp.StatusCode)
+	assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected 402 for expired challenge, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
@@ -169,17 +192,18 @@ func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 		callCount++
 		body, _ := io.ReadAll(r.Body)
 		if r.Header.Get("Authorization") == "" {
-			if string(body) != "request-body" {
-				t.Errorf("first request body = %q, want %q", string(body), "request-body")
-			}
+			assert.Equalf(t, "request-body", string(body),
+				"first request body = %q, want %q", string(body), "request-body")
+
 			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
-		// Retry should have the same body.
-		if string(body) != "request-body" {
-			t.Errorf("retry body = %q, want %q", string(body), "request-body")
-		}
+		assert.
+			// Retry should have the same body.
+			Equalf(t, "request-body", string(body),
+				"retry body = %q, want %q", string(body), "request-body")
+
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -194,16 +218,21 @@ func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 		return io.NopCloser(strings.NewReader(bodyStr)), nil
 	}
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
-	if callCount != 2 {
-		t.Fatalf("expected 2 calls, got %d", callCount)
+	if !assert.EqualValuesf(t, 2, callCount,
+		"expected 2 calls, got %d", callCount) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_MultipleWWWAuthenticate(t *testing.T) {
@@ -228,13 +257,17 @@ func TestTransport_RoundTrip_MultipleWWWAuthenticate(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_MergedWWWAuthenticate(t *testing.T) {
@@ -256,13 +289,17 @@ func TestTransport_RoundTrip_MergedWWWAuthenticate(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_NonPaymentAuthScheme(t *testing.T) {
@@ -277,14 +314,19 @@ func TestTransport_RoundTrip_NonPaymentAuthScheme(t *testing.T) {
 	tr := NewTransport([]Method{method}, nil)
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
+	if !
 	// Non-Payment scheme → no matching method → return original 402.
-	if resp.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("expected 402, got %d", resp.StatusCode)
+	assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected 402, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestTransport_RoundTrip_RejectsOriginMismatchFromContext(t *testing.T) {
@@ -301,12 +343,15 @@ func TestTransport_RoundTrip_RejectsOriginMismatchFromContext(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	req = req.WithContext(withPaymentOrigin(req.Context(), "https://api.example.com"))
 	_, err := tr.RoundTrip(req)
-	if err == nil || !strings.Contains(err.Error(), "refusing payment for redirected origin") {
-		t.Fatalf("RoundTrip() error = %v, want origin mismatch", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "refusing payment for redirected origin"),
+		"RoundTrip() error = %v, want origin mismatch", err) {
+		return
 	}
-	if method.calls != 0 {
-		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
+	if !assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0", method.calls) {
+		return
 	}
+
 }
 
 func TestClient_Get(t *testing.T) {
@@ -328,25 +373,28 @@ func TestClient_Get(t *testing.T) {
 	method := &mockMethod{name: "tempo", cred: cred}
 	c := New([]Method{method})
 	resp, err := c.Get(context.Background(), srv.URL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestClient_Post(t *testing.T) {
 	var challenge *mpp.Challenge
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		if r.Header.Get("Content-Type") != "application/json" {
-			t.Errorf("content-type = %q, want application/json", r.Header.Get("Content-Type"))
-		}
+		assert.Equalf(t, http.MethodPost, r.Method,
+			"expected POST, got %s", r.Method)
+		assert.Equalf(t, "application/json", r.Header.Get("Content-Type"),
+			"content-type = %q, want application/json", r.Header.Get("Content-Type"))
+
 		if r.Header.Get("Authorization") == "" {
 			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
 			w.WriteHeader(http.StatusPaymentRequired)
@@ -362,21 +410,27 @@ func TestClient_Post(t *testing.T) {
 	c := New([]Method{method})
 	body := strings.NewReader(`{"key":"value"}`)
 	resp, err := c.Post(context.Background(), srv.URL, "application/json", body)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
 	}
+
 }
 
 func TestClient_WithHTTPClient(t *testing.T) {
 	custom := &http.Client{}
 	c := New(nil, WithHTTPClient(custom))
-	if c.httpClient != custom {
-		t.Fatal("expected custom http client to be set")
+	if !assert.Equal(t, custom, c.httpClient,
+		"expected custom http client to be set") {
+		return
 	}
+
 }
 
 func TestClient_Do_RejectsCrossOriginRedirect(t *testing.T) {
@@ -396,10 +450,13 @@ func TestClient_Do_RejectsCrossOriginRedirect(t *testing.T) {
 	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
 	c := New([]Method{method})
 	_, err := c.Get(context.Background(), origin.URL)
-	if err == nil || !strings.Contains(err.Error(), "refusing cross-origin redirect") {
-		t.Fatalf("Get() error = %v, want cross-origin redirect rejection", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "refusing cross-origin redirect"),
+		"Get() error = %v, want cross-origin redirect rejection", err) {
+		return
 	}
-	if method.calls != 0 {
-		t.Fatalf("CreateCredential() calls = %d, want 0", method.calls)
+	if !assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0", method.calls) {
+		return
 	}
+
 }

--- a/pkg/mpp/challenge_vectors_test.go
+++ b/pkg/mpp/challenge_vectors_test.go
@@ -1,7 +1,7 @@
 package mpp
 
 import (
-	"strings"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -146,10 +146,15 @@ func TestGenerateChallengeIDCrossSDKCompatibilityVectors(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			{
 
-			if got := GenerateChallengeID(tt.in); got != tt.want {
-				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+				got := GenerateChallengeID(tt.in)
+				if !assert.Equalf(t, tt.want, got,
+					"GenerateChallengeID() = %q, want %q", got, tt.want) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -238,10 +243,15 @@ func TestGenerateChallengeIDGoldenVectors(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			{
 
-			if got := GenerateChallengeID(tt.in); got != tt.want {
-				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+				got := GenerateChallengeID(tt.in)
+				if !assert.Equalf(t, tt.want, got,
+					"GenerateChallengeID() = %q, want %q", got, tt.want) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -285,10 +295,15 @@ func TestGenerateChallengeIDOpaqueGoldenVectors(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			{
 
-			if got := GenerateChallengeID(tt.in); got != tt.want {
-				t.Fatalf("GenerateChallengeID() = %q, want %q", got, tt.want)
+				got := GenerateChallengeID(tt.in)
+				if !assert.Equalf(t, tt.want, got,
+					"GenerateChallengeID() = %q, want %q", got, tt.want) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -306,17 +321,21 @@ func TestEmptyOpaquePreservedOnWire(t *testing.T) {
 	)
 
 	header := challenge.ToAuthenticate("api.example.com")
-	if !strings.Contains(header, `opaque="`) {
-		t.Fatalf("challenge header = %q, want opaque field", header)
+	if !assert.Containsf(t, header, `opaque="`,
+		"challenge header = %q, want opaque field", header) {
+		return
 	}
 
 	parsed, err := ParseChallenge(header)
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChallenge() error = %v", err) {
+		return
 	}
-	if parsed.Opaque == nil {
-		t.Fatal("parsed.Opaque = nil, want empty map")
+	if !assert.NotNil(t, parsed.Opaque,
+		"parsed.Opaque = nil, want empty map") {
+		return
 	}
+
 	if got := GenerateChallengeID(GenerateChallengeIDInput{
 		SecretKey: "test-vector-secret",
 		Realm:     "api.example.com",
@@ -325,19 +344,25 @@ func TestEmptyOpaquePreservedOnWire(t *testing.T) {
 		Request:   map[string]any{"amount": "1000000"},
 		Opaque:    parsed.Opaque,
 	}); got != challenge.ID {
-		t.Fatalf("GenerateChallengeID(parsed opaque) = %q, want %q", got, challenge.ID)
+		assert.Failf(t, "", "GenerateChallengeID(parsed opaque) = %q, want %q", got, challenge.ID)
+		return
 	}
 
 	credential := &Credential{Challenge: challenge.ToEcho(), Payload: map[string]any{"type": "hash", "hash": "0xabc123"}}
 	authorization := credential.ToAuthorization()
-	if !strings.Contains(authorization, "ey") {
-		t.Fatalf("credential authorization = %q, want base64 payload", authorization)
+	if !assert.Containsf(t, authorization, "ey",
+		"credential authorization = %q, want base64 payload", authorization) {
+		return
 	}
+
 	parsedCredential, err := ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
-	if parsedCredential.Challenge.Opaque == nil {
-		t.Fatal("parsedCredential.Challenge.Opaque = nil, want empty map")
+	if !assert.NotNil(t, parsedCredential.Challenge.Opaque,
+		"parsedCredential.Challenge.Opaque = nil, want empty map") {
+		return
 	}
+
 }

--- a/pkg/mpp/digest_test.go
+++ b/pkg/mpp/digest_test.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -8,17 +9,17 @@ func TestBodyDigest_Compute_String(t *testing.T) {
 	digest := BodyDigest.Compute("hello")
 	// SHA-256 of "hello" = LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=
 	want := "sha-256=LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
-	if digest != want {
-		t.Errorf("got %q, want %q", digest, want)
-	}
+	assert.Equalf(t, want, digest,
+		"got %q, want %q", digest, want)
+
 }
 
 func TestBodyDigest_Compute_Bytes(t *testing.T) {
 	digest := BodyDigest.Compute([]byte("hello"))
 	want := "sha-256=LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
-	if digest != want {
-		t.Errorf("got %q, want %q", digest, want)
-	}
+	assert.Equalf(t, want, digest,
+		"got %q, want %q", digest, want)
+
 }
 
 func TestBodyDigest_Compute_Map(t *testing.T) {
@@ -27,51 +28,54 @@ func TestBodyDigest_Compute_Map(t *testing.T) {
 		"a": 1,
 	}
 	digest := BodyDigest.Compute(body)
+	if !
 	// json.Marshal sorts map keys, so {"a":1,"b":2}
-	if digest == "" {
-		t.Fatal("digest should not be empty")
+	assert.NotEqual(t, "", digest,
+		"digest should not be empty") {
+		return
+
+		// Same map should produce same digest.
 	}
-	// Same map should produce same digest.
+
 	digest2 := BodyDigest.Compute(map[string]any{"a": 1, "b": 2})
-	if digest != digest2 {
-		t.Errorf("same content should produce same digest: %q vs %q", digest, digest2)
-	}
+	assert.Equalf(t, digest2, digest,
+		"same content should produce same digest: %q vs %q", digest, digest2)
+
 }
 
 func TestBodyDigest_Compute_StandardBase64(t *testing.T) {
 	// Ensure we use standard base64 (with + and /), not URL-safe.
 	digest := BodyDigest.Compute("hello")
+	if !
 	// The known digest contains '+' which confirms standard encoding.
-	if len(digest) <= len("sha-256=") {
-		t.Fatal("digest too short")
+	assert.False(t, len(digest) <= len("sha-256="),
+		"digest too short") {
+		return
 	}
+
 }
 
 func TestBodyDigest_Verify(t *testing.T) {
 	body := "test body"
 	digest := BodyDigest.Compute(body)
+	assert.True(t, BodyDigest.Verify(digest, body),
+		"verify should return true for matching digest")
+	assert.False(t, BodyDigest.Verify("sha-256=AAAA", body),
+		"verify should return false for non-matching digest")
 
-	if !BodyDigest.Verify(digest, body) {
-		t.Error("verify should return true for matching digest")
-	}
-
-	if BodyDigest.Verify("sha-256=AAAA", body) {
-		t.Error("verify should return false for non-matching digest")
-	}
 }
 
 func TestBodyDigest_Verify_Map(t *testing.T) {
 	body := map[string]any{"key": "value"}
 	digest := BodyDigest.Compute(body)
+	assert.True(t, BodyDigest.Verify(digest, body),
+		"verify should return true for matching map digest")
 
-	if !BodyDigest.Verify(digest, body) {
-		t.Error("verify should return true for matching map digest")
-	}
 }
 
 func TestBodyDigest_Prefix(t *testing.T) {
 	digest := BodyDigest.Compute("x")
-	if len(digest) < 8 || digest[:8] != "sha-256=" {
-		t.Errorf("digest should start with 'sha-256=', got %q", digest)
-	}
+	assert.Falsef(t, len(digest) < 8 || digest[:8] != "sha-256=",
+		"digest should start with 'sha-256=', got %q", digest)
+
 }

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -2,6 +2,7 @@ package mpp
 
 import (
 	"errors"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"strings"
 	"testing"
@@ -94,16 +95,19 @@ func TestPaymentErrorConstructors(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if !assert.Equalf(t, tt.want, tt.err.Type,
+				"err.Type = %q, want %q", tt.err.Type, tt.want) {
+				return
+			}
+			if !assert.Equalf(t, tt.status, tt.err.Status,
+				"err.Status = %d, want %d", tt.err.Status, tt.status) {
+				return
+			}
+			if !assert.Equalf(t, tt.detail, tt.err.Detail,
+				"err.Detail = %q, want %q", tt.err.Detail, tt.detail) {
+				return
+			}
 
-			if tt.err.Type != tt.want {
-				t.Fatalf("err.Type = %q, want %q", tt.err.Type, tt.want)
-			}
-			if tt.err.Status != tt.status {
-				t.Fatalf("err.Status = %d, want %d", tt.err.Status, tt.status)
-			}
-			if tt.err.Detail != tt.detail {
-				t.Fatalf("err.Detail = %q, want %q", tt.err.Detail, tt.detail)
-			}
 		})
 	}
 }
@@ -113,26 +117,33 @@ func TestPaymentErrorHelpers(t *testing.T) {
 
 	err := ErrVerificationFailed("signature mismatch")
 	if got := err.Error(); got != "Verification Failed: signature mismatch" {
-		t.Fatalf("err.Error() = %q, want %q", got, "Verification Failed: signature mismatch")
+		assert.Failf(t, "", "err.Error() = %q, want %q", got, "Verification Failed: signature mismatch")
+		return
 	}
-	if !errors.Is(err, ErrVerification) {
-		t.Fatal("errors.Is(err, ErrVerification) = false, want true")
+	if !assert.True(t, errors.Is(err, ErrVerification),
+		"errors.Is(err, ErrVerification) = false, want true") {
+		return
 	}
 
 	problem := err.ProblemDetails("challenge-1")
-	if problem["type"] != err.Type {
-		t.Fatalf("problem[type] = %#v, want %q", problem["type"], err.Type)
+	if !assert.Equalf(t, err.Type, problem["type"],
+		"problem[type] = %#v, want %q", problem["type"], err.Type) {
+		return
 	}
-	if problem["challengeId"] != "challenge-1" {
-		t.Fatalf("problem[challengeId] = %#v, want %q", problem["challengeId"], "challenge-1")
+	if !assert.Equalf(t, "challenge-1", problem["challengeId"],
+		"problem[challengeId] = %#v, want %q", problem["challengeId"], "challenge-1") {
+		return
 	}
 
 	nonVerification := ErrBadRequest("invalid")
-	if errors.Is(nonVerification, ErrVerification) {
-		t.Fatal("errors.Is(nonVerification, ErrVerification) = true, want false")
+	if !assert.False(t, errors.Is(nonVerification, ErrVerification),
+		"errors.Is(nonVerification, ErrVerification) = true, want false") {
+		return
 	}
+
 	if got := nonVerification.ProblemDetails(""); got["challengeId"] != nil {
-		t.Fatalf("problem[challengeId] = %#v, want nil", got["challengeId"])
+		assert.Failf(t, "", "problem[challengeId] = %#v, want nil", got["challengeId"])
+		return
 	}
 }
 
@@ -145,32 +156,41 @@ func TestReceiptRoundTrip(t *testing.T) {
 		WithExternalID("ext-123"),
 		WithExtra(map[string]any{"settled": true}),
 	)
-	if receipt.Status != "success" {
-		t.Fatalf("receipt.Status = %q, want %q", receipt.Status, "success")
+	if !assert.Equalf(t, "success", receipt.Status,
+		"receipt.Status = %q, want %q", receipt.Status, "success") {
+		return
 	}
-	if receipt.Timestamp.Location() != time.UTC {
-		t.Fatalf("receipt.Timestamp.Location() = %v, want UTC", receipt.Timestamp.Location())
+	if !assert.Equalf(t, time.UTC, receipt.Timestamp.Location(),
+		"receipt.Timestamp.Location() = %v, want UTC", receipt.Timestamp.Location()) {
+		return
 	}
 
 	header := FormatReceipt(receipt)
 	parsed, err := ParseReceipt(header)
-	if err != nil {
-		t.Fatalf("ParseReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseReceipt() error = %v", err) {
+		return
 	}
-	if parsed.Reference != receipt.Reference {
-		t.Fatalf("parsed.Reference = %q, want %q", parsed.Reference, receipt.Reference)
+	if !assert.Equalf(t, receipt.Reference, parsed.Reference,
+		"parsed.Reference = %q, want %q", parsed.Reference, receipt.Reference) {
+		return
 	}
-	if parsed.Method != receipt.Method {
-		t.Fatalf("parsed.Method = %q, want %q", parsed.Method, receipt.Method)
+	if !assert.Equalf(t, receipt.Method, parsed.Method,
+		"parsed.Method = %q, want %q", parsed.Method, receipt.Method) {
+		return
 	}
-	if parsed.ExternalID != receipt.ExternalID {
-		t.Fatalf("parsed.ExternalID = %q, want %q", parsed.ExternalID, receipt.ExternalID)
+	if !assert.Equalf(t, receipt.ExternalID, parsed.ExternalID,
+		"parsed.ExternalID = %q, want %q", parsed.ExternalID, receipt.ExternalID) {
+		return
 	}
-	if parsed.Extra["settled"] != true {
-		t.Fatalf("parsed.Extra[settled] = %#v, want true", parsed.Extra["settled"])
+	if !assert.Equalf(t, true, parsed.Extra["settled"],
+		"parsed.Extra[settled] = %#v, want true", parsed.Extra["settled"]) {
+		return
 	}
+
 	if got, want := parsed.Timestamp.Format("2006-01-02T15:04:05.000Z"), receipt.Timestamp.Format("2006-01-02T15:04:05.000Z"); got != want {
-		t.Fatalf("parsed.Timestamp = %q, want %q", got, want)
+		assert.Failf(t, "", "parsed.Timestamp = %q, want %q", got, want)
+		return
 	}
 }
 
@@ -182,15 +202,17 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",
 	}))
-	if err == nil || !strings.Contains(err.Error(), "invalid receipt status") {
-		t.Fatalf("ParseReceipt() error = %v, want invalid status error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt status"),
+		"ParseReceipt() error = %v, want invalid status error", err) {
+		return
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
 		"status": "success",
 	}))
-	if err == nil || !strings.Contains(err.Error(), "receipt missing reference") {
-		t.Fatalf("ParseReceipt() error = %v, want missing reference error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "receipt missing reference"),
+		"ParseReceipt() error = %v, want missing reference error", err) {
+		return
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
@@ -199,8 +221,9 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",
 	}))
-	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
-		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
+		"ParseReceipt() error = %v, want invalid method error", err) {
+		return
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
@@ -209,8 +232,9 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",
 	}))
-	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
-		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
+		"ParseReceipt() error = %v, want invalid method error", err) {
+		return
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
@@ -219,9 +243,11 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",
 	}))
-	if err == nil || !strings.Contains(err.Error(), "invalid receipt method") {
-		t.Fatalf("ParseReceipt() error = %v, want invalid method error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
+		"ParseReceipt() error = %v, want invalid method error", err) {
+		return
 	}
+
 }
 
 func TestChallengeVerifyAndToEcho(t *testing.T) {
@@ -235,27 +261,34 @@ func TestChallengeVerifyAndToEcho(t *testing.T) {
 		map[string]any{"amount": "100"},
 		WithExpires("2026-01-01T00:00:00.000Z"),
 	)
-	if !challenge.Verify("secret-key", "api.example.com") {
-		t.Fatal("challenge.Verify(secret-key, api.example.com) = false, want true")
+	if !assert.True(t, challenge.Verify("secret-key", "api.example.com"),
+		"challenge.Verify(secret-key, api.example.com) = false, want true") {
+		return
 	}
-	if challenge.Verify("secret-key", "other.example.com") {
-		t.Fatal("challenge.Verify(secret-key, other.example.com) = true, want false")
+	if !assert.False(t, challenge.Verify("secret-key", "other.example.com"),
+		"challenge.Verify(secret-key, other.example.com) = true, want false") {
+		return
 	}
 
 	challenge.RequestB64 = ""
 	echo := challenge.ToEcho()
-	if echo.Request == "" {
-		t.Fatal("echo.Request = empty, want base64-encoded request")
+	if !assert.NotEqual(t, "", echo.Request,
+		"echo.Request = empty, want base64-encoded request") {
+		return
 	}
-	if !ConstantTimeEqual(challenge.ID, echo.ID) {
-		t.Fatal("ConstantTimeEqual(challenge.ID, echo.ID) = false, want true")
+	if !assert.True(t, ConstantTimeEqual(challenge.ID, echo.ID),
+		"ConstantTimeEqual(challenge.ID, echo.ID) = false, want true") {
+		return
 	}
-	if ConstantTimeEqual(challenge.ID, "different") {
-		t.Fatal("ConstantTimeEqual(challenge.ID, different) = true, want false")
+	if !assert.False(t, ConstantTimeEqual(challenge.ID, "different"),
+		"ConstantTimeEqual(challenge.ID, different) = true, want false") {
+		return
 	}
-	if echo.Expires != challenge.Expires {
-		t.Fatalf("echo.Expires = %q, want %q", echo.Expires, challenge.Expires)
+	if !assert.Equalf(t, challenge.Expires, echo.Expires,
+		"echo.Expires = %q, want %q", echo.Expires, challenge.Expires) {
+		return
 	}
+
 }
 
 func TestChallengeNewCredential(t *testing.T) {
@@ -273,17 +306,21 @@ func TestChallengeNewCredential(t *testing.T) {
 		map[string]any{"type": "hash", "hash": "0xabc123"},
 		WithCredentialSource("did:pkh:eip155:42431:0x1234"),
 	)
+	if !assert.Equalf(t, challenge.ID, credential.Challenge.ID,
+		"credential.Challenge.ID = %q, want %q", credential.Challenge.ID, challenge.ID) {
+		return
+	}
+	if !assert.Equalf(t, challenge.ToEcho().Request, credential.Challenge.Request,
+		"credential.Challenge.Request = %q, want %q", credential.Challenge.Request, challenge.ToEcho().Request) {
+		return
+	}
+	if !assert.Equalf(t, "did:pkh:eip155:42431:0x1234", credential.Source,
+		"credential.Source = %q, want source", credential.Source) {
+		return
+	}
+	if !assert.Equalf(t, "0xabc123", credential.Payload["hash"],
+		"credential.Payload[hash] = %#v, want %q", credential.Payload["hash"], "0xabc123") {
+		return
+	}
 
-	if credential.Challenge.ID != challenge.ID {
-		t.Fatalf("credential.Challenge.ID = %q, want %q", credential.Challenge.ID, challenge.ID)
-	}
-	if credential.Challenge.Request != challenge.ToEcho().Request {
-		t.Fatalf("credential.Challenge.Request = %q, want %q", credential.Challenge.Request, challenge.ToEcho().Request)
-	}
-	if credential.Source != "did:pkh:eip155:42431:0x1234" {
-		t.Fatalf("credential.Source = %q, want source", credential.Source)
-	}
-	if credential.Payload["hash"] != "0xabc123" {
-		t.Fatalf("credential.Payload[hash] = %#v, want %q", credential.Payload["hash"], "0xabc123")
-	}
 }

--- a/pkg/mpp/expires_test.go
+++ b/pkg/mpp/expires_test.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
@@ -10,15 +11,17 @@ func TestExpires_Format(t *testing.T) {
 
 	// Parse the result back.
 	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", result)
-	if err != nil {
-		t.Fatalf("failed to parse result %q: %v", result, err)
+	if !assert.NoErrorf(t, err,
+		"failed to parse result %q: %v", result, err) {
+		return
+
+		// Should be approximately 60 seconds from now.
 	}
 
-	// Should be approximately 60 seconds from now.
 	diff := time.Until(parsed)
-	if diff < 59*time.Second || diff > 61*time.Second {
-		t.Errorf("expected ~60s from now, got %v", diff)
-	}
+	assert.Falsef(t, diff < 59*time.Second || diff > 61*time.Second,
+		"expected ~60s from now, got %v", diff)
+
 }
 
 func TestExpires_EndsWithZ(t *testing.T) {
@@ -34,66 +37,75 @@ func TestExpires_EndsWithZ(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.fn(1)
-			if result[len(result)-1] != 'Z' {
-				t.Errorf("expected Z suffix, got %q", result)
-			}
+			assert.EqualValuesf(t, 'Z', result[len(result)-1],
+				"expected Z suffix, got %q", result)
+
 		})
 	}
 }
 
 func TestExpires_HasMilliseconds(t *testing.T) {
 	result := Expires.Seconds(1)
-	// Format: 2006-01-02T15:04:05.000Z — the .000 is 3 digits.
-	if len(result) != 24 {
-		t.Errorf("expected 24 char ISO string, got %d: %q", len(result), result)
-	}
+	assert.
+		// Format: 2006-01-02T15:04:05.000Z — the .000 is 3 digits.
+		Lenf(t, result, 24,
+			"expected 24 char ISO string, got %d: %q", len(result), result)
+
 }
 
 func TestExpires_Minutes(t *testing.T) {
 	result := Expires.Minutes(5)
 	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", result)
-	if err != nil {
-		t.Fatalf("failed to parse: %v", err)
+	if !assert.NoErrorf(t, err,
+		"failed to parse: %v", err) {
+		return
 	}
+
 	diff := time.Until(parsed)
-	if diff < 4*time.Minute+59*time.Second || diff > 5*time.Minute+1*time.Second {
-		t.Errorf("expected ~5min from now, got %v", diff)
-	}
+	assert.Falsef(t, diff < 4*time.Minute+59*time.Second || diff > 5*time.Minute+1*time.Second,
+		"expected ~5min from now, got %v", diff)
+
 }
 
 func TestExpires_Hours(t *testing.T) {
 	result := Expires.Hours(2)
 	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", result)
-	if err != nil {
-		t.Fatalf("failed to parse: %v", err)
+	if !assert.NoErrorf(t, err,
+		"failed to parse: %v", err) {
+		return
 	}
+
 	diff := time.Until(parsed)
-	if diff < 1*time.Hour+59*time.Minute || diff > 2*time.Hour+1*time.Minute {
-		t.Errorf("expected ~2h from now, got %v", diff)
-	}
+	assert.Falsef(t, diff < 1*time.Hour+59*time.Minute || diff > 2*time.Hour+1*time.Minute,
+		"expected ~2h from now, got %v", diff)
+
 }
 
 func TestExpires_Days(t *testing.T) {
 	result := Expires.Days(1)
 	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", result)
-	if err != nil {
-		t.Fatalf("failed to parse: %v", err)
+	if !assert.NoErrorf(t, err,
+		"failed to parse: %v", err) {
+		return
 	}
+
 	diff := time.Until(parsed)
-	if diff < 23*time.Hour+59*time.Minute || diff > 24*time.Hour+1*time.Minute {
-		t.Errorf("expected ~24h from now, got %v", diff)
-	}
+	assert.Falsef(t, diff < 23*time.Hour+59*time.Minute || diff > 24*time.Hour+1*time.Minute,
+		"expected ~24h from now, got %v", diff)
+
 }
 
 func TestExpires_Weeks(t *testing.T) {
 	result := Expires.Weeks(1)
 	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", result)
-	if err != nil {
-		t.Fatalf("failed to parse: %v", err)
+	if !assert.NoErrorf(t, err,
+		"failed to parse: %v", err) {
+		return
 	}
+
 	diff := time.Until(parsed)
 	expected := 7 * 24 * time.Hour
-	if diff < expected-1*time.Minute || diff > expected+1*time.Minute {
-		t.Errorf("expected ~1 week from now, got %v", diff)
-	}
+	assert.Falsef(t, diff < expected-1*time.Minute || diff > expected+1*time.Minute,
+		"expected ~1 week from now, got %v", diff)
+
 }

--- a/pkg/mpp/json_test.go
+++ b/pkg/mpp/json_test.go
@@ -2,6 +2,7 @@ package mpp
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
@@ -18,25 +19,31 @@ func TestChallengeJSONMarshalUsesDecodedRequest(t *testing.T) {
 	}
 
 	encoded, err := json.Marshal(challenge)
-	if err != nil {
-		t.Fatalf("json.Marshal(challenge) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"json.Marshal(challenge) error = %v", err) {
+		return
 	}
 
 	var decoded map[string]any
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal(encoded) error = %v", err)
+		assert.Failf(t, "", "json.Unmarshal(encoded) error = %v", err)
+		return
 	}
 
 	if _, ok := decoded["requestB64"]; ok {
-		t.Fatal("challenge JSON unexpectedly included requestB64")
+		assert.Fail(t, "challenge JSON unexpectedly included requestB64")
+		return
 	}
 	request, ok := decoded["request"].(map[string]any)
-	if !ok {
-		t.Fatalf("challenge JSON request = %#v, want object", decoded["request"])
+	if !assert.Truef(t, ok,
+		"challenge JSON request = %#v, want object", decoded["request"]) {
+		return
 	}
-	if request["amount"] != "100" {
-		t.Fatalf("challenge JSON request[amount] = %#v, want %q", request["amount"], "100")
+	if !assert.Equalf(t, "100", request["amount"],
+		"challenge JSON request[amount] = %#v, want %q", request["amount"], "100") {
+		return
 	}
+
 }
 
 func TestChallengeJSONOpaqueRoundTrip(t *testing.T) {
@@ -53,30 +60,37 @@ func TestChallengeJSONOpaqueRoundTrip(t *testing.T) {
 	}
 
 	encoded, err := json.Marshal(challenge)
-	if err != nil {
-		t.Fatalf("json.Marshal(challenge) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"json.Marshal(challenge) error = %v", err) {
+		return
 	}
 
 	var decoded map[string]any
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal(encoded) error = %v", err)
+		assert.Failf(t, "", "json.Unmarshal(encoded) error = %v", err)
+		return
 	}
 
 	opaque, ok := decoded["opaque"].(map[string]any)
-	if !ok {
-		t.Fatalf("challenge JSON opaque = %#v, want object", decoded["opaque"])
+	if !assert.Truef(t, ok,
+		"challenge JSON opaque = %#v, want object", decoded["opaque"]) {
+		return
 	}
-	if opaque["trace"] != "123" {
-		t.Fatalf("challenge JSON opaque[trace] = %#v, want %q", opaque["trace"], "123")
+	if !assert.Equalf(t, "123", opaque["trace"],
+		"challenge JSON opaque[trace] = %#v, want %q", opaque["trace"], "123") {
+		return
 	}
 
 	var roundTripped Challenge
 	if err := json.Unmarshal([]byte(`{"id":"challenge-id","realm":"api.example.com","method":"tempo","intent":"charge","request":{"amount":"100"},"opaque":"`+rawOpaque+`"}`), &roundTripped); err != nil {
-		t.Fatalf("json.Unmarshal(challenge) error = %v", err)
+		assert.Failf(t, "", "json.Unmarshal(challenge) error = %v", err)
+		return
 	}
-	if roundTripped.Opaque["trace"] != "123" {
-		t.Fatalf("challenge.Opaque[trace] = %q, want %q", roundTripped.Opaque["trace"], "123")
+	if !assert.Equalf(t, "123", roundTripped.Opaque["trace"],
+		"challenge.Opaque[trace] = %q, want %q", roundTripped.Opaque["trace"], "123") {
+		return
 	}
+
 }
 
 func TestChallengeJSONUnmarshalNormalizesRequest(t *testing.T) {
@@ -123,25 +137,32 @@ func TestChallengeJSONUnmarshalNormalizesRequest(t *testing.T) {
 			var challenge Challenge
 			err := json.Unmarshal([]byte(tt.input), &challenge)
 			if tt.wantErr != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("json.Unmarshal(challenge) error = %v, want substring %q", err, tt.wantErr)
+				if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+					"json.Unmarshal(challenge) error = %v, want substring %q", err, tt.wantErr) {
+					return
 				}
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("json.Unmarshal(challenge) error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"json.Unmarshal(challenge) error = %v", err) {
+				return
+			}
+			if !assert.Equalf(t, tt.wantB64, challenge.RequestB64,
+				"challenge.RequestB64 = %q, want %q", challenge.RequestB64, tt.wantB64) {
+				return
 			}
 
-			if challenge.RequestB64 != tt.wantB64 {
-				t.Fatalf("challenge.RequestB64 = %q, want %q", challenge.RequestB64, tt.wantB64)
-			}
 			decoded, err := B64Decode(challenge.RequestB64)
-			if err != nil {
-				t.Fatalf("B64Decode(challenge.RequestB64) error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"B64Decode(challenge.RequestB64) error = %v", err) {
+				return
 			}
-			if !JSONEqual(challenge.Request, decoded) {
-				t.Fatalf("challenge.Request = %#v, want %#v", challenge.Request, decoded)
+			if !assert.Truef(t, JSONEqual(challenge.Request, decoded),
+				"challenge.Request = %#v, want %#v", challenge.Request, decoded) {
+				return
 			}
+
 		})
 	}
 }
@@ -163,35 +184,45 @@ func TestCredentialJSONMarshalUsesDecodedChallengeRequest(t *testing.T) {
 	}
 
 	encoded, err := json.Marshal(credential)
-	if err != nil {
-		t.Fatalf("json.Marshal(credential) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"json.Marshal(credential) error = %v", err) {
+		return
 	}
 
 	var decoded map[string]any
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal(encoded) error = %v", err)
+		assert.Failf(t, "", "json.Unmarshal(encoded) error = %v", err)
+		return
 	}
 
 	challenge, ok := decoded["challenge"].(map[string]any)
-	if !ok {
-		t.Fatalf("credential JSON challenge = %#v, want object", decoded["challenge"])
+	if !assert.Truef(t, ok,
+		"credential JSON challenge = %#v, want object", decoded["challenge"]) {
+		return
 	}
+
 	if _, ok := challenge["requestB64"]; ok {
-		t.Fatal("credential JSON challenge unexpectedly included requestB64")
+		assert.Fail(t, "credential JSON challenge unexpectedly included requestB64")
+		return
 	}
 	if _, ok := challenge["description"]; ok {
-		t.Fatal("credential JSON challenge unexpectedly included description")
+		assert.Fail(t, "credential JSON challenge unexpectedly included description")
+		return
 	}
 	request, ok := challenge["request"].(map[string]any)
-	if !ok {
-		t.Fatalf("credential JSON challenge.request = %#v, want object", challenge["request"])
+	if !assert.Truef(t, ok,
+		"credential JSON challenge.request = %#v, want object", challenge["request"]) {
+		return
 	}
-	if request["amount"] != "100" {
-		t.Fatalf("credential JSON challenge.request[amount] = %#v, want %q", request["amount"], "100")
+	if !assert.Equalf(t, "100", request["amount"],
+		"credential JSON challenge.request[amount] = %#v, want %q", request["amount"], "100") {
+		return
 	}
-	if decoded["source"] != credential.Source {
-		t.Fatalf("credential JSON source = %#v, want %q", decoded["source"], credential.Source)
+	if !assert.Equalf(t, credential.Source, decoded["source"],
+		"credential JSON source = %#v, want %q", decoded["source"], credential.Source) {
+		return
 	}
+
 }
 
 func TestCredentialJSONUnmarshalNormalizesChallengeOpaque(t *testing.T) {
@@ -202,12 +233,14 @@ func TestCredentialJSONUnmarshalNormalizesChallengeOpaque(t *testing.T) {
 
 	var credential Credential
 	if err := json.Unmarshal([]byte(input), &credential); err != nil {
-		t.Fatalf("json.Unmarshal(credential) error = %v", err)
+		assert.Failf(t, "", "json.Unmarshal(credential) error = %v", err)
+		return
+	}
+	if !assert.Equalf(t, "123", credential.Challenge.Opaque["trace"],
+		"credential.Challenge.Opaque[trace] = %q, want %q", credential.Challenge.Opaque["trace"], "123") {
+		return
 	}
 
-	if credential.Challenge.Opaque["trace"] != "123" {
-		t.Fatalf("credential.Challenge.Opaque[trace] = %q, want %q", credential.Challenge.Opaque["trace"], "123")
-	}
 }
 
 func TestCredentialJSONUnmarshalNormalizesChallengeRequest(t *testing.T) {
@@ -244,25 +277,32 @@ func TestCredentialJSONUnmarshalNormalizesChallengeRequest(t *testing.T) {
 			var credential Credential
 			err := json.Unmarshal([]byte(tt.input), &credential)
 			if tt.wantErr != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("json.Unmarshal(credential) error = %v, want substring %q", err, tt.wantErr)
+				if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+					"json.Unmarshal(credential) error = %v, want substring %q", err, tt.wantErr) {
+					return
 				}
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("json.Unmarshal(credential) error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"json.Unmarshal(credential) error = %v", err) {
+				return
+			}
+			if !assert.Equalf(t, tt.wantB64, credential.Challenge.Request,
+				"credential.Challenge.Request = %q, want %q", credential.Challenge.Request, tt.wantB64) {
+				return
 			}
 
-			if credential.Challenge.Request != tt.wantB64 {
-				t.Fatalf("credential.Challenge.Request = %q, want %q", credential.Challenge.Request, tt.wantB64)
-			}
 			decoded, err := B64Decode(credential.Challenge.Request)
-			if err != nil {
-				t.Fatalf("B64Decode(credential.Challenge.Request) error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"B64Decode(credential.Challenge.Request) error = %v", err) {
+				return
 			}
-			if decoded["amount"] != "100" {
-				t.Fatalf("decoded request[amount] = %#v, want %q", decoded["amount"], "100")
+			if !assert.Equalf(t, "100", decoded["amount"],
+				"decoded request[amount] = %#v, want %q", decoded["amount"], "100") {
+				return
 			}
+
 		})
 	}
 }

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -1,7 +1,6 @@
 package mpp
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -86,9 +85,11 @@ func TestSplitAuthenticate(t *testing.T) {
 			t.Parallel()
 
 			got := SplitAuthenticate(tt.header)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("SplitAuthenticate() = %#v, want %#v", got, tt.want)
+			if !assert.Equalf(t, tt.want, got,
+				"SplitAuthenticate() = %#v, want %#v", got, tt.want) {
+				return
 			}
+
 		})
 	}
 }
@@ -134,9 +135,11 @@ func TestFindPaymentAuthorization(t *testing.T) {
 			t.Parallel()
 
 			got := FindPaymentAuthorization(tt.header)
-			if got != tt.want {
-				t.Fatalf("FindPaymentAuthorization() = %q, want %q", got, tt.want)
+			if !assert.Equalf(t, tt.want, got,
+				"FindPaymentAuthorization() = %q, want %q", got, tt.want) {
+				return
 			}
+
 		})
 	}
 }
@@ -162,10 +165,15 @@ func TestIsMethodName(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			{
 
-			if got := isMethodName(tt.value); got != tt.want {
-				t.Fatalf("isMethodName(%q) = %t, want %t", tt.value, got, tt.want)
+				got := isMethodName(tt.value)
+				if !assert.Equalf(t, tt.want, got,
+					"isMethodName(%q) = %t, want %t", tt.value, got, tt.want) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -339,18 +347,24 @@ func TestParseChallenge(t *testing.T) {
 			} {
 				got, err := parse.fn(tt.header)
 				if tt.wantErr != "" {
-					if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-						t.Fatalf("%s() error = %v, want substring %q", parse.name, err, tt.wantErr)
+					if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+						"%s() error = %v, want substring %q", parse.name, err, tt.wantErr) {
+						return
 					}
+
 					continue
 				}
-				if err != nil {
-					t.Fatalf("%s() unexpected error: %v", parse.name, err)
+				if !assert.NoErrorf(t, err,
+					"%s() unexpected error: %v", parse.name, err) {
+					return
 				}
+
 				assertChallengeEqual(t, got, tt.want)
-				if got.Request == nil {
-					t.Fatalf("%s() returned nil Request, want empty object", parse.name)
+				if !assert.NotNilf(t, got.Request,
+					"%s() returned nil Request, want empty object", parse.name) {
+					return
 				}
+
 			}
 		})
 	}
@@ -454,14 +468,18 @@ func TestParseCredential(t *testing.T) {
 			} {
 				got, err := parse.fn(tt.header)
 				if tt.wantErr != "" {
-					if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-						t.Fatalf("%s() error = %v, want substring %q", parse.name, err, tt.wantErr)
+					if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+						"%s() error = %v, want substring %q", parse.name, err, tt.wantErr) {
+						return
 					}
+
 					continue
 				}
-				if err != nil {
-					t.Fatalf("%s() unexpected error: %v", parse.name, err)
+				if !assert.NoErrorf(t, err,
+					"%s() unexpected error: %v", parse.name, err) {
+					return
 				}
+
 				assertCredentialEqual(t, got, tt.want)
 			}
 		})
@@ -472,41 +490,54 @@ func assertChallengeEqual(t *testing.T, got, want *Challenge) {
 	t.Helper()
 
 	if got == nil || want == nil {
-		if got != want {
-			t.Fatalf("challenge mismatch: got %#v want %#v", got, want)
+		if !assert.Equalf(t, want, got,
+			"challenge mismatch: got %#v want %#v", got, want) {
+			return
 		}
+
 		return
 	}
-	if got.ID != want.ID || got.Realm != want.Realm || got.Method != want.Method || got.Intent != want.Intent {
-		t.Fatalf("challenge identity mismatch: got %#v want %#v", got, want)
+	if !assert.Falsef(t, got.ID != want.ID || got.Realm != want.Realm || got.Method != want.Method || got.Intent != want.Intent,
+		"challenge identity mismatch: got %#v want %#v", got, want) {
+		return
 	}
-	if got.RequestB64 != want.RequestB64 || got.Digest != want.Digest || got.Expires != want.Expires || got.Description != want.Description {
-		t.Fatalf("challenge metadata mismatch: got %#v want %#v", got, want)
+	if !assert.Falsef(t, got.RequestB64 != want.RequestB64 || got.Digest != want.Digest || got.Expires != want.Expires || got.Description != want.Description,
+		"challenge metadata mismatch: got %#v want %#v", got, want) {
+		return
 	}
-	if !JSONEqual(got.Request, want.Request) {
-		t.Fatalf("challenge request mismatch: got %#v want %#v", got.Request, want.Request)
+	if !assert.Truef(t, JSONEqual(got.Request, want.Request),
+		"challenge request mismatch: got %#v want %#v", got.Request, want.Request) {
+		return
 	}
-	if !reflect.DeepEqual(got.Opaque, want.Opaque) {
-		t.Fatalf("challenge opaque mismatch: got %#v want %#v", got.Opaque, want.Opaque)
+	if !assert.Equalf(t, want.Opaque, got.Opaque,
+		"challenge opaque mismatch: got %#v want %#v", got.Opaque, want.Opaque) {
+		return
 	}
+
 }
 
 func assertCredentialEqual(t *testing.T, got, want *Credential) {
 	t.Helper()
 
 	if got == nil || want == nil {
-		if got != want {
-			t.Fatalf("credential mismatch: got %#v want %#v", got, want)
+		if !assert.Equalf(t, want, got,
+			"credential mismatch: got %#v want %#v", got, want) {
+			return
 		}
+
 		return
 	}
-	if got.Source != want.Source {
-		t.Fatalf("credential source mismatch: got %q want %q", got.Source, want.Source)
+	if !assert.Equalf(t, want.Source, got.Source,
+		"credential source mismatch: got %q want %q", got.Source, want.Source) {
+		return
 	}
-	if !reflect.DeepEqual(got.Challenge, want.Challenge) {
-		t.Fatalf("credential challenge mismatch: got %#v want %#v", got.Challenge, want.Challenge)
+	if !assert.Equalf(t, want.Challenge, got.Challenge,
+		"credential challenge mismatch: got %#v want %#v", got.Challenge, want.Challenge) {
+		return
 	}
-	if !JSONEqual(got.Payload, want.Payload) {
-		t.Fatalf("credential payload mismatch: got %#v want %#v", got.Payload, want.Payload)
+	if !assert.Truef(t, JSONEqual(got.Payload, want.Payload),
+		"credential payload mismatch: got %#v want %#v", got.Payload, want.Payload) {
+		return
 	}
+
 }

--- a/pkg/mpp/units_test.go
+++ b/pkg/mpp/units_test.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -33,17 +34,18 @@ func TestParseUnits(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := ParseUnits(tc.value, tc.decimals)
 			if tc.wantErr {
-				if err == nil {
-					t.Errorf("expected error, got %d", got)
-				}
+				assert.Errorf(t, err,
+					"expected error, got %d", got)
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			if !assert.NoErrorf(t, err,
+				"unexpected error: %v", err) {
+				return
 			}
-			if got != tc.want {
-				t.Errorf("got %d, want %d", got, tc.want)
-			}
+			assert.Equalf(t, tc.want, got,
+				"got %d, want %d", got, tc.want)
+
 		})
 	}
 }
@@ -56,18 +58,21 @@ func TestTransformUnits(t *testing.T) {
 			"extra":    "keep",
 		}
 		out, err := TransformUnits(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !assert.NoErrorf(t, err,
+			"unexpected error: %v", err) {
+			return
 		}
-		if out["amount"] != "1500000" {
-			t.Errorf("amount = %v, want 1500000", out["amount"])
+		assert.Equalf(t, "1500000", out["amount"],
+			"amount = %v, want 1500000", out["amount"])
+		{
+
+			_, ok := out["decimals"]
+			assert.False(t, ok,
+				"decimals key should be removed")
 		}
-		if _, ok := out["decimals"]; ok {
-			t.Error("decimals key should be removed")
-		}
-		if out["extra"] != "keep" {
-			t.Error("extra key should be preserved")
-		}
+		assert.Equal(t, "keep", out["extra"],
+			"extra key should be preserved")
+
 	})
 
 	t.Run("with suggestedDeposit", func(t *testing.T) {
@@ -77,15 +82,15 @@ func TestTransformUnits(t *testing.T) {
 			"decimals":         6,
 		}
 		out, err := TransformUnits(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !assert.NoErrorf(t, err,
+			"unexpected error: %v", err) {
+			return
 		}
-		if out["amount"] != "10000" {
-			t.Errorf("amount = %v, want 10000", out["amount"])
-		}
-		if out["suggestedDeposit"] != "1000000" {
-			t.Errorf("suggestedDeposit = %v, want 1000000", out["suggestedDeposit"])
-		}
+		assert.Equalf(t, "10000", out["amount"],
+			"amount = %v, want 10000", out["amount"])
+		assert.Equalf(t, "1000000", out["suggestedDeposit"],
+			"suggestedDeposit = %v, want 1000000", out["suggestedDeposit"])
+
 	})
 
 	t.Run("without decimals", func(t *testing.T) {
@@ -93,12 +98,13 @@ func TestTransformUnits(t *testing.T) {
 			"amount": "100",
 		}
 		out, err := TransformUnits(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !assert.NoErrorf(t, err,
+			"unexpected error: %v", err) {
+			return
 		}
-		if out["amount"] != "100" {
-			t.Errorf("amount should be unchanged, got %v", out["amount"])
-		}
+		assert.Equalf(t, "100", out["amount"],
+			"amount should be unchanged, got %v", out["amount"])
+
 	})
 
 	t.Run("does not mutate original", func(t *testing.T) {
@@ -107,15 +113,19 @@ func TestTransformUnits(t *testing.T) {
 			"decimals": 6,
 		}
 		_, err := TransformUnits(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !assert.NoErrorf(t, err,
+			"unexpected error: %v", err) {
+			return
 		}
-		if req["amount"] != "1.0" {
-			t.Error("original map was mutated")
+		assert.Equal(t, "1.0", req["amount"],
+			"original map was mutated")
+		{
+
+			_, ok := req["decimals"]
+			assert.True(t, ok,
+				"original map decimals was removed")
 		}
-		if _, ok := req["decimals"]; !ok {
-			t.Error("original map decimals was removed")
-		}
+
 	})
 
 	t.Run("float64 decimals from JSON", func(t *testing.T) {
@@ -124,11 +134,12 @@ func TestTransformUnits(t *testing.T) {
 			"decimals": float64(6),
 		}
 		out, err := TransformUnits(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !assert.NoErrorf(t, err,
+			"unexpected error: %v", err) {
+			return
 		}
-		if out["amount"] != "1000000" {
-			t.Errorf("amount = %v, want 1000000", out["amount"])
-		}
+		assert.Equalf(t, "1000000", out["amount"],
+			"amount = %v, want 1000000", out["amount"])
+
 	})
 }

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -84,8 +84,6 @@ func findChallenge(t *testing.T, resp *http.Response, methodName string) *mpp.Ch
 	}
 	assert.Failf(t, "", "did not find challenge for method %q", methodName)
 	return *new(*mpp.Challenge)
-
-	return nil
 }
 
 // payWith sends a credential and returns the response.

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -54,12 +54,16 @@ func composeTestServer(t *testing.T, configs ...ComposeConfig) *httptest.Server 
 func getChallenge(t *testing.T, url string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatalf("http.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.Get() error = %v", err) {
+		return *new(*http.Response)
 	}
+
 	if resp.StatusCode != http.StatusPaymentRequired {
 		resp.Body.Close()
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPaymentRequired)
+		assert.Failf(t, "", "status = %d, want %d", resp.StatusCode, http.StatusPaymentRequired)
+		return *new(*http.Response)
+
 	}
 	return resp
 }
@@ -69,14 +73,18 @@ func findChallenge(t *testing.T, resp *http.Response, methodName string) *mpp.Ch
 	t.Helper()
 	for _, h := range resp.Header.Values("WWW-Authenticate") {
 		c, err := mpp.ParseChallenge(h)
-		if err != nil {
-			t.Fatalf("ParseChallenge() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"ParseChallenge() error = %v", err) {
+			return *new(*mpp.Challenge)
 		}
+
 		if c.Method == methodName {
 			return c
 		}
 	}
-	t.Fatalf("did not find challenge for method %q", methodName)
+	assert.Failf(t, "", "did not find challenge for method %q", methodName)
+	return *new(*mpp.Challenge)
+
 	return nil
 }
 
@@ -89,14 +97,18 @@ func payWith(t *testing.T, url string, challenge *mpp.Challenge) *http.Response 
 		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
 	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return *new(*http.Response)
 	}
+
 	req.Header.Set("Authorization", credential.ToAuthorization())
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return *new(*http.Response)
 	}
+
 	return resp
 }
 
@@ -116,15 +128,18 @@ func TestComposeMiddleware_FansOutChallenges(t *testing.T) {
 	defer resp.Body.Close()
 
 	wwwAuth := resp.Header.Values("WWW-Authenticate")
-	if len(wwwAuth) != 2 {
-		t.Fatalf("got %d WWW-Authenticate headers, want 2", len(wwwAuth))
+	if !assert.Lenf(t, wwwAuth, 2,
+		"got %d WWW-Authenticate headers, want 2", len(wwwAuth)) {
+		return
 	}
 
 	challenge0, _ := mpp.ParseChallenge(wwwAuth[0])
 	challenge1, _ := mpp.ParseChallenge(wwwAuth[1])
-	if challenge0.Method == challenge1.Method {
-		t.Fatalf("expected different methods, both are %q", challenge0.Method)
+	if !assert.NotEqualf(t, challenge1.Method, challenge0.Method,
+		"expected different methods, both are %q", challenge0.Method) {
+		return
 	}
+
 }
 
 func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
@@ -146,21 +161,26 @@ func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
 
 	if paid.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		assert.Failf(t, "", "paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		return
 	}
 
 	body, _ := io.ReadAll(paid.Body)
 	if got := string(body); got != "beta:0xreceipt-beta" {
-		t.Fatalf("body = %q, want %q", got, "beta:0xreceipt-beta")
+		assert.Failf(t, "", "body = %q, want %q", got, "beta:0xreceipt-beta")
+		return
 	}
 
 	receipt, err := mpp.ParsePaymentReceipt(paid.Header.Get("Payment-Receipt"))
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Reference != "0xreceipt-beta" {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt-beta")
+	if !assert.Equalf(t, "0xreceipt-beta", receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt-beta") {
+		return
 	}
+
 }
 
 func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
@@ -179,24 +199,29 @@ func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
 	defer resp.Body.Close()
 
 	wwwAuth := resp.Header.Values("WWW-Authenticate")
-	if len(wwwAuth) != 2 {
-		t.Fatalf("got %d WWW-Authenticate headers, want 2", len(wwwAuth))
+	if !assert.Lenf(t, wwwAuth, 2,
+		"got %d WWW-Authenticate headers, want 2", len(wwwAuth)) {
+		return
+
+		// Pick the second (expensive) challenge by parsing and checking the request amount.
 	}
 
-	// Pick the second (expensive) challenge by parsing and checking the request amount.
 	var expensiveChallenge *mpp.Challenge
 	for _, h := range wwwAuth {
 		c, err := mpp.ParseChallenge(h)
-		if err != nil {
-			t.Fatalf("ParseChallenge() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"ParseChallenge() error = %v", err) {
+			return
 		}
+
 		if amt, ok := c.Request["amount"]; ok && amt == "10.00" {
 			expensiveChallenge = c
 			break
 		}
 	}
-	if expensiveChallenge == nil {
-		t.Fatal("did not find the 10.00 amount challenge")
+	if !assert.NotNil(t, expensiveChallenge,
+		"did not find the 10.00 amount challenge") {
+		return
 	}
 
 	paid := payWith(t, srv.URL, expensiveChallenge)
@@ -204,7 +229,8 @@ func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
 
 	if paid.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		assert.Failf(t, "", "paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		return
 	}
 }
 
@@ -224,16 +250,19 @@ func TestComposeMiddleware_SameRequestDifferentMetaSelectsMatchingConfig(t *test
 	var proChallenge *mpp.Challenge
 	for _, h := range resp.Header.Values("WWW-Authenticate") {
 		c, err := mpp.ParseChallenge(h)
-		if err != nil {
-			t.Fatalf("ParseChallenge() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"ParseChallenge() error = %v", err) {
+			return
 		}
+
 		if c.Opaque["plan"] == "pro" {
 			proChallenge = c
 			break
 		}
 	}
-	if proChallenge == nil {
-		t.Fatal("did not find the pro challenge")
+	if !assert.NotNil(t, proChallenge,
+		"did not find the pro challenge") {
+		return
 	}
 
 	paid := payWith(t, srv.URL, proChallenge)
@@ -241,7 +270,8 @@ func TestComposeMiddleware_SameRequestDifferentMetaSelectsMatchingConfig(t *test
 
 	if paid.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		assert.Failf(t, "", "paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		return
 	}
 }
 
@@ -256,10 +286,11 @@ func TestComposeMiddleware_RejectsUnknownMethod(t *testing.T) {
 	fakeChallenge := mpp.NewChallenge(composeSecret, composeRealm, "unknown", "charge", map[string]any{"amount": "1.00"})
 	resp := payWith(t, srv.URL, fakeChallenge)
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	if !assert.Equalf(t, http.StatusBadRequest, resp.StatusCode,
+		"status = %d, want %d", resp.StatusCode, http.StatusBadRequest) {
+		return
 	}
+
 }
 
 func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
@@ -288,14 +319,17 @@ func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
 	req.Header.Set("Authorization", credential.ToAuthorization())
 
 	paid, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
 	}
-	defer paid.Body.Close()
 
-	if paid.StatusCode == http.StatusOK {
-		t.Fatal("expected credential to be rejected, but got 200")
+	defer paid.Body.Close()
+	if !assert.NotEqual(t, http.StatusOK, paid.StatusCode,
+		"expected credential to be rejected, but got 200") {
+		return
 	}
+
 }
 
 func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing.T) {
@@ -318,20 +352,25 @@ func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing
 		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
 	}
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return
 	}
+
 	req.Header.Set("Authorization", "Bearer test-token, "+credential.ToAuthorization())
 
 	paid, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
 	}
+
 	defer paid.Body.Close()
 
 	if paid.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		assert.Failf(t, "", "paid status = %d, want 200; body = %s", paid.StatusCode, body)
+		return
 	}
 }
 
@@ -354,31 +393,39 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 	credential.Challenge.Request = "%%%"
 
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return
 	}
+
 	req.Header.Set("Authorization", credential.ToAuthorization())
 
 	paid, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
 	}
+
 	defer paid.Body.Close()
 
 	if paid.StatusCode != http.StatusBadRequest {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("status = %d, want %d; body = %s", paid.StatusCode, http.StatusBadRequest, body)
+		assert.Failf(t, "", "status = %d, want %d; body = %s", paid.StatusCode, http.StatusBadRequest, body)
+		return
 	}
 
 	var problem struct {
 		Type string `json:"type"`
 	}
 	if err := json.NewDecoder(paid.Body).Decode(&problem); err != nil {
-		t.Fatalf("Decode(problem) error = %v", err)
+		assert.Failf(t, "", "Decode(problem) error = %v", err)
+		return
 	}
-	if problem.Type != string(mpp.ErrorTypeMalformedCredential) {
-		t.Fatalf("problem type = %q, want %q", problem.Type, mpp.ErrorTypeMalformedCredential)
+	if !assert.Equalf(t, string(mpp.ErrorTypeMalformedCredential), problem.Type,
+		"problem type = %q, want %q", problem.Type, mpp.ErrorTypeMalformedCredential) {
+		return
 	}
+
 }
 
 func TestComposeMiddleware_SingleMethod(t *testing.T) {
@@ -393,8 +440,9 @@ func TestComposeMiddleware_SingleMethod(t *testing.T) {
 	defer resp.Body.Close()
 
 	wwwAuth := resp.Header.Values("WWW-Authenticate")
-	if len(wwwAuth) != 1 {
-		t.Fatalf("got %d WWW-Authenticate headers, want 1", len(wwwAuth))
+	if !assert.Lenf(t, wwwAuth, 1,
+		"got %d WWW-Authenticate headers, want 1", len(wwwAuth)) {
+		return
 	}
 
 	challenge, _ := mpp.ParseChallenge(wwwAuth[0])
@@ -403,12 +451,14 @@ func TestComposeMiddleware_SingleMethod(t *testing.T) {
 
 	if paid.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(paid.Body)
-		t.Fatalf("status = %d, want 200; body = %s", paid.StatusCode, body)
+		assert.Failf(t, "", "status = %d, want 200; body = %s", paid.StatusCode, body)
+		return
 	}
 
 	body, _ := io.ReadAll(paid.Body)
 	if got := string(body); got != "alpha:0xreceipt-alpha" {
-		t.Fatalf("body = %q, want %q", got, "alpha:0xreceipt-alpha")
+		assert.Failf(t, "", "body = %q, want %q", got, "alpha:0xreceipt-alpha")
+		return
 	}
 }
 
@@ -427,9 +477,11 @@ func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	defer srv.Close()
 
 	resp, err := http.Get(srv.URL)
-	if err != nil {
-		t.Fatalf("http.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.Get() error = %v", err) {
+		return
 	}
+
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -444,18 +496,28 @@ func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 
 func TestComposeMiddleware_PanicsOnEmptyConfigs(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for empty configs")
+		{
+			r := recover()
+			if !assert.NotNil(t, r,
+				"expected panic for empty configs") {
+				return
+			}
 		}
+
 	}()
 	ComposeMiddleware()
 }
 
 func TestComposeMiddleware_PanicsOnNilMpp(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil Mpp")
+		{
+			r := recover()
+			if !assert.NotNil(t, r,
+				"expected panic for nil Mpp") {
+				return
+			}
 		}
+
 	}()
 	ComposeMiddleware(ComposeConfig{Mpp: nil, Params: ChargeParams{Amount: "1.00"}})
 }
@@ -465,9 +527,14 @@ func TestComposeMiddleware_PanicsOnMixedRealms(t *testing.T) {
 	b := New(composeTestMethod{name: "beta"}, "realm-b.example.com", composeSecret)
 
 	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for mixed realms")
+		{
+			r := recover()
+			if !assert.NotNil(t, r,
+				"expected panic for mixed realms") {
+				return
+			}
 		}
+
 	}()
 	ComposeMiddleware(
 		ComposeConfig{Mpp: a, Params: ChargeParams{Amount: "1.00"}},

--- a/pkg/server/defaults_test.go
+++ b/pkg/server/defaults_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
@@ -11,7 +12,8 @@ func TestDetectRealmPrecedenceAndDefault(t *testing.T) {
 	}
 
 	if got := DetectRealm(); got != "MPP Payment" {
-		t.Fatalf("DetectRealm() = %q, want %q", got, "MPP Payment")
+		assert.Failf(t, "", "DetectRealm() = %q, want %q", got, "MPP Payment")
+		return
 	}
 
 	t.Setenv("HOSTNAME", "host.example.com")
@@ -19,22 +21,27 @@ func TestDetectRealmPrecedenceAndDefault(t *testing.T) {
 	t.Setenv("MPP_REALM", "api.example.com")
 
 	if got := DetectRealm(); got != "api.example.com" {
-		t.Fatalf("DetectRealm() = %q, want %q", got, "api.example.com")
+		assert.Failf(t, "", "DetectRealm() = %q, want %q", got, "api.example.com")
+		return
 	}
 }
 
 func TestDetectSecretKey(t *testing.T) {
 	t.Setenv("MPP_SECRET_KEY", "")
 	if _, err := DetectSecretKey(); err == nil || !strings.Contains(err.Error(), "MPP_SECRET_KEY environment variable is not set") {
-		t.Fatalf("DetectSecretKey() error = %v, want missing env error", err)
+		assert.Failf(t, "", "DetectSecretKey() error = %v, want missing env error", err)
+		return
 	}
 
 	t.Setenv("MPP_SECRET_KEY", "secret-key")
 	key, err := DetectSecretKey()
-	if err != nil {
-		t.Fatalf("DetectSecretKey() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"DetectSecretKey() error = %v", err) {
+		return
 	}
-	if key != "secret-key" {
-		t.Fatalf("DetectSecretKey() = %q, want %q", key, "secret-key")
+	if !assert.Equalf(t, "secret-key", key,
+		"DetectSecretKey() = %q, want %q", key, "secret-key") {
+		return
 	}
+
 }

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	echofw "github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 )
@@ -47,14 +48,16 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	e.GET("/paid", func(c echofw.Context) error {
 		credential := Credential(c)
 		receipt := Receipt(c)
-		if credential == nil || receipt == nil {
-			t.Fatalf("expected credential and receipt on echo context")
+		if !assert.Falsef(t, credential == nil || receipt == nil,
+			"expected credential and receipt on echo context") {
+			return *new(error)
 		}
 
 		ctxCredential := server.CredentialFromContext(c.Request().Context())
 		ctxReceipt := server.ReceiptFromContext(c.Request().Context())
-		if ctxCredential == nil || ctxReceipt == nil {
-			t.Fatalf("expected credential and receipt on request context")
+		if !assert.Falsef(t, ctxCredential == nil || ctxReceipt == nil,
+			"expected credential and receipt on request context") {
+			return *new(error)
 		}
 
 		return c.String(http.StatusOK, credential.Source+":"+receipt.Reference)
@@ -63,20 +66,23 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
 	challengeResponse := httptest.NewRecorder()
 	e.ServeHTTP(challengeResponse, challengeRequest)
-
-	if challengeResponse.Code != http.StatusPaymentRequired {
-		t.Fatalf("challenge status = %d, want %d", challengeResponse.Code, http.StatusPaymentRequired)
+	if !assert.Equalf(t, http.StatusPaymentRequired, challengeResponse.Code,
+		"challenge status = %d, want %d", challengeResponse.Code, http.StatusPaymentRequired) {
+		return
 	}
-	if !challengeCommitted {
-		t.Fatal("challenge response was not marked committed in echo")
+	if !assert.True(t, challengeCommitted,
+		"challenge response was not marked committed in echo") {
+		return
 	}
-	if challengeStatus != http.StatusPaymentRequired {
-		t.Fatalf("echo challenge status = %d, want %d", challengeStatus, http.StatusPaymentRequired)
+	if !assert.Equalf(t, http.StatusPaymentRequired, challengeStatus,
+		"echo challenge status = %d, want %d", challengeStatus, http.StatusPaymentRequired) {
+		return
 	}
 
 	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChallenge() error = %v", err) {
+		return
 	}
 
 	credential := &mpp.Credential{
@@ -89,20 +95,23 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
 	paidResponse := httptest.NewRecorder()
 	e.ServeHTTP(paidResponse, paidRequest)
-
-	if paidResponse.Code != http.StatusOK {
-		t.Fatalf("paid status = %d, want %d", paidResponse.Code, http.StatusOK)
+	if !assert.Equalf(t, http.StatusOK, paidResponse.Code,
+		"paid status = %d, want %d", paidResponse.Code, http.StatusOK) {
+		return
 	}
 
 	receipt, err := mpp.ParsePaymentReceipt(paidResponse.Header().Get("Payment-Receipt"))
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Reference != "0xreceipt" {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
+	if !assert.Equalf(t, "0xreceipt", receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
+		return
 	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {
-		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		return
 	}
 }

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -126,10 +126,8 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Amount:      "0.50",
 		Description: "Line one\r\nLine two",
 	}), func(c *fiberfw.Ctx) error {
-		assert.Fail(t, "handler should not be called")
+		require.Fail(t, "handler should not be called")
 		return *new(error)
-
-		return nil
 	})
 
 	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -40,14 +40,16 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
 		credential := Credential(c)
 		receipt := Receipt(c)
-		if credential == nil || receipt == nil {
-			t.Fatalf("expected credential and receipt on fiber context")
+		if !assert.Falsef(t, credential == nil || receipt == nil,
+			"expected credential and receipt on fiber context") {
+			return *new(error)
 		}
 
 		ctxCredential := server.CredentialFromContext(c.UserContext())
 		ctxReceipt := server.ReceiptFromContext(c.UserContext())
-		if ctxCredential == nil || ctxReceipt == nil {
-			t.Fatalf("expected credential and receipt on user context")
+		if !assert.Falsef(t, ctxCredential == nil || ctxReceipt == nil,
+			"expected credential and receipt on user context") {
+			return *new(error)
 		}
 
 		return c.SendString(credential.Source + ":" + receipt.Reference)
@@ -55,17 +57,19 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 
 	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
 	challengeResponse, err := app.Test(challengeRequest)
-	if err != nil {
-		t.Fatalf("app.Test() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"app.Test() error = %v", err) {
+		return
 	}
-
-	if challengeResponse.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusPaymentRequired)
+	if !assert.Equalf(t, http.StatusPaymentRequired, challengeResponse.StatusCode,
+		"challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusPaymentRequired) {
+		return
 	}
 
 	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChallenge() error = %v", err) {
+		return
 	}
 
 	credential := &mpp.Credential{
@@ -77,29 +81,39 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
 	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
 	paidResponse, err := app.Test(paidRequest)
-	if err != nil {
-		t.Fatalf("app.Test() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"app.Test() error = %v", err) {
+		return
 	}
-
-	if paidResponse.StatusCode != http.StatusOK {
-		t.Fatalf("paid status = %d, want %d", paidResponse.StatusCode, http.StatusOK)
+	if !assert.Equalf(t, http.StatusOK, paidResponse.StatusCode,
+		"paid status = %d, want %d", paidResponse.StatusCode, http.StatusOK) {
+		return
 	}
 
 	receipt, err := mpp.ParsePaymentReceipt(paidResponse.Header.Get("Payment-Receipt"))
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Reference != "0xreceipt" {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
+	if !assert.Equalf(t, "0xreceipt", receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
+		return
 	}
 
 	body, err := io.ReadAll(paidResponse.Body)
-	if err != nil {
-		t.Fatalf("ReadAll() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ReadAll() error = %v", err) {
+		return
 	}
-	if got := string(body); got != "did:key:z6Mkrdemo:0xreceipt" {
-		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+	{
+
+		got := string(body)
+		if !assert.Equalf(t, "did:key:z6Mkrdemo:0xreceipt", got,
+			"response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt") {
+			return
+		}
 	}
+
 }
 
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
@@ -112,15 +126,19 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Amount:      "0.50",
 		Description: "Line one\r\nLine two",
 	}), func(c *fiberfw.Ctx) error {
-		t.Fatal("handler should not be called")
+		assert.Fail(t, "handler should not be called")
+		return *new(error)
+
 		return nil
 	})
 
 	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
 	challengeResponse, err := app.Test(challengeRequest)
-	if err != nil {
-		t.Fatalf("app.Test() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"app.Test() error = %v", err) {
+		return
 	}
+
 	defer challengeResponse.Body.Close()
 
 	require.Equal(t, http.StatusBadRequest, challengeResponse.StatusCode)

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ginfw "github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 )
@@ -36,14 +37,16 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	router.GET("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
 		credential := Credential(c)
 		receipt := Receipt(c)
-		if credential == nil || receipt == nil {
-			t.Fatalf("expected credential and receipt on gin context")
+		if !assert.Falsef(t, credential == nil || receipt == nil,
+			"expected credential and receipt on gin context") {
+			return
 		}
 
 		ctxCredential := server.CredentialFromContext(c.Request.Context())
 		ctxReceipt := server.ReceiptFromContext(c.Request.Context())
-		if ctxCredential == nil || ctxReceipt == nil {
-			t.Fatalf("expected credential and receipt on request context")
+		if !assert.Falsef(t, ctxCredential == nil || ctxReceipt == nil,
+			"expected credential and receipt on request context") {
+			return
 		}
 
 		c.String(http.StatusOK, "%s:%s", credential.Source, receipt.Reference)
@@ -52,14 +55,15 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
 	challengeResponse := httptest.NewRecorder()
 	router.ServeHTTP(challengeResponse, challengeRequest)
-
-	if challengeResponse.Code != http.StatusPaymentRequired {
-		t.Fatalf("challenge status = %d, want %d", challengeResponse.Code, http.StatusPaymentRequired)
+	if !assert.Equalf(t, http.StatusPaymentRequired, challengeResponse.Code,
+		"challenge status = %d, want %d", challengeResponse.Code, http.StatusPaymentRequired) {
+		return
 	}
 
 	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChallenge() error = %v", err) {
+		return
 	}
 
 	credential := &mpp.Credential{
@@ -72,20 +76,23 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
 	paidResponse := httptest.NewRecorder()
 	router.ServeHTTP(paidResponse, paidRequest)
-
-	if paidResponse.Code != http.StatusOK {
-		t.Fatalf("paid status = %d, want %d", paidResponse.Code, http.StatusOK)
+	if !assert.Equalf(t, http.StatusOK, paidResponse.Code,
+		"paid status = %d, want %d", paidResponse.Code, http.StatusOK) {
+		return
 	}
 
 	receipt, err := mpp.ParsePaymentReceipt(paidResponse.Header().Get("Payment-Receipt"))
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Reference != "0xreceipt" {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
+	if !assert.Equalf(t, "0xreceipt", receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
+		return
 	}
 
 	if got := paidResponse.Body.String(); got != "did:key:z6Mkrdemo:0xreceipt" {
-		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		return
 	}
 }

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -29,18 +29,21 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	defer server.Close()
 
 	challengeResponse, err := http.Get(server.URL)
-	if err != nil {
-		t.Fatalf("http.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.Get() error = %v", err) {
+		return
 	}
-	defer challengeResponse.Body.Close()
 
-	if challengeResponse.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusPaymentRequired)
+	defer challengeResponse.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, challengeResponse.StatusCode,
+		"challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusPaymentRequired) {
+		return
 	}
 
 	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
-	if err != nil {
-		t.Fatalf("ParseChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChallenge() error = %v", err) {
+		return
 	}
 
 	credential := &mpp.Credential{
@@ -50,35 +53,44 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 
 	retry, err := http.NewRequest(http.MethodGet, server.URL, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return
 	}
+
 	retry.Header.Set("Authorization", credential.ToAuthorization())
 
 	paidResponse, err := http.DefaultClient.Do(retry)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
 	}
-	defer paidResponse.Body.Close()
 
-	if paidResponse.StatusCode != http.StatusOK {
-		t.Fatalf("paid status = %d, want %d", paidResponse.StatusCode, http.StatusOK)
+	defer paidResponse.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, paidResponse.StatusCode,
+		"paid status = %d, want %d", paidResponse.StatusCode, http.StatusOK) {
+		return
 	}
 
 	receipt, err := mpp.ParsePaymentReceipt(paidResponse.Header.Get("Payment-Receipt"))
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Reference != "0xreceipt" {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, "0xreceipt")
+	if !assert.Equalf(t, "0xreceipt", receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, "0xreceipt") {
+		return
 	}
 
 	body, err := io.ReadAll(paidResponse.Body)
-	if err != nil {
-		t.Fatalf("io.ReadAll() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"io.ReadAll() error = %v", err) {
+		return
 	}
+
 	if got := string(body); got != "did:key:z6Mkrdemo:0xreceipt" {
-		t.Fatalf("response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
+		return
 	}
 }
 
@@ -88,7 +100,8 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Amount:      "0.50",
 		Description: "Line one\r\nLine two",
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called")
+		assert.Fail(t, "handler should not be called")
+		return
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/paid", nil)

--- a/pkg/server/payment_middleware_test.go
+++ b/pkg/server/payment_middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
@@ -14,16 +15,21 @@ func TestWritePaymentError_FormatsProblemResponses(t *testing.T) {
 
 	paymentErrorResponse := httptest.NewRecorder()
 	WritePaymentError(paymentErrorResponse, mpp.ErrBadRequest("bad request"))
-	if paymentErrorResponse.Code != http.StatusBadRequest {
-		t.Fatalf("paymentErrorResponse.Code = %d, want %d", paymentErrorResponse.Code, http.StatusBadRequest)
+	if !assert.Equalf(t, http.StatusBadRequest, paymentErrorResponse.Code,
+		"paymentErrorResponse.Code = %d, want %d", paymentErrorResponse.Code, http.StatusBadRequest) {
+		return
 	}
+
 	if got := paymentErrorResponse.Header().Get("Content-Type"); got != "application/problem+json" {
-		t.Fatalf("Content-Type = %q, want %q", got, "application/problem+json")
+		assert.Failf(t, "", "Content-Type = %q, want %q", got, "application/problem+json")
+		return
 	}
 
 	genericErrorResponse := httptest.NewRecorder()
 	WritePaymentError(genericErrorResponse, errors.New("verification failed"))
-	if genericErrorResponse.Code != http.StatusPaymentRequired {
-		t.Fatalf("genericErrorResponse.Code = %d, want %d", genericErrorResponse.Code, http.StatusPaymentRequired)
+	if !assert.Equalf(t, http.StatusPaymentRequired, genericErrorResponse.Code,
+		"genericErrorResponse.Code = %d, want %d", genericErrorResponse.Code, http.StatusPaymentRequired) {
+		return
 	}
+
 }

--- a/pkg/server/server_charge_test.go
+++ b/pkg/server/server_charge_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
@@ -28,33 +29,43 @@ func TestMppCharge_UsesMetaAsChallengeMeta(t *testing.T) {
 		Memo:       "0x" + strings.Repeat("ab", 32),
 		Meta:       map[string]string{"trace": "abc123"},
 	})
-	if err != nil {
-		t.Fatalf("Charge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Charge() error = %v", err) {
+		return
 	}
-	if !result.IsChallenge() {
-		t.Fatal("result.IsChallenge() = false, want true")
+	if !assert.True(t, result.IsChallenge(),
+		"result.IsChallenge() = false, want true") {
+		return
 	}
-	if result.Challenge.Opaque["trace"] != "abc123" {
-		t.Fatalf("result.Challenge.Opaque[trace] = %q, want %q", result.Challenge.Opaque["trace"], "abc123")
+	if !assert.Equalf(t, "abc123", result.Challenge.Opaque["trace"],
+		"result.Challenge.Opaque[trace] = %q, want %q", result.Challenge.Opaque["trace"], "abc123") {
+		return
 	}
-	if result.Challenge.Request["amount"] != "0.50" {
-		t.Fatalf("result.Challenge.Request[amount] = %#v, want %q", result.Challenge.Request["amount"], "0.50")
+	if !assert.Equalf(t, "0.50", result.Challenge.Request["amount"],
+		"result.Challenge.Request[amount] = %#v, want %q", result.Challenge.Request["amount"], "0.50") {
+		return
 	}
-	if result.Challenge.Request["recipient"] != "0x70997970c51812dc3a010c7d01b50e0d17dc79c8" {
-		t.Fatalf("result.Challenge.Request[recipient] = %#v", result.Challenge.Request["recipient"])
+	if !assert.Equalf(t, "0x70997970c51812dc3a010c7d01b50e0d17dc79c8", result.Challenge.Request["recipient"],
+		"result.Challenge.Request[recipient] = %#v", result.Challenge.Request["recipient"]) {
+		return
 	}
-	if result.Challenge.Request["externalId"] != "ext-123" {
-		t.Fatalf("result.Challenge.Request[externalId] = %#v, want %q", result.Challenge.Request["externalId"], "ext-123")
+	if !assert.Equalf(t, "ext-123", result.Challenge.Request["externalId"],
+		"result.Challenge.Request[externalId] = %#v, want %q", result.Challenge.Request["externalId"], "ext-123") {
+		return
 	}
-	if result.Challenge.Request["feePayer"] != true {
-		t.Fatalf("result.Challenge.Request[feePayer] = %#v, want true", result.Challenge.Request["feePayer"])
+	if !assert.Equalf(t, true, result.Challenge.Request["feePayer"],
+		"result.Challenge.Request[feePayer] = %#v, want true", result.Challenge.Request["feePayer"]) {
+		return
 	}
-	if result.Challenge.Request["chainId"] != 42431 {
-		t.Fatalf("result.Challenge.Request[chainId] = %#v, want %d", result.Challenge.Request["chainId"], 42431)
+	if !assert.EqualValuesf(t, 42431, result.Challenge.Request["chainId"],
+		"result.Challenge.Request[chainId] = %#v, want %d", result.Challenge.Request["chainId"], 42431) {
+		return
 	}
-	if result.Challenge.Request["memo"] != "0x"+strings.Repeat("ab", 32) {
-		t.Fatalf("result.Challenge.Request[memo] = %#v", result.Challenge.Request["memo"])
+	if !assert.Equalf(t, "0x"+strings.Repeat("ab", 32), result.Challenge.Request["memo"],
+		"result.Challenge.Request[memo] = %#v", result.Challenge.Request["memo"]) {
+		return
 	}
+
 }
 
 func TestMppCharge_RequiresChargeIntent(t *testing.T) {
@@ -62,7 +73,9 @@ func TestMppCharge_RequiresChargeIntent(t *testing.T) {
 
 	mppServer := New(chargeTestMethod{intents: map[string]Intent{}}, "api.example.com", "secret-key")
 	_, err := mppServer.Charge(context.Background(), ChargeParams{Amount: "0.50"})
-	if err == nil || !strings.Contains(err.Error(), `does not support charge intent`) {
-		t.Fatalf("Charge() error = %v, want missing charge intent error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), `does not support charge intent`),
+		"Charge() error = %v, want missing charge intent error", err) {
+		return
 	}
+
 }

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
@@ -56,12 +57,15 @@ func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {
 		Method:    "tempo",
 		Expires:   challenge.Expires,
 	})
-	if err != nil {
-		t.Fatalf("VerifyOrChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge() error = %v", err) {
+		return
 	}
-	if result.Receipt == nil || result.Receipt.Reference != "0xreceipt" {
-		t.Fatalf("expected successful receipt, got %#v", result)
+	if !assert.Falsef(t, result.Receipt == nil || result.Receipt.Reference != "0xreceipt",
+		"expected successful receipt, got %#v", result) {
+		return
 	}
+
 }
 
 func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
@@ -94,11 +98,13 @@ func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
 		Meta:          map[string]string{},
 		Expires:       challenge.Expires,
 	})
-	if err != nil {
-		t.Fatalf("VerifyOrChallenge(issue) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge(issue) error = %v", err) {
+		return
 	}
-	if issued.Challenge == nil || issued.Challenge.Opaque == nil {
-		t.Fatalf("issued challenge opaque = %#v, want empty map", issued.Challenge)
+	if !assert.Falsef(t, issued.Challenge == nil || issued.Challenge.Opaque == nil,
+		"issued challenge opaque = %#v, want empty map", issued.Challenge) {
+		return
 	}
 
 	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
@@ -111,12 +117,15 @@ func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
 		Meta:          map[string]string{},
 		Expires:       challenge.Expires,
 	})
-	if err != nil {
-		t.Fatalf("VerifyOrChallenge(verify) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge(verify) error = %v", err) {
+		return
 	}
-	if result.Receipt == nil || result.Receipt.Reference != "0xreceipt" {
-		t.Fatalf("expected successful receipt, got %#v", result)
+	if !assert.Falsef(t, result.Receipt == nil || result.Receipt.Reference != "0xreceipt",
+		"expected successful receipt, got %#v", result) {
+		return
 	}
+
 }
 
 func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
@@ -145,9 +154,11 @@ func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 		SecretKey:     "secret-key",
 		Method:        "tempo",
 	})
-	if err == nil || !strings.Contains(err.Error(), "missing required expires") {
-		t.Fatalf("VerifyOrChallenge() error = %v, want missing required expires", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "missing required expires"),
+		"VerifyOrChallenge() error = %v, want missing required expires", err) {
+		return
 	}
+
 }
 
 func TestVerifyOrChallenge_AllowsDynamicExpiresOverrides(t *testing.T) {
@@ -179,12 +190,15 @@ func TestVerifyOrChallenge_AllowsDynamicExpiresOverrides(t *testing.T) {
 		Method:        "tempo",
 		Expires:       mpp.Expires.Minutes(5),
 	})
-	if err != nil {
-		t.Fatalf("VerifyOrChallenge() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge() error = %v", err) {
+		return
 	}
-	if result.Receipt == nil || result.Receipt.Reference != "0xreceipt" {
-		t.Fatalf("expected successful receipt, got %#v", result)
+	if !assert.Falsef(t, result.Receipt == nil || result.Receipt.Reference != "0xreceipt",
+		"expected successful receipt, got %#v", result) {
+		return
 	}
+
 }
 
 func TestVerifyOrChallenge_RejectsOpaqueMismatch(t *testing.T) {
@@ -217,7 +231,9 @@ func TestVerifyOrChallenge_RejectsOpaqueMismatch(t *testing.T) {
 		Meta:          map[string]string{"trace": "current"},
 		Expires:       challenge.Expires,
 	})
-	if err == nil || !strings.Contains(err.Error(), "opaque metadata does not match") {
-		t.Fatalf("VerifyOrChallenge() error = %v, want opaque metadata mismatch", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "opaque metadata does not match"),
+		"VerifyOrChallenge() error = %v, want opaque metadata mismatch", err) {
+		return
 	}
+
 }

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	temporpc "github.com/tempoxyz/tempo-go/pkg/client"
@@ -143,18 +144,26 @@ func TestCreateCredentialScenarios(t *testing.T) {
 			config.RPC = tt.rpc
 
 			method, err := New(config)
-			if err != nil {
-				t.Fatalf("New() error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"New() error = %v", err) {
+				return
 			}
 
 			challenge := buildChallenge(t, tt.params)
 			_, err = method.CreateCredential(context.Background(), challenge)
-			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("CreateCredential() error = %v, want substring %q", err, tt.wantErr)
+			if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+				"CreateCredential() error = %v, want substring %q", err, tt.wantErr) {
+				return
 			}
-			if got := len(tt.rpc.sentRawTxs); got != tt.wantBroadcasts {
-				t.Fatalf("len(tt.rpc.sentRawTxs) = %d, want %d", got, tt.wantBroadcasts)
+			{
+
+				got := len(tt.rpc.sentRawTxs)
+				if !assert.Equalf(t, tt.wantBroadcasts, got,
+					"len(tt.rpc.sentRawTxs) = %d, want %d", got, tt.wantBroadcasts) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -166,30 +175,37 @@ func TestNewInfersChainIDFromRPCURL(t *testing.T) {
 		PrivateKey: testPrivateKey,
 		RPCURL:     tempotx.RpcUrlModerato,
 	})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"New() error = %v", err) {
+		return
 	}
-	if method.chainID != tempotx.ChainIdModerato {
-		t.Fatalf("method.chainID = %d, want %d", method.chainID, tempotx.ChainIdModerato)
+	if !assert.EqualValuesf(t, tempotx.ChainIdModerato, method.chainID,
+		"method.chainID = %d, want %d", method.chainID, tempotx.ChainIdModerato) {
+		return
 	}
+
 }
 
 func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
 	t.Parallel()
 
 	_, err := New(Config{PrivateKey: testPrivateKey, ChainID: 999999})
-	if err == nil || err.Error() != "tempo client: unknown chain id 999999; configure RPC or RPCURL explicitly" {
-		t.Fatalf("New() error = %v, want unknown chain id error", err)
+	if !assert.Falsef(t, err == nil || err.Error() != "tempo client: unknown chain id 999999; configure RPC or RPCURL explicitly",
+		"New() error = %v, want unknown chain id error", err) {
+		return
 	}
+
 }
 
 func TestCreateCredentialRejectsUnknownChallengeChainWithoutRPC(t *testing.T) {
 	t.Parallel()
 
 	method, err := New(Config{PrivateKey: testPrivateKey})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"New() error = %v", err) {
+		return
 	}
+
 	challenge := buildChallenge(t, tempo.ChargeRequestParams{
 		Amount:    "0.50",
 		Currency:  testCurrency,
@@ -198,17 +214,20 @@ func TestCreateCredentialRejectsUnknownChallengeChainWithoutRPC(t *testing.T) {
 		ChainID:   999999,
 	})
 	_, err = method.CreateCredential(context.Background(), challenge)
-	if err == nil || !strings.Contains(err.Error(), "unknown chain id 999999") {
-		t.Fatalf("CreateCredential() error = %v, want unknown chain id error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "unknown chain id 999999"),
+		"CreateCredential() error = %v, want unknown chain id error", err) {
+		return
 	}
+
 }
 
 func buildChallenge(t *testing.T, params tempo.ChargeRequestParams) *mpp.Challenge {
 	t.Helper()
 
 	request, err := tempo.NormalizeChargeRequest(params)
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return *new(*mpp.Challenge)
 	}
 
 	return mpp.NewChallenge(

--- a/pkg/tempo/defaults_test.go
+++ b/pkg/tempo/defaults_test.go
@@ -3,6 +3,7 @@ package tempo
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
@@ -10,13 +11,16 @@ func TestDefaultCurrencyForChain(t *testing.T) {
 	t.Parallel()
 
 	if got := DefaultCurrencyForChain(tempotx.ChainIdMainnet); got != MainnetUSDCAddress {
-		t.Fatalf("DefaultCurrencyForChain(mainnet) = %q, want %q", got, MainnetUSDCAddress)
+		assert.Failf(t, "", "DefaultCurrencyForChain(mainnet) = %q, want %q", got, MainnetUSDCAddress)
+		return
 	}
 	if got := DefaultCurrencyForChain(tempotx.ChainIdModerato); got != tempotx.AlphaUSDAddress.Hex() {
-		t.Fatalf("DefaultCurrencyForChain(moderato) = %q, want %q", got, tempotx.AlphaUSDAddress.Hex())
+		assert.Failf(t, "", "DefaultCurrencyForChain(moderato) = %q, want %q", got, tempotx.AlphaUSDAddress.Hex())
+		return
 	}
 	if got := DefaultCurrencyForChain(999999); got != tempotx.AlphaUSDAddress.Hex() {
-		t.Fatalf("DefaultCurrencyForChain(unknown) = %q, want %q", got, tempotx.AlphaUSDAddress.Hex())
+		assert.Failf(t, "", "DefaultCurrencyForChain(unknown) = %q, want %q", got, tempotx.AlphaUSDAddress.Hex())
+		return
 	}
 }
 
@@ -40,10 +44,15 @@ func TestInferChainIDFromRPCURL(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			{
 
-			if got := InferChainIDFromRPCURL(tt.rpcURL); got != tt.want {
-				t.Fatalf("InferChainIDFromRPCURL(%q) = %d, want %d", tt.rpcURL, got, tt.want)
+				got := InferChainIDFromRPCURL(tt.rpcURL)
+				if !assert.Equalf(t, tt.want, got,
+					"InferChainIDFromRPCURL(%q) = %d, want %d", tt.rpcURL, got, tt.want) {
+					return
+				}
 			}
+
 		})
 	}
 }
@@ -70,17 +79,22 @@ func TestRPCURLForChain(t *testing.T) {
 
 			got, err := RPCURLForChain(tt.chainID)
 			if tt.wantErr != "" {
-				if err == nil || err.Error() != tt.wantErr {
-					t.Fatalf("RPCURLForChain(%d) error = %v, want %q", tt.chainID, err, tt.wantErr)
+				if !assert.Falsef(t, err == nil || err.Error() != tt.wantErr,
+					"RPCURLForChain(%d) error = %v, want %q", tt.chainID, err, tt.wantErr) {
+					return
 				}
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("RPCURLForChain(%d) error = %v", tt.chainID, err)
+			if !assert.NoErrorf(t, err,
+				"RPCURLForChain(%d) error = %v", tt.chainID, err) {
+				return
 			}
-			if got != tt.want {
-				t.Fatalf("RPCURLForChain(%d) = %q, want %q", tt.chainID, got, tt.want)
+			if !assert.Equalf(t, tt.want, got,
+				"RPCURLForChain(%d) = %q, want %q", tt.chainID, got, tt.want) {
+				return
 			}
+
 		})
 	}
 }

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -2,11 +2,11 @@ package tempo
 
 import (
 	"math/big"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNormalizeChargeRequest_RoundTripsCanonicalShape(t *testing.T) {
@@ -30,46 +30,58 @@ func TestNormalizeChargeRequest_RoundTripsCanonicalShape(t *testing.T) {
 		}},
 		SupportedModes: []ChargeMode{ChargeModePull, ChargeModePush},
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
+	}
+	if !assert.Equalf(t, "500000", request.Amount,
+		"request.Amount = %q, want %q", request.Amount, "500000") {
+		return
+	}
+	if !assert.Equalf(t, common.HexToAddress("0x20c0000000000000000000000000000000000001").Hex(), request.Currency,
+		"request.Currency = %q", request.Currency) {
+		return
+	}
+	if !assert.Equalf(t, common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8").Hex(), request.Recipient,
+		"request.Recipient = %q", request.Recipient) {
+		return
+	}
+	if !assert.Equalf(t, "0x"+strings.Repeat("ab", 32), request.MethodDetails.Memo,
+		"request.MethodDetails.Memo = %q", request.MethodDetails.Memo) {
+		return
+	}
+	if !assert.Equalf(t, "https://fee-payer.example.com", request.MethodDetails.FeePayerURL,
+		"request.MethodDetails.FeePayerURL = %q", request.MethodDetails.FeePayerURL) {
+		return
 	}
 
-	if request.Amount != "500000" {
-		t.Fatalf("request.Amount = %q, want %q", request.Amount, "500000")
-	}
-	if request.Currency != common.HexToAddress("0x20c0000000000000000000000000000000000001").Hex() {
-		t.Fatalf("request.Currency = %q", request.Currency)
-	}
-	if request.Recipient != common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8").Hex() {
-		t.Fatalf("request.Recipient = %q", request.Recipient)
-	}
-	if request.MethodDetails.Memo != "0x"+strings.Repeat("ab", 32) {
-		t.Fatalf("request.MethodDetails.Memo = %q", request.MethodDetails.Memo)
-	}
-	if request.MethodDetails.FeePayerURL != "https://fee-payer.example.com" {
-		t.Fatalf("request.MethodDetails.FeePayerURL = %q", request.MethodDetails.FeePayerURL)
-	}
 	if got := len(request.MethodDetails.Splits); got != 1 {
-		t.Fatalf("len(request.MethodDetails.Splits) = %d, want 1", got)
+		assert.Failf(t, "", "len(request.MethodDetails.Splits) = %d, want 1", got)
+		return
 	}
-	if request.MethodDetails.Splits[0].Amount != "100000" {
-		t.Fatalf("request.MethodDetails.Splits[0].Amount = %q, want 100000", request.MethodDetails.Splits[0].Amount)
+	if !assert.Equalf(t, "100000", request.MethodDetails.Splits[0].Amount,
+		"request.MethodDetails.Splits[0].Amount = %q, want 100000", request.MethodDetails.Splits[0].Amount) {
+		return
 	}
 
 	parsed, err := ParseChargeRequest(request.Map())
-	if err != nil {
-		t.Fatalf("ParseChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChargeRequest() error = %v", err) {
+		return
 	}
-	if !reflect.DeepEqual(parsed, request) {
-		t.Fatalf("ParseChargeRequest() = %#v, want %#v", parsed, request)
+	if !assert.Equalf(t, request, parsed,
+		"ParseChargeRequest() = %#v, want %#v", parsed, request) {
+		return
+	}
+	if !assert.True(t, request.Allows(CredentialTypeTransaction),
+		"request should allow transaction credentials") {
+		return
+	}
+	if !assert.True(t, request.Allows(CredentialTypeHash),
+		"request should allow hash credentials") {
+		return
 	}
 
-	if !request.Allows(CredentialTypeTransaction) {
-		t.Fatal("request should allow transaction credentials")
-	}
-	if !request.Allows(CredentialTypeHash) {
-		t.Fatal("request should allow hash credentials")
-	}
 }
 
 func TestNormalizeChargeRequest_RejectsInvalidMemo(t *testing.T) {
@@ -81,9 +93,11 @@ func TestNormalizeChargeRequest_RejectsInvalidMemo(t *testing.T) {
 		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 		Memo:      "0x1234",
 	})
-	if err == nil || !strings.Contains(err.Error(), "memo must be exactly 32 bytes") {
-		t.Fatalf("NormalizeChargeRequest() error = %v, want invalid memo error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "memo must be exactly 32 bytes"),
+		"NormalizeChargeRequest() error = %v, want invalid memo error", err) {
+		return
 	}
+
 }
 
 func TestNormalizeChargeRequest_RejectsNegativeDecimals(t *testing.T) {
@@ -95,9 +109,11 @@ func TestNormalizeChargeRequest_RejectsNegativeDecimals(t *testing.T) {
 		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 		Decimals:  -1,
 	})
-	if err == nil || !strings.Contains(err.Error(), "decimals must be non-negative") {
-		t.Fatalf("NormalizeChargeRequest() error = %v, want negative decimals error", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "decimals must be non-negative"),
+		"NormalizeChargeRequest() error = %v, want negative decimals error", err) {
+		return
 	}
+
 }
 
 func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
@@ -112,33 +128,42 @@ func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
 			Recipient: "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
 		}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "split total must be less than the total amount") {
-		t.Fatalf("NormalizeChargeRequest() error = %v, want invalid split total", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "split total must be less than the total amount"),
+		"NormalizeChargeRequest() error = %v, want invalid split total", err) {
+		return
 	}
+
 }
 
 func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 	t.Parallel()
 
 	memo := EncodeAttribution("api.example.com", "cli-app", "challenge-1")
-	if len(memo) != 66 {
-		t.Fatalf("len(memo) = %d, want 66", len(memo))
+	if !assert.Lenf(t, memo, 66,
+		"len(memo) = %d, want 66", len(memo)) {
+		return
 	}
-	if !IsAttributionMemo(memo) {
-		t.Fatalf("IsAttributionMemo(%q) = false, want true", memo)
+	if !assert.Truef(t, IsAttributionMemo(memo),
+		"IsAttributionMemo(%q) = false, want true", memo) {
+		return
 	}
-	if !VerifyAttributionServer(memo, "api.example.com") {
-		t.Fatalf("VerifyAttributionServer(%q, api.example.com) = false, want true", memo)
+	if !assert.Truef(t, VerifyAttributionServer(memo, "api.example.com"),
+		"VerifyAttributionServer(%q, api.example.com) = false, want true", memo) {
+		return
 	}
-	if VerifyAttributionServer(memo, "other.example.com") {
-		t.Fatalf("VerifyAttributionServer(%q, other.example.com) = true, want false", memo)
+	if !assert.Falsef(t, VerifyAttributionServer(memo, "other.example.com"),
+		"VerifyAttributionServer(%q, other.example.com) = true, want false", memo) {
+		return
 	}
-	if !VerifyAttributionChallenge(memo, "challenge-1") {
-		t.Fatalf("VerifyAttributionChallenge(%q, challenge-1) = false, want true", memo)
+	if !assert.Truef(t, VerifyAttributionChallenge(memo, "challenge-1"),
+		"VerifyAttributionChallenge(%q, challenge-1) = false, want true", memo) {
+		return
 	}
-	if VerifyAttributionChallenge(memo, "challenge-2") {
-		t.Fatalf("VerifyAttributionChallenge(%q, challenge-2) = true, want false", memo)
+	if !assert.Falsef(t, VerifyAttributionChallenge(memo, "challenge-2"),
+		"VerifyAttributionChallenge(%q, challenge-2) = true, want false", memo) {
+		return
 	}
+
 }
 
 func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
@@ -158,29 +183,36 @@ func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
 	}
 
 	calldata, err := EncodeTransferWithMemo(recipient, amount, explicitMemo)
-	if err != nil {
-		t.Fatalf("EncodeTransferWithMemo() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"EncodeTransferWithMemo() error = %v", err) {
+		return
 	}
-	if !MatchTransferCalldata(calldata, explicitRequest, "ignored.example.com", "ignored-challenge") {
-		t.Fatal("MatchTransferCalldata() = false, want true for explicit memo")
+	if !assert.True(t, MatchTransferCalldata(calldata, explicitRequest, "ignored.example.com", "ignored-challenge"),
+		"MatchTransferCalldata() = false, want true for explicit memo") {
+		return
 	}
 
 	implicitRequest := explicitRequest
 	implicitRequest.MethodDetails.Memo = ""
 	attributionMemo := EncodeAttribution("api.example.com", "cli-app", "challenge-1")
 	attributedCalldata, err := EncodeTransferWithMemo(recipient, amount, attributionMemo)
-	if err != nil {
-		t.Fatalf("EncodeTransferWithMemo() attribution error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"EncodeTransferWithMemo() attribution error = %v", err) {
+		return
 	}
-	if !MatchTransferCalldata(attributedCalldata, implicitRequest, "api.example.com", "challenge-1") {
-		t.Fatal("MatchTransferCalldata() = false, want true for attribution memo")
+	if !assert.True(t, MatchTransferCalldata(attributedCalldata, implicitRequest, "api.example.com", "challenge-1"),
+		"MatchTransferCalldata() = false, want true for attribution memo") {
+		return
 	}
-	if MatchTransferCalldata(attributedCalldata, implicitRequest, "other.example.com", "challenge-1") {
-		t.Fatal("MatchTransferCalldata() = true, want false for wrong attribution realm")
+	if !assert.False(t, MatchTransferCalldata(attributedCalldata, implicitRequest, "other.example.com", "challenge-1"),
+		"MatchTransferCalldata() = true, want false for wrong attribution realm") {
+		return
 	}
-	if MatchTransferCalldata(attributedCalldata, implicitRequest, "api.example.com", "challenge-2") {
-		t.Fatal("MatchTransferCalldata() = true, want false for wrong challenge binding")
+	if !assert.False(t, MatchTransferCalldata(attributedCalldata, implicitRequest, "api.example.com", "challenge-2"),
+		"MatchTransferCalldata() = true, want false for wrong challenge binding") {
+		return
 	}
+
 }
 
 func TestParseChargeCredentialPayload_RoundTripsPayloadShapes(t *testing.T) {
@@ -226,20 +258,26 @@ func TestParseChargeCredentialPayload_RoundTripsPayloadShapes(t *testing.T) {
 
 			payload, err := ParseChargeCredentialPayload(tt.input)
 			if tt.wantErr != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("ParseChargeCredentialPayload() error = %v, want substring %q", err, tt.wantErr)
+				if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), tt.wantErr),
+					"ParseChargeCredentialPayload() error = %v, want substring %q", err, tt.wantErr) {
+					return
 				}
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("ParseChargeCredentialPayload() error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"ParseChargeCredentialPayload() error = %v", err) {
+				return
 			}
-			if !reflect.DeepEqual(payload, tt.want) {
-				t.Fatalf("ParseChargeCredentialPayload() = %#v, want %#v", payload, tt.want)
+			if !assert.Equalf(t, tt.want, payload,
+				"ParseChargeCredentialPayload() = %#v, want %#v", payload, tt.want) {
+				return
 			}
-			if !reflect.DeepEqual(payload.Map(), tt.input) {
-				t.Fatalf("payload.Map() = %#v, want %#v", payload.Map(), tt.input)
+			if !assert.Equalf(t, tt.input, payload.Map(),
+				"payload.Map() = %#v, want %#v", payload.Map(), tt.input) {
+				return
 			}
+
 		})
 	}
 }

--- a/pkg/tempo/proof_rpc_test.go
+++ b/pkg/tempo/proof_rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
@@ -13,13 +14,16 @@ func TestDefaultRPCURLForChain(t *testing.T) {
 	t.Parallel()
 
 	if got := DefaultRPCURLForChain(tempotx.ChainIdModerato); got != tempotx.RpcUrlModerato {
-		t.Fatalf("DefaultRPCURLForChain(moderato) = %q, want %q", got, tempotx.RpcUrlModerato)
+		assert.Failf(t, "", "DefaultRPCURLForChain(moderato) = %q, want %q", got, tempotx.RpcUrlModerato)
+		return
 	}
 	if got := DefaultRPCURLForChain(tempotx.ChainIdMainnet); got != tempotx.RpcUrlMainnet {
-		t.Fatalf("DefaultRPCURLForChain(mainnet) = %q, want %q", got, tempotx.RpcUrlMainnet)
+		assert.Failf(t, "", "DefaultRPCURLForChain(mainnet) = %q, want %q", got, tempotx.RpcUrlMainnet)
+		return
 	}
 	if got := DefaultRPCURLForChain(999999); got != tempotx.RpcUrlMainnet {
-		t.Fatalf("DefaultRPCURLForChain(unknown) = %q, want %q", got, tempotx.RpcUrlMainnet)
+		assert.Failf(t, "", "DefaultRPCURLForChain(unknown) = %q, want %q", got, tempotx.RpcUrlMainnet)
+		return
 	}
 }
 
@@ -28,69 +32,90 @@ func TestProofHelpers(t *testing.T) {
 
 	address := common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8")
 	if got := ProofSource(42431, address); got != "did:pkh:eip155:42431:"+address.Hex() {
-		t.Fatalf("ProofSource() = %q, want %q", got, "did:pkh:eip155:42431:"+address.Hex())
+		assert.Failf(t, "", "ProofSource() = %q, want %q", got, "did:pkh:eip155:42431:"+address.Hex())
+		return
 	}
 
 	hash1, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() error = %v", err) {
+		return
 	}
+
 	hash2, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() repeat error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() repeat error = %v", err) {
+		return
 	}
+
 	hash3, err := ProofTypedDataHash(42431, "challenge-2", "api.example.com")
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() different challenge error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() different challenge error = %v", err) {
+		return
 	}
+
 	hash4, err := ProofTypedDataHash(42431, "challenge-1", "other.example.com")
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() different realm error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() different realm error = %v", err) {
+		return
 	}
-	if hash1 != hash2 {
-		t.Fatalf("hash1 = %s, want same hash as hash2 %s", hash1.Hex(), hash2.Hex())
+	if !assert.Equalf(t, hash2, hash1,
+		"hash1 = %s, want same hash as hash2 %s", hash1.Hex(), hash2.Hex()) {
+		return
 	}
-	if hash1 == hash3 {
-		t.Fatalf("hash1 = %s, want different hash from hash3 %s", hash1.Hex(), hash3.Hex())
+
+	if !assert.NotEqualf(t, hash3, hash1,
+		"hash1 = %s, want different hash from hash3 %s", hash1.Hex(), hash3.Hex()) {
+		return
 	}
-	if hash1 == hash4 {
-		t.Fatalf("hash1 = %s, want different hash from hash4 %s", hash1.Hex(), hash4.Hex())
+	if !assert.NotEqualf(t, hash4, hash1,
+		"hash1 = %s, want different hash from hash4 %s", hash1.Hex(), hash4.Hex()) {
+		return
 	}
+
 }
 
 func TestParseHexHelpersAndClientConstruction(t *testing.T) {
 	t.Parallel()
 
 	parsedUint, err := ParseHexUint64("0x2a")
-	if err != nil {
-		t.Fatalf("ParseHexUint64() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseHexUint64() error = %v", err) {
+		return
 	}
-	if parsedUint != 42 {
-		t.Fatalf("ParseHexUint64() = %d, want %d", parsedUint, 42)
+	if !assert.EqualValuesf(t, 42, parsedUint,
+		"ParseHexUint64() = %d, want %d", parsedUint, 42) {
+		return
 	}
 
 	parsedBig, err := ParseHexBigInt("0x2a")
-	if err != nil {
-		t.Fatalf("ParseHexBigInt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseHexBigInt() error = %v", err) {
+		return
 	}
-	if parsedBig.Cmp(big.NewInt(42)) != 0 {
-		t.Fatalf("ParseHexBigInt() = %s, want %d", parsedBig.String(), 42)
+	if !assert.EqualValuesf(t, 0, parsedBig.Cmp(big.NewInt(42)),
+		"ParseHexBigInt() = %s, want %d", parsedBig.String(), 42) {
+		return
 	}
 
 	zero, err := ParseHexBigInt("0x")
-	if err != nil {
-		t.Fatalf("ParseHexBigInt(0x) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseHexBigInt(0x) error = %v", err) {
+		return
 	}
-	if zero.Sign() != 0 {
-		t.Fatalf("ParseHexBigInt(0x) = %s, want 0", zero.String())
+	if !assert.EqualValuesf(t, 0, zero.Sign(),
+		"ParseHexBigInt(0x) = %s, want 0", zero.String()) {
+		return
 	}
 
 	if _, err := ParseHexBigInt("0xzz"); err == nil {
-		t.Fatal("ParseHexBigInt(0xzz) error = nil, want error")
+		assert.Fail(t, "ParseHexBigInt(0xzz) error = nil, want error")
+		return
 	}
 
 	if client := NewRPCClient("https://rpc.example.com"); client == nil {
-		t.Fatal("NewRPCClient() = nil, want client")
+		assert.Fail(t, "NewRPCClient() = nil, want client")
+		return
 	}
 }
 
@@ -100,13 +125,17 @@ func TestTransferABIHelpers(t *testing.T) {
 	recipient := common.HexToAddress("0x70997970c51812dc3a010c7d01b50e0d17dc79c8")
 	amount := big.NewInt(42)
 	calldata := EncodeTransfer(recipient.Hex(), amount)
-	if len(calldata) != 2+8+64+64 {
-		t.Fatalf("len(calldata) = %d, want %d", len(calldata), 2+8+64+64)
+	if !assert.Lenf(t, calldata, 2+8+64+64,
+		"len(calldata) = %d, want %d", len(calldata), 2+8+64+64) {
+		return
 	}
+
 	if got := ParseTopicAddress("0x" + strings.Repeat("0", 24) + recipient.Hex()[2:]); got != recipient.Hex() {
-		t.Fatalf("ParseTopicAddress() = %q, want %q", got, recipient.Hex())
+		assert.Failf(t, "", "ParseTopicAddress() = %q, want %q", got, recipient.Hex())
+		return
 	}
 	if got := ParseTopicAddress("0x1234"); got != "" {
-		t.Fatalf("ParseTopicAddress(short) = %q, want empty string", got)
+		assert.Failf(t, "", "ParseTopicAddress(short) = %q, want empty string", got)
+		return
 	}
 }

--- a/pkg/tempo/redis_store_test.go
+++ b/pkg/tempo/redis_store_test.go
@@ -7,6 +7,7 @@ import (
 
 	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRedisStoreOperations(t *testing.T) {
@@ -21,25 +22,38 @@ func TestRedisStoreOperations(t *testing.T) {
 			name: "missing key",
 			run: func(t *testing.T, store *RedisStore, _ *miniredis.Miniredis) {
 				t.Helper()
-				if value, ok, err := store.Get(context.Background(), "missing"); err != nil || ok || value != "" {
-					t.Fatalf("Get() = (%q, %t, %v), want (\"\", false, nil)", value, ok, err)
+				{
+					value, ok, err := store.Get(context.Background(), "missing")
+					if !assert.Falsef(t, err != nil || ok || value != "",
+						"Get() = (%q, %t, %v), want (\"\", false, nil)", value, ok, err) {
+						return
+					}
 				}
+
 			},
 		},
 		{
 			name: "put and get",
 			run: func(t *testing.T, store *RedisStore, _ *miniredis.Miniredis) {
 				t.Helper()
-				if err := store.Put(context.Background(), "k", "v"); err != nil {
-					t.Fatalf("Put() error = %v", err)
+				{
+					err := store.Put(context.Background(), "k", "v")
+					if !assert.NoErrorf(t, err,
+						"Put() error = %v", err) {
+						return
+					}
 				}
+
 				value, ok, err := store.Get(context.Background(), "k")
-				if err != nil {
-					t.Fatalf("Get() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"Get() error = %v", err) {
+					return
 				}
-				if !ok || value != "v" {
-					t.Fatalf("Get() = (%q, %t), want (\"v\", true)", value, ok)
+				if !assert.Falsef(t, !ok || value != "v",
+					"Get() = (%q, %t), want (\"v\", true)", value, ok) {
+					return
 				}
+
 			},
 		},
 		{
@@ -47,41 +61,65 @@ func TestRedisStoreOperations(t *testing.T) {
 			run: func(t *testing.T, store *RedisStore, _ *miniredis.Miniredis) {
 				t.Helper()
 				inserted, err := store.PutIfAbsent(context.Background(), "k", "first")
-				if err != nil {
-					t.Fatalf("first PutIfAbsent() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"first PutIfAbsent() error = %v", err) {
+					return
 				}
-				if !inserted {
-					t.Fatal("first PutIfAbsent() = false, want true")
+				if !assert.True(t, inserted,
+					"first PutIfAbsent() = false, want true") {
+					return
 				}
+
 				inserted, err = store.PutIfAbsent(context.Background(), "k", "second")
-				if err != nil {
-					t.Fatalf("second PutIfAbsent() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"second PutIfAbsent() error = %v", err) {
+					return
 				}
-				if inserted {
-					t.Fatal("second PutIfAbsent() = true, want false")
+				if !assert.False(t, inserted,
+					"second PutIfAbsent() = true, want false") {
+					return
 				}
+
 				value, ok, err := store.Get(context.Background(), "k")
-				if err != nil {
-					t.Fatalf("Get() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"Get() error = %v", err) {
+					return
 				}
-				if !ok || value != "first" {
-					t.Fatalf("Get() = (%q, %t), want (\"first\", true)", value, ok)
+				if !assert.Falsef(t, !ok || value != "first",
+					"Get() = (%q, %t), want (\"first\", true)", value, ok) {
+					return
 				}
+
 			},
 		},
 		{
 			name: "delete removes key",
 			run: func(t *testing.T, store *RedisStore, _ *miniredis.Miniredis) {
 				t.Helper()
-				if err := store.Put(context.Background(), "k", "v"); err != nil {
-					t.Fatalf("Put() error = %v", err)
+				{
+					err := store.Put(context.Background(), "k", "v")
+					if !assert.NoErrorf(t, err,
+						"Put() error = %v", err) {
+						return
+					}
 				}
-				if err := store.Delete(context.Background(), "k"); err != nil {
-					t.Fatalf("Delete() error = %v", err)
+				{
+
+					err := store.Delete(context.Background(), "k")
+					if !assert.NoErrorf(t, err,
+						"Delete() error = %v", err) {
+						return
+					}
 				}
-				if value, ok, err := store.Get(context.Background(), "k"); err != nil || ok || value != "" {
-					t.Fatalf("Get() after delete = (%q, %t, %v), want (\"\", false, nil)", value, ok, err)
+				{
+
+					value, ok, err := store.Get(context.Background(), "k")
+					if !assert.Falsef(t, err != nil || ok || value != "",
+						"Get() after delete = (%q, %t, %v), want (\"\", false, nil)", value, ok, err) {
+						return
+					}
 				}
+
 			},
 		},
 		{
@@ -89,13 +127,23 @@ func TestRedisStoreOperations(t *testing.T) {
 			ttl:  time.Minute,
 			run: func(t *testing.T, store *RedisStore, server *miniredis.Miniredis) {
 				t.Helper()
-				if err := store.Put(context.Background(), "k", "v"); err != nil {
-					t.Fatalf("Put() error = %v", err)
+				{
+					err := store.Put(context.Background(), "k", "v")
+					if !assert.NoErrorf(t, err,
+						"Put() error = %v", err) {
+						return
+					}
 				}
+
 				server.FastForward(time.Minute + time.Second)
-				if value, ok, err := store.Get(context.Background(), "k"); err != nil || ok || value != "" {
-					t.Fatalf("Get() after expiry = (%q, %t, %v), want (\"\", false, nil)", value, ok, err)
+				{
+					value, ok, err := store.Get(context.Background(), "k")
+					if !assert.Falsef(t, err != nil || ok || value != "",
+						"Get() after expiry = (%q, %t, %v), want (\"\", false, nil)", value, ok, err) {
+						return
+					}
 				}
+
 			},
 		},
 		{
@@ -104,20 +152,26 @@ func TestRedisStoreOperations(t *testing.T) {
 			run: func(t *testing.T, store *RedisStore, server *miniredis.Miniredis) {
 				t.Helper()
 				inserted, err := store.PutIfAbsent(context.Background(), "k", "v")
-				if err != nil {
-					t.Fatalf("PutIfAbsent() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"PutIfAbsent() error = %v", err) {
+					return
 				}
-				if !inserted {
-					t.Fatal("PutIfAbsent() = false, want true")
+				if !assert.True(t, inserted,
+					"PutIfAbsent() = false, want true") {
+					return
 				}
+
 				server.FastForward(time.Minute + time.Second)
 				value, ok, err := store.Get(context.Background(), "k")
-				if err != nil {
-					t.Fatalf("Get() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"Get() error = %v", err) {
+					return
 				}
-				if !ok || value != "v" {
-					t.Fatalf("Get() = (%q, %t), want (\"v\", true)", value, ok)
+				if !assert.Falsef(t, !ok || value != "v",
+					"Get() = (%q, %t), want (\"v\", true)", value, ok) {
+					return
 				}
+
 			},
 		},
 	}
@@ -128,9 +182,11 @@ func TestRedisStoreOperations(t *testing.T) {
 			t.Parallel()
 
 			server, err := miniredis.Run()
-			if err != nil {
-				t.Fatalf("miniredis.Run() error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"miniredis.Run() error = %v", err) {
+				return
 			}
+
 			defer server.Close()
 
 			client := redis.NewClient(&redis.Options{Addr: server.Addr()})

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	"github.com/tempoxyz/mpp-go/pkg/tempo/client"
@@ -107,69 +108,98 @@ func TestChargeFlow_FeePayerTransactionViaRemoteSigner(t *testing.T) {
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
+
 	raw := credential.Payload["signature"].(string)
 
 	feePayerSigner, err := temposigner.NewSigner(feePayerKey)
-	if err != nil {
-		t.Fatalf("NewSigner() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner() error = %v", err) {
+		return
 	}
+
 	feePayerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			Method string   `json:"method"`
 			Params []string `json:"params"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("Decode(request) error = %v", err)
+		{
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if !assert.NoErrorf(t, err,
+				"Decode(request) error = %v", err) {
+				return
+			}
 		}
-		if body.Method != "eth_signRawTransaction" {
-			t.Fatalf("method = %q, want eth_signRawTransaction", body.Method)
+		if !assert.Equalf(t, "eth_signRawTransaction", body.Method,
+			"method = %q, want eth_signRawTransaction", body.Method) {
+			return
 		}
-		if len(body.Params) != 1 || body.Params[0] != raw {
-			t.Fatalf("params = %#v, want original raw tx", body.Params)
+		if !assert.Falsef(t, len(body.Params) != 1 || body.Params[0] != raw,
+			"params = %#v, want original raw tx", body.Params) {
+			return
 		}
+
 		coSignedTx, err := tempotx.Deserialize(raw)
-		if err != nil {
-			t.Fatalf("Deserialize(raw) error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"Deserialize(raw) error = %v", err) {
+			return
 		}
+
 		sender, err := tempotx.VerifySignature(coSignedTx)
-		if err != nil {
-			t.Fatalf("VerifySignature() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"VerifySignature() error = %v", err) {
+			return
 		}
+
 		coSignedTx.From = sender
 		coSignedTx.FeeToken = common.HexToAddress(request.Currency)
 		coSignedTx.AwaitingFeePayer = false
-		if err := tempotx.AddFeePayerSignature(coSignedTx, feePayerSigner); err != nil {
-			t.Fatalf("AddFeePayerSignature() error = %v", err)
+		{
+			err := tempotx.AddFeePayerSignature(coSignedTx, feePayerSigner)
+			if !assert.NoErrorf(t, err,
+				"AddFeePayerSignature() error = %v", err) {
+				return
+			}
 		}
+
 		serialized, err := tempotx.Serialize(coSignedTx, nil)
-		if err != nil {
-			t.Fatalf("Serialize() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"Serialize() error = %v", err) {
+			return
 		}
+
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": serialized})
 	}))
 	defer feePayerServer.Close()
 	request.MethodDetails.FeePayerURL = feePayerServer.URL
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	receipt, err := intent.Verify(ctx, credential, request.Map())
-	if err != nil {
-		t.Fatalf("Verify() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Verify() error = %v", err) {
+		return
 	}
-	if receipt.Reference != testReceiptHash {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, testReceiptHash)
+	if !assert.Equalf(t, testReceiptHash, receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, testReceiptHash) {
+		return
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected 1 broadcast, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected 1 broadcast, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
-	if strings.Contains(rpc.sentRawTxs[0], "feefeefeefee") {
-		t.Fatalf("broadcast transaction still contains fee payer marker: %q", rpc.sentRawTxs[0])
+	if !assert.NotContainsf(t, rpc.sentRawTxs[0], "feefeefeefee",
+		"broadcast transaction still contains fee payer marker: %q", rpc.sentRawTxs[0]) {
+		return
 	}
+
 }
 
 func TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsTamperedFeeToken(t *testing.T) {
@@ -180,49 +210,69 @@ func TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsTamperedFeeToken(t 
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
+
 	raw := credential.Payload["signature"].(string)
 
 	feePayerSigner, err := temposigner.NewSigner(feePayerKey)
-	if err != nil {
-		t.Fatalf("NewSigner() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner() error = %v", err) {
+		return
 	}
+
 	feePayerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		coSignedTx, err := tempotx.Deserialize(raw)
-		if err != nil {
-			t.Fatalf("Deserialize(raw) error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"Deserialize(raw) error = %v", err) {
+			return
 		}
+
 		sender, err := tempotx.VerifySignature(coSignedTx)
-		if err != nil {
-			t.Fatalf("VerifySignature() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"VerifySignature() error = %v", err) {
+			return
 		}
+
 		coSignedTx.From = sender
 		coSignedTx.FeeToken = common.HexToAddress("0x20c0000000000000000000000000000000000002")
 		coSignedTx.AwaitingFeePayer = false
-		if err := tempotx.AddFeePayerSignature(coSignedTx, feePayerSigner); err != nil {
-			t.Fatalf("AddFeePayerSignature() error = %v", err)
+		{
+			err := tempotx.AddFeePayerSignature(coSignedTx, feePayerSigner)
+			if !assert.NoErrorf(t, err,
+				"AddFeePayerSignature() error = %v", err) {
+				return
+			}
 		}
+
 		serialized, err := tempotx.Serialize(coSignedTx, nil)
-		if err != nil {
-			t.Fatalf("Serialize() error = %v", err)
+		if !assert.NoErrorf(t, err,
+			"Serialize() error = %v", err) {
+			return
 		}
+
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": serialized})
 	}))
 	defer feePayerServer.Close()
 	request.MethodDetails.FeePayerURL = feePayerServer.URL
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "fee token") {
-		t.Fatalf("Verify() error = %v, want fee token rejection", err)
+		assert.Failf(t, "", "Verify() error = %v, want fee token rejection", err)
+		return
 	}
-	if len(rpc.sentRawTxs) != 0 {
-		t.Fatalf("expected tampered transaction to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected tampered transaction to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {
@@ -234,32 +284,41 @@ func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {
 		Decimals:  6,
 		ChainID:   42431,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	challenge := buildChallenge(t, request)
 
 	rootSigner, err := temposigner.NewSigner(testPrivateKey)
-	if err != nil {
-		t.Fatalf("NewSigner(root) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner(root) error = %v", err) {
+		return
 	}
+
 	accessKey, err := temposigner.NewSigner(feePayerKey)
-	if err != nil {
-		t.Fatalf("NewSigner(access key) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner(access key) error = %v", err) {
+		return
 	}
 	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() error = %v", err) {
+		return
 	}
+
 	v2Payload := make([]byte, 0, 1+len(proofHash.Bytes())+common.AddressLength)
 	v2Payload = append(v2Payload, keychain.KeychainSignatureType)
 	v2Payload = append(v2Payload, proofHash.Bytes()...)
 	v2Payload = append(v2Payload, rootSigner.Address().Bytes()...)
 	innerSignature, err := accessKey.Sign(crypto.Keccak256Hash(v2Payload))
-	if err != nil {
-		t.Fatalf("accessKey.Sign() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"accessKey.Sign() error = %v", err) {
+		return
 	}
+
 	rpc.callResult = encodeActiveKeyInfo(accessKey.Address(), time.Now().Add(time.Hour).Unix())
 
 	credential := &mpp.Credential{
@@ -272,16 +331,21 @@ func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	receipt, err := intent.Verify(ctx, credential, request.Map())
-	if err != nil {
-		t.Fatalf("Verify() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Verify() error = %v", err) {
+		return
 	}
-	if receipt.Reference != challenge.ID {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, challenge.ID)
+	if !assert.Equalf(t, challenge.ID, receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, challenge.ID) {
+		return
 	}
+
 }
 
 func TestChargeFlow_ProofCredentialWithAccessKeyWithoutExpiry(t *testing.T) {
@@ -293,32 +357,41 @@ func TestChargeFlow_ProofCredentialWithAccessKeyWithoutExpiry(t *testing.T) {
 		Decimals:  6,
 		ChainID:   42431,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	challenge := buildChallenge(t, request)
 
 	rootSigner, err := temposigner.NewSigner(testPrivateKey)
-	if err != nil {
-		t.Fatalf("NewSigner(root) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner(root) error = %v", err) {
+		return
 	}
+
 	accessKey, err := temposigner.NewSigner(feePayerKey)
-	if err != nil {
-		t.Fatalf("NewSigner(access key) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner(access key) error = %v", err) {
+		return
 	}
 	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
-	if err != nil {
-		t.Fatalf("ProofTypedDataHash() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() error = %v", err) {
+		return
 	}
+
 	v2Payload := make([]byte, 0, 1+len(proofHash.Bytes())+common.AddressLength)
 	v2Payload = append(v2Payload, keychain.KeychainSignatureType)
 	v2Payload = append(v2Payload, proofHash.Bytes()...)
 	v2Payload = append(v2Payload, rootSigner.Address().Bytes()...)
 	innerSignature, err := accessKey.Sign(crypto.Keccak256Hash(v2Payload))
-	if err != nil {
-		t.Fatalf("accessKey.Sign() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"accessKey.Sign() error = %v", err) {
+		return
 	}
+
 	rpc.callResult = encodeActiveKeyInfo(accessKey.Address(), 0)
 
 	credential := &mpp.Credential{
@@ -331,16 +404,21 @@ func TestChargeFlow_ProofCredentialWithAccessKeyWithoutExpiry(t *testing.T) {
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	receipt, err := intent.Verify(ctx, credential, request.Map())
-	if err != nil {
-		t.Fatalf("Verify() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Verify() error = %v", err) {
+		return
 	}
-	if receipt.Reference != challenge.ID {
-		t.Fatalf("receipt reference = %q, want %q", receipt.Reference, challenge.ID)
+	if !assert.Equalf(t, challenge.ID, receipt.Reference,
+		"receipt reference = %q, want %q", receipt.Reference, challenge.ID) {
+		return
 	}
+
 }
 
 func TestChargeFlow_HashCredentialRejectsExtraTransferLogs(t *testing.T) {
@@ -357,9 +435,11 @@ func TestChargeFlow_HashCredentialRejectsExtraTransferLogs(t *testing.T) {
 			Recipient: "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
 		}},
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	rpc.onSend = func(raw string) (string, map[string]any, error) {
 		tx, err := tempotx.Deserialize(raw)
@@ -380,16 +460,20 @@ func TestChargeFlow_HashCredentialRejectsExtraTransferLogs(t *testing.T) {
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "does not satisfy") {
-		t.Fatalf("Verify() error = %v, want receipt mismatch", err)
+		assert.Failf(t, "", "Verify() error = %v, want receipt mismatch", err)
+		return
 	}
 }
 
@@ -403,9 +487,11 @@ func TestChargeFlow_HashCredentialIgnoresFeeControllerLogs(t *testing.T) {
 		ChainID:        42431,
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	rpc.onSend = func(raw string) (string, map[string]any, error) {
 		tx, err := tempotx.Deserialize(raw)
@@ -426,16 +512,20 @@ func TestChargeFlow_HashCredentialIgnoresFeeControllerLogs(t *testing.T) {
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("Verify() error = %v", err)
+		assert.Failf(t, "", "Verify() error = %v", err)
+		return
 	}
 }
 
@@ -450,13 +540,17 @@ func TestChargeFlow_HashCredentialRejectsExplicitPrimaryMemo(t *testing.T) {
 		Memo:           "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	signer, err := temposigner.NewSigner(testPrivateKey)
-	if err != nil {
-		t.Fatalf("NewSigner() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner() error = %v", err) {
+		return
 	}
+
 	challenge := buildChallenge(t, request)
 	credential := &mpp.Credential{
 		Challenge: challenge.ToEcho(),
@@ -468,11 +562,14 @@ func TestChargeFlow_HashCredentialRejectsExplicitPrimaryMemo(t *testing.T) {
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: newMockRPC(request)})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "explicit memo") {
-		t.Fatalf("Verify() error = %v, want explicit memo rejection", err)
+		assert.Failf(t, "", "Verify() error = %v, want explicit memo rejection", err)
+		return
 	}
 }
 
@@ -484,17 +581,22 @@ func TestChargeFlow_RejectsMalformedCredentialSource(t *testing.T) {
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
+
 	credential.Source = "not-a-did"
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "credential source is invalid") {
-		t.Fatalf("Verify() error = %v, want invalid credential source", err)
+		assert.Failf(t, "", "Verify() error = %v, want invalid credential source", err)
+		return
 	}
 }
 
@@ -507,26 +609,37 @@ func TestChargeFlow_ProofCredentialRejectsDifferentRealm(t *testing.T) {
 		Decimals:  6,
 		ChainID:   42431,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeProof)
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
+
 	credential.Challenge.Realm = "other.example.com"
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "proof signature does not match source") {
-		t.Fatalf("Verify() error = %v, want proof signature mismatch", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "proof signature does not match source"),
+			"Verify() error = %v, want proof signature mismatch", err) {
+			return
+		}
 	}
+
 }
 
 func TestChargeFlow_TransactionCredentialReservesHashBeforeBroadcast(t *testing.T) {
@@ -552,26 +665,41 @@ func TestChargeFlow_TransactionCredentialReservesHashBeforeBroadcast(t *testing.
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("first Verify() error = %v", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err,
+			"first Verify() error = %v", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs)) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("second Verify() error = %v", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err,
+			"second Verify() error = %v", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected no second broadcast, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected no second broadcast, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_TransactionCredentialRefetchesReservedHashAfterReceiptFailure(t *testing.T) {
@@ -605,26 +733,41 @@ func TestChargeFlow_TransactionCredentialRefetchesReservedHashAfterReceiptFailur
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "failed to fetch transaction receipt") {
-		t.Fatalf("first Verify() error = %v, want receipt fetch failure", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "failed to fetch transaction receipt"),
+			"first Verify() error = %v, want receipt fetch failure", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("second Verify() error = %v", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err,
+			"second Verify() error = %v", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected retry to refetch without rebroadcast, got %d broadcasts", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected retry to refetch without rebroadcast, got %d broadcasts", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_TransactionCredentialReleasesReservationAfterBroadcastFailure(t *testing.T) {
@@ -638,19 +781,27 @@ func TestChargeFlow_TransactionCredentialReleasesReservationAfterBroadcastFailur
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction submission failed") {
-		t.Fatalf("first Verify() error = %v, want submission failure", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "transaction submission failed"),
+			"first Verify() error = %v, want submission failure", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected first Verify() to broadcast once, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
 
 	rpc.onSend = func(raw string) (string, map[string]any, error) {
@@ -664,12 +815,18 @@ func TestChargeFlow_TransactionCredentialReleasesReservationAfterBroadcastFailur
 		}
 		return testReceiptHash, buildReceipt(raw, request, sender), nil
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("second Verify() error = %v", err)
+	{
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err,
+			"second Verify() error = %v", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 2 {
-		t.Fatalf("expected second Verify() to broadcast after release, got %d broadcasts", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 2,
+		"expected second Verify() to broadcast after release, got %d broadcasts", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_RejectsFeePayerTransactionOutsideSponsorPolicy(t *testing.T) {
@@ -681,16 +838,20 @@ func TestChargeFlow_RejectsFeePayerTransactionOutsideSponsorPolicy(t *testing.T)
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "sponsor policy") {
-		t.Fatalf("Verify() error = %v, want sponsor policy rejection", err)
+		assert.Failf(t, "", "Verify() error = %v, want sponsor policy rejection", err)
+		return
 	}
 }
 
@@ -705,26 +866,41 @@ func TestChargeFlow_FeePayerTransactionUsesChallengeOnceAfterRevert(t *testing.T
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction reverted") {
-		t.Fatalf("first Verify() error = %v, want reverted transaction", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "transaction reverted"),
+			"first Verify() error = %v, want reverted transaction", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected 1 broadcast after first Verify(), got %d", len(rpc.sentRawTxs)) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "challenge already used") {
-		t.Fatalf("second Verify() error = %v, want reused challenge rejection", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "challenge already used"),
+			"second Verify() error = %v, want reused challenge rejection", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected no second broadcast, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected no second broadcast, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.T) {
@@ -733,51 +909,78 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 	rpc := newMockRPC(request)
 	rpc.onEstimateGas = func(params ...interface{}) (*temporpc.JSONRPCResponse, error) {
 		callObject, ok := params[0].(map[string]any)
-		if !ok {
-			t.Fatalf("estimateGas params[0] type = %T, want map[string]any", params[0])
+		if !assert.Truef(t, ok,
+			"estimateGas params[0] type = %T, want map[string]any", params[0]) {
+			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
+
 		if _, ok := callObject["calls"]; !ok {
 			return &temporpc.JSONRPCResponse{Result: rpc.estimateGas}, nil
 		}
-		if callObject["from"] == "" {
-			t.Fatal("estimateGas call object missing from")
+		if !assert.NotEqual(t, "", callObject["from"],
+			"estimateGas call object missing from") {
+			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
-		if callObject["feeToken"] != request.Currency {
-			t.Fatalf("estimateGas feeToken = %v, want %s", callObject["feeToken"], request.Currency)
+		if !assert.Equalf(t, request.Currency, callObject["feeToken"],
+			"estimateGas feeToken = %v, want %s", callObject["feeToken"], request.Currency) {
+			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
+
 		calls, ok := callObject["calls"].([]map[string]any)
-		if !ok || len(calls) == 0 {
-			t.Fatalf("estimateGas calls = %#v, want non-empty call batch", callObject["calls"])
+		if !assert.Falsef(t, !ok || len(calls) == 0,
+			"estimateGas calls = %#v, want non-empty call batch", callObject["calls"]) {
+			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
-		if _, ok := callObject["nonceKey"]; !ok {
-			t.Fatal("estimateGas call object missing nonceKey")
+		{
+
+			_, ok := callObject["nonceKey"]
+			if !assert.True(t, ok,
+				"estimateGas call object missing nonceKey") {
+				return *new(*temporpc.JSONRPCResponse), *new(error)
+			}
 		}
-		if _, ok := callObject["validBefore"]; !ok {
-			t.Fatal("estimateGas call object missing validBefore")
+		{
+
+			_, ok := callObject["validBefore"]
+			if !assert.True(t, ok,
+				"estimateGas call object missing validBefore") {
+				return *new(*temporpc.JSONRPCResponse), *new(error)
+			}
 		}
+
 		return temporpc.NewJSONRPCErrorResponse(1, temporpc.InvalidTransactionType, "execution reverted", nil), nil
 	}
 	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "transaction preflight failed") {
-		t.Fatalf("Verify() error = %v, want preflight failure", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "transaction preflight failed"),
+			"Verify() error = %v, want preflight failure", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 0 {
-		t.Fatalf("expected no broadcast after failed preflight, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected no broadcast after failed preflight, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
-	if len(rpc.estimateGasCalls) < 2 {
-		t.Fatalf("expected client estimate and server preflight calls, got %d", len(rpc.estimateGasCalls))
+	if !assert.Falsef(t, len(rpc.estimateGasCalls) < 2,
+		"expected client estimate and server preflight calls, got %d", len(rpc.estimateGasCalls)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_RejectsUnsupportedFeePayerToken(t *testing.T) {
@@ -790,28 +993,39 @@ func TestChargeFlow_RejectsUnsupportedFeePayerToken(t *testing.T) {
 		ChainID:   42431,
 		FeePayer:  true,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "not supported") {
-		t.Fatalf("Verify() error = %v, want unsupported fee token rejection", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "not supported"),
+			"Verify() error = %v, want unsupported fee token rejection", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 0 {
-		t.Fatalf("expected unsupported fee token to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected unsupported fee token to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestChargeFlow_CustomFeePayerPolicyAllowsConfiguredToken(t *testing.T) {
@@ -824,16 +1038,19 @@ func TestChargeFlow_CustomFeePayerPolicyAllowsConfiguredToken(t *testing.T) {
 		ChainID:   42431,
 		FeePayer:  true,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return
 	}
+
 	rpc := newMockRPC(request)
 	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
 	challenge := buildChallenge(t, request)
 
 	credential, err := clientMethod.CreateCredential(ctx, challenge)
-	if err != nil {
-		t.Fatalf("CreateCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
 	}
 
 	intent, err := NewIntent(IntentConfig{
@@ -847,15 +1064,23 @@ func TestChargeFlow_CustomFeePayerPolicyAllowsConfiguredToken(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if _, err := intent.Verify(ctx, credential, request.Map()); err != nil {
-		t.Fatalf("Verify() error = %v", err)
+	{
+
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err,
+			"Verify() error = %v", err) {
+			return
+		}
 	}
-	if len(rpc.sentRawTxs) != 1 {
-		t.Fatalf("expected configured fee token to broadcast once, got %d", len(rpc.sentRawTxs))
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected configured fee token to broadcast once, got %d", len(rpc.sentRawTxs)) {
+		return
 	}
+
 }
 
 func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
@@ -865,11 +1090,14 @@ func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
 
 	started := time.Now()
 	_, err := fetchReceipt(ctx, rpc, testReceiptHash)
-	if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
-		t.Fatalf("fetchReceipt() error = %v, want context cancellation", err)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), context.Canceled.Error()),
+		"fetchReceipt() error = %v, want context cancellation", err) {
+		return
 	}
+
 	if elapsed := time.Since(started); elapsed >= receiptRetryDelay/2 {
-		t.Fatalf("fetchReceipt() took %s, want early cancellation before retry delay %s", elapsed, receiptRetryDelay)
+		assert.Failf(t, "", "fetchReceipt() took %s, want early cancellation before retry delay %s", elapsed, receiptRetryDelay)
+		return
 	}
 }
 
@@ -881,9 +1109,11 @@ func newClientMethod(t *testing.T, rpc tempo.RPCClient, credentialType tempo.Cre
 		ChainID:        42431,
 		CredentialType: credentialType,
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return *new(*chargeclient.Method)
 	}
+
 	return method
 }
 
@@ -898,9 +1128,11 @@ func buildRequest(t *testing.T, feePayer bool, modes []tempo.ChargeMode) tempo.C
 		FeePayer:       feePayer,
 		SupportedModes: modes,
 	})
-	if err != nil {
-		t.Fatalf("NormalizeChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NormalizeChargeRequest() error = %v", err) {
+		return *new(tempo.ChargeRequest)
 	}
+
 	return request
 }
 

--- a/pkg/tempo/server/config_test.go
+++ b/pkg/tempo/server/config_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
@@ -16,65 +17,88 @@ func TestMethodFromConfigBuildsMethod(t *testing.T) {
 		RPCURL:    tempotx.RpcUrlModerato,
 		Recipient: testRecipient,
 	})
-	if err != nil {
-		t.Fatalf("MethodFromConfig() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"MethodFromConfig() error = %v", err) {
+		return
 	}
+
 	requestMap, err := method.BuildChargeRequest(mppserver.ChargeParams{Amount: "0.50"})
-	if err != nil {
-		t.Fatalf("BuildChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"BuildChargeRequest() error = %v", err) {
+		return
 	}
+
 	request, err := tempo.ParseChargeRequest(requestMap)
-	if err != nil {
-		t.Fatalf("ParseChargeRequest() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseChargeRequest() error = %v", err) {
+		return
 	}
-	if request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato {
-		t.Fatalf("request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato)
+	if !assert.Falsef(t, request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato,
+		"request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato) {
+		return
 	}
-	if request.Currency != tempotx.AlphaUSDAddress.Hex() {
-		t.Fatalf("request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex())
+	if !assert.Equalf(t, tempotx.AlphaUSDAddress.Hex(), request.Currency,
+		"request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex()) {
+		return
 	}
+
 }
 
 func TestNewIntentLoadsFeePayerPrivateKeyFromEnv(t *testing.T) {
 	t.Setenv("FEE_PAYER_KEY", feePayerKey)
 	intent, err := NewIntent(IntentConfig{FeePayerPrivateKeyEnv: "FEE_PAYER_KEY"})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
-	if intent.feePayerSigner == nil {
-		t.Fatal("intent.feePayerSigner = nil, want signer")
+	if !assert.NotNil(t, intent.feePayerSigner,
+		"intent.feePayerSigner = nil, want signer") {
+		return
 	}
+
 }
 
 func TestNewIntent_DefaultFeePayerPoliciesIncludeKnownTokens(t *testing.T) {
 	intent, err := NewIntent(IntentConfig{})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
+
 	moderatoPolicy, ok := intent.feePayerPolicy[tempotx.AlphaUSDAddress.Hex()]
-	if !ok {
-		t.Fatalf("missing default policy for %s", tempotx.AlphaUSDAddress.Hex())
+	if !assert.Truef(t, ok,
+		"missing default policy for %s", tempotx.AlphaUSDAddress.Hex()) {
+		return
 	}
-	if moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)) != 0 {
-		t.Fatalf("moderato max total fee = %s, want 50000000000000000", moderatoPolicy.MaxTotalFee)
+	if !assert.Equalf(t, 0, moderatoPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)),
+		"moderato max total fee = %s, want 50000000000000000", moderatoPolicy.MaxTotalFee) {
+		return
 	}
-	if moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(100_000_000_000)) != 0 {
-		t.Fatalf("moderato max fee per gas = %s, want 100000000000", moderatoPolicy.MaxFeePerGas)
+	if !assert.Equalf(t, 0, moderatoPolicy.MaxFeePerGas.Cmp(big.NewInt(100_000_000_000)),
+		"moderato max fee per gas = %s, want 100000000000", moderatoPolicy.MaxFeePerGas) {
+		return
 	}
+
 	legacyPolicy, ok := intent.feePayerPolicy["0x20C0000000000000000000000000000000000000"]
-	if !ok {
-		t.Fatal("missing default policy for legacy moderato fee token")
+	if !assert.True(t, ok,
+		"missing default policy for legacy moderato fee token") {
+		return
 	}
-	if legacyPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)) != 0 {
-		t.Fatalf("legacy moderato max total fee = %s, want 50000000000000000", legacyPolicy.MaxTotalFee)
+	if !assert.Equalf(t, 0, legacyPolicy.MaxTotalFee.Cmp(big.NewInt(50_000_000_000_000_000)),
+		"legacy moderato max total fee = %s, want 50000000000000000", legacyPolicy.MaxTotalFee) {
+		return
 	}
+
 	mainnetPolicy, ok := intent.feePayerPolicy[tempo.MainnetUSDCAddress]
-	if !ok {
-		t.Fatalf("missing default policy for %s", tempo.MainnetUSDCAddress)
+	if !assert.Truef(t, ok,
+		"missing default policy for %s", tempo.MainnetUSDCAddress) {
+		return
 	}
-	if mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(100_000_000_000)) != 0 {
-		t.Fatalf("mainnet max priority fee per gas = %s, want 100000000000", mainnetPolicy.MaxPriorityFeePerGas)
+	if !assert.Equalf(t, 0, mainnetPolicy.MaxPriorityFeePerGas.Cmp(big.NewInt(100_000_000_000)),
+		"mainnet max priority fee per gas = %s, want 100000000000", mainnetPolicy.MaxPriorityFeePerGas) {
+		return
 	}
+
 }
 
 func TestNewIntentRejectsInvalidFeePayerPolicy(t *testing.T) {
@@ -87,7 +111,9 @@ func TestNewIntentRejectsInvalidFeePayerPolicy(t *testing.T) {
 			},
 		},
 	})
-	if err == nil || err.Error() != "tempo server: max priority fee per gas exceeds max fee per gas for 0x20c0000000000000000000000000000000000001" {
-		t.Fatalf("NewIntent() error = %v, want max priority fee validation error", err)
+	if !assert.Falsef(t, err == nil || err.Error() != "tempo server: max priority fee per gas exceeds max fee per gas for 0x20c0000000000000000000000000000000000001",
+		"NewIntent() error = %v, want max priority fee validation error", err) {
+		return
 	}
+
 }

--- a/pkg/tempo/server/method_test.go
+++ b/pkg/tempo/server/method_test.go
@@ -3,6 +3,7 @@ package chargeserver
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
@@ -12,8 +13,9 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 	t.Parallel()
 
 	moderatoIntent, err := NewIntent(IntentConfig{RPCURL: tempotx.RpcUrlModerato})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
 	}
 
 	tests := []struct {
@@ -33,12 +35,15 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			},
 			assertions: func(t *testing.T, request tempo.ChargeRequest) {
 				t.Helper()
-				if request.Currency != tempotx.AlphaUSDAddress.Hex() {
-					t.Fatalf("request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex())
+				if !assert.Equalf(t, tempotx.AlphaUSDAddress.Hex(), request.Currency,
+					"request.Currency = %q, want %q", request.Currency, tempotx.AlphaUSDAddress.Hex()) {
+					return
 				}
-				if request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato {
-					t.Fatalf("request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato)
+				if !assert.Falsef(t, request.MethodDetails.ChainID == nil || *request.MethodDetails.ChainID != tempotx.ChainIdModerato,
+					"request.MethodDetails.ChainID = %v, want %d", request.MethodDetails.ChainID, tempotx.ChainIdModerato) {
+					return
 				}
+
 			},
 		},
 		{
@@ -67,15 +72,19 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			},
 			assertions: func(t *testing.T, request tempo.ChargeRequest) {
 				t.Helper()
-				if request.ExternalID != "ext-123" {
-					t.Fatalf("request.ExternalID = %q, want ext-123", request.ExternalID)
+				if !assert.Equalf(t, "ext-123", request.ExternalID,
+					"request.ExternalID = %q, want ext-123", request.ExternalID) {
+					return
 				}
-				if !request.MethodDetails.FeePayer {
-					t.Fatal("request.MethodDetails.FeePayer = false, want true")
+				if !assert.True(t, request.MethodDetails.FeePayer,
+					"request.MethodDetails.FeePayer = false, want true") {
+					return
 				}
-				if request.MethodDetails.FeePayerURL != "https://fee-payer.example.com" {
-					t.Fatalf("request.MethodDetails.FeePayerURL = %q, want https://fee-payer.example.com", request.MethodDetails.FeePayerURL)
+				if !assert.Equalf(t, "https://fee-payer.example.com", request.MethodDetails.FeePayerURL,
+					"request.MethodDetails.FeePayerURL = %q, want https://fee-payer.example.com", request.MethodDetails.FeePayerURL) {
+					return
 				}
+
 			},
 		},
 		{
@@ -96,12 +105,22 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			},
 			assertions: func(t *testing.T, request tempo.ChargeRequest) {
 				t.Helper()
-				if got := len(request.MethodDetails.Splits); got != 1 {
-					t.Fatalf("len(request.MethodDetails.Splits) = %d, want 1", got)
+				{
+					got := len(request.MethodDetails.Splits)
+					if !assert.EqualValuesf(t, 1, got,
+						"len(request.MethodDetails.Splits) = %d, want 1", got) {
+						return
+					}
 				}
-				if got := len(request.MethodDetails.SupportedModes); got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePush {
-					t.Fatalf("request.MethodDetails.SupportedModes = %#v, want [push]", request.MethodDetails.SupportedModes)
+				{
+
+					got := len(request.MethodDetails.SupportedModes)
+					if !assert.Falsef(t, got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePush,
+						"request.MethodDetails.SupportedModes = %#v, want [push]", request.MethodDetails.SupportedModes) {
+						return
+					}
 				}
+
 			},
 		},
 		{
@@ -118,9 +137,14 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			},
 			assertions: func(t *testing.T, request tempo.ChargeRequest) {
 				t.Helper()
-				if got := len(request.MethodDetails.SupportedModes); got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePull {
-					t.Fatalf("request.MethodDetails.SupportedModes = %#v, want [pull]", request.MethodDetails.SupportedModes)
+				{
+					got := len(request.MethodDetails.SupportedModes)
+					if !assert.Falsef(t, got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePull,
+						"request.MethodDetails.SupportedModes = %#v, want [pull]", request.MethodDetails.SupportedModes) {
+						return
+					}
 				}
+
 			},
 		},
 	}
@@ -133,19 +157,24 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			method := NewMethod(tt.config)
 			requestMap, err := method.BuildChargeRequest(tt.params)
 			if tt.name == "rejects unknown chain without intent rpc" {
-				if err == nil || err.Error() != "tempo server: unknown chain id 999999; configure Intent.RPC or Intent.RPCURL explicitly" {
-					t.Fatalf("BuildChargeRequest() error = %v, want unknown chain id error", err)
+				if !assert.Falsef(t, err == nil || err.Error() != "tempo server: unknown chain id 999999; configure Intent.RPC or Intent.RPCURL explicitly",
+					"BuildChargeRequest() error = %v, want unknown chain id error", err) {
+					return
 				}
+
 				return
 			}
-			if err != nil {
-				t.Fatalf("BuildChargeRequest() error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"BuildChargeRequest() error = %v", err) {
+				return
 			}
 
 			request, err := tempo.ParseChargeRequest(requestMap)
-			if err != nil {
-				t.Fatalf("ParseChargeRequest() error = %v", err)
+			if !assert.NoErrorf(t, err,
+				"ParseChargeRequest() error = %v", err) {
+				return
 			}
+
 			tt.assertions(t, request)
 		})
 	}

--- a/pkg/tempo/store_test.go
+++ b/pkg/tempo/store_test.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -16,25 +17,38 @@ func TestMemoryStoreOperations(t *testing.T) {
 			name: "missing key",
 			run: func(t *testing.T, store *MemoryStore) {
 				t.Helper()
-				if value, ok, err := store.Get(context.Background(), "missing"); err != nil || ok || value != "" {
-					t.Fatalf("Get() = (%q, %t, %v), want (\"\", false, nil)", value, ok, err)
+				{
+					value, ok, err := store.Get(context.Background(), "missing")
+					if !assert.Falsef(t, err != nil || ok || value != "",
+						"Get() = (%q, %t, %v), want (\"\", false, nil)", value, ok, err) {
+						return
+					}
 				}
+
 			},
 		},
 		{
 			name: "put and get",
 			run: func(t *testing.T, store *MemoryStore) {
 				t.Helper()
-				if err := store.Put(context.Background(), "k", "v"); err != nil {
-					t.Fatalf("Put() error = %v", err)
+				{
+					err := store.Put(context.Background(), "k", "v")
+					if !assert.NoErrorf(t, err,
+						"Put() error = %v", err) {
+						return
+					}
 				}
+
 				value, ok, err := store.Get(context.Background(), "k")
-				if err != nil {
-					t.Fatalf("Get() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"Get() error = %v", err) {
+					return
 				}
-				if !ok || value != "v" {
-					t.Fatalf("Get() = (%q, %t), want (\"v\", true)", value, ok)
+				if !assert.Falsef(t, !ok || value != "v",
+					"Get() = (%q, %t), want (\"v\", true)", value, ok) {
+					return
 				}
+
 			},
 		},
 		{
@@ -42,41 +56,65 @@ func TestMemoryStoreOperations(t *testing.T) {
 			run: func(t *testing.T, store *MemoryStore) {
 				t.Helper()
 				inserted, err := store.PutIfAbsent(context.Background(), "k", "first")
-				if err != nil {
-					t.Fatalf("first PutIfAbsent() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"first PutIfAbsent() error = %v", err) {
+					return
 				}
-				if !inserted {
-					t.Fatal("first PutIfAbsent() = false, want true")
+				if !assert.True(t, inserted,
+					"first PutIfAbsent() = false, want true") {
+					return
 				}
+
 				inserted, err = store.PutIfAbsent(context.Background(), "k", "second")
-				if err != nil {
-					t.Fatalf("second PutIfAbsent() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"second PutIfAbsent() error = %v", err) {
+					return
 				}
-				if inserted {
-					t.Fatal("second PutIfAbsent() = true, want false")
+				if !assert.False(t, inserted,
+					"second PutIfAbsent() = true, want false") {
+					return
 				}
+
 				value, ok, err := store.Get(context.Background(), "k")
-				if err != nil {
-					t.Fatalf("Get() error = %v", err)
+				if !assert.NoErrorf(t, err,
+					"Get() error = %v", err) {
+					return
 				}
-				if !ok || value != "first" {
-					t.Fatalf("Get() = (%q, %t), want (\"first\", true)", value, ok)
+				if !assert.Falsef(t, !ok || value != "first",
+					"Get() = (%q, %t), want (\"first\", true)", value, ok) {
+					return
 				}
+
 			},
 		},
 		{
 			name: "delete removes key",
 			run: func(t *testing.T, store *MemoryStore) {
 				t.Helper()
-				if err := store.Put(context.Background(), "k", "v"); err != nil {
-					t.Fatalf("Put() error = %v", err)
+				{
+					err := store.Put(context.Background(), "k", "v")
+					if !assert.NoErrorf(t, err,
+						"Put() error = %v", err) {
+						return
+					}
 				}
-				if err := store.Delete(context.Background(), "k"); err != nil {
-					t.Fatalf("Delete() error = %v", err)
+				{
+
+					err := store.Delete(context.Background(), "k")
+					if !assert.NoErrorf(t, err,
+						"Delete() error = %v", err) {
+						return
+					}
 				}
-				if value, ok, err := store.Get(context.Background(), "k"); err != nil || ok || value != "" {
-					t.Fatalf("Get() after delete = (%q, %t, %v), want (\"\", false, nil)", value, ok, err)
+				{
+
+					value, ok, err := store.Get(context.Background(), "k")
+					if !assert.Falsef(t, err != nil || ok || value != "",
+						"Get() after delete = (%q, %t, %v), want (\"\", false, nil)", value, ok, err) {
+						return
+					}
 				}
+
 			},
 		},
 	}
@@ -119,9 +157,11 @@ func TestStoreKeys(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.got != tt.want {
-				t.Fatalf("key = %q, want %q", tt.got, tt.want)
+			if !assert.Equalf(t, tt.want, tt.got,
+				"key = %q, want %q", tt.got, tt.want) {
+				return
 			}
+
 		})
 	}
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
@@ -703,10 +704,8 @@ func waitForRPC(t *testing.T, ctx context.Context, rpc tempo.RPCClient) uint64 {
 		}
 		time.Sleep(rpcReadinessPollInterval)
 	}
-	assert.Failf(t, "", "Tempo RPC at %s did not become ready before timeout; start the local devnet with `docker compose up -d` in mpp-go or set TEMPO_RPC_URL", integrationRPCURL(t))
+	require.Failf(t, "", "Tempo RPC at %s did not become ready before timeout; start the local devnet with `docker compose up -d` in mpp-go or set TEMPO_RPC_URL", integrationRPCURL(t))
 	return *new(uint64)
-
-	return 0
 }
 
 func fundAddress(t *testing.T, ctx context.Context, rpc tempo.RPCClient, address common.Address) {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
 	mppclient "github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
@@ -90,8 +91,9 @@ func TestIntegrationChargeFlow_LocalNode(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -100,53 +102,69 @@ func TestIntegrationChargeFlow_LocalNode(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	defer response.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, response.StatusCode,
+		"status = %d, want %d", response.StatusCode, http.StatusOK) {
+		return
 	}
+
 	receiptHeader := response.Header.Get("Payment-Receipt")
-	if receiptHeader == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", receiptHeader,
+		"Payment-Receipt header missing") {
+		return
 	}
+
 	receipt, err := mpp.ParsePaymentReceipt(receiptHeader)
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Status != "success" {
-		t.Fatalf("receipt.Status = %q, want success", receipt.Status)
+	if !assert.Equalf(t, "success", receipt.Status,
+		"receipt.Status = %q, want success", receipt.Status) {
+		return
 	}
-	if receipt.Method != tempo.MethodName {
-		t.Fatalf("receipt.Method = %q, want %q", receipt.Method, tempo.MethodName)
+	if !assert.Equalf(t, tempo.MethodName, receipt.Method,
+		"receipt.Method = %q, want %q", receipt.Method, tempo.MethodName) {
+		return
 	}
-	if receipt.Reference == "" {
-		t.Fatal("receipt.Reference is empty")
+	if !assert.NotEqual(t, "", receipt.Reference,
+		"receipt.Reference is empty") {
+		return
 	}
 
 	var body struct {
 		Payer string `json:"payer"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
-		t.Fatalf("Decode(response.Body) error = %v", err)
+		assert.Failf(t, "", "Decode(response.Body) error = %v", err)
+		return
 	}
-	if body.Payer == "" {
-		t.Fatal("response payer is empty")
+	if !assert.NotEqual(t, "", body.Payer,
+		"response payer is empty") {
+		return
 	}
 
 	authorization := transport.Authorization()
-	if authorization == "" {
-		t.Fatal("retry authorization header missing")
+	if !assert.NotEqual(t, "", authorization,
+		"retry authorization header missing") {
+		return
 	}
+
 	credential, err := mpp.ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
-	if credential.Payload["type"] != string(tempo.CredentialTypeTransaction) {
-		t.Fatalf("credential payload type = %#v, want transaction", credential.Payload["type"])
+	if !assert.Equalf(t, string(tempo.CredentialTypeTransaction), credential.Payload["type"],
+		"credential payload type = %#v, want transaction", credential.Payload["type"]) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_LocalNodeFeePayer(t *testing.T) {
@@ -167,8 +185,9 @@ func TestIntegrationChargeFlow_LocalNodeFeePayer(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -177,33 +196,43 @@ func TestIntegrationChargeFlow_LocalNodeFeePayer(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-fee-payer")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	defer response.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, response.StatusCode,
+		"status = %d, want %d", response.StatusCode, http.StatusOK) {
+		return
 	}
-	if response.Header.Get("Payment-Receipt") == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", response.Header.Get("Payment-Receipt"),
+		"Payment-Receipt header missing") {
+		return
 	}
 
 	authorization := transport.Authorization()
-	if authorization == "" {
-		t.Fatal("retry authorization header missing")
+	if !assert.NotEqual(t, "", authorization,
+		"retry authorization header missing") {
+		return
 	}
+
 	credential, err := mpp.ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
-	if credential.Payload["type"] != string(tempo.CredentialTypeTransaction) {
-		t.Fatalf("credential payload type = %#v, want transaction", credential.Payload["type"])
+	if !assert.Equalf(t, string(tempo.CredentialTypeTransaction), credential.Payload["type"],
+		"credential payload type = %#v, want transaction", credential.Payload["type"]) {
+		return
 	}
+
 	signature, _ := credential.Payload["signature"].(string)
-	if !strings.Contains(signature, "feefeefeefee") {
-		t.Fatalf("expected fee payer marker in credential payload, got %q", signature)
+	if !assert.Containsf(t, signature, "feefeefeefee",
+		"expected fee payer marker in credential payload, got %q", signature) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_LocalNodeHashReplayProtected(t *testing.T) {
@@ -223,8 +252,9 @@ func TestIntegrationChargeFlow_LocalNodeHashReplayProtected(t *testing.T) {
 		ChainID:        int64(chainID),
 		CredentialType: tempo.CredentialTypeHash,
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -233,54 +263,71 @@ func TestIntegrationChargeFlow_LocalNodeHashReplayProtected(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-hash")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	defer response.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, response.StatusCode,
+		"status = %d, want %d", response.StatusCode, http.StatusOK) {
+		return
 	}
-	if response.Header.Get("Payment-Receipt") == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", response.Header.Get("Payment-Receipt"),
+		"Payment-Receipt header missing") {
+		return
 	}
 
 	authorization := transport.Authorization()
-	if authorization == "" {
-		t.Fatal("retry authorization header missing")
+	if !assert.NotEqual(t, "", authorization,
+		"retry authorization header missing") {
+		return
 	}
+
 	credential, err := mpp.ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
-	if credential.Payload["type"] != string(tempo.CredentialTypeHash) {
-		t.Fatalf("credential payload type = %#v, want hash", credential.Payload["type"])
+	if !assert.Equalf(t, string(tempo.CredentialTypeHash), credential.Payload["type"],
+		"credential payload type = %#v, want hash", credential.Payload["type"]) {
+		return
 	}
+
 	if hash, _ := credential.Payload["hash"].(string); hash == "" {
-		t.Fatal("hash credential payload is empty")
+		assert.Fail(t, "hash credential payload is empty")
+		return
 	}
 
 	replayRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/paid-hash", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewRequestWithContext() error = %v", err) {
+		return
 	}
+
 	replayRequest.Header.Set("Authorization", authorization)
 	replayResponse, err := http.DefaultClient.Do(replayRequest)
-	if err != nil {
-		t.Fatalf("replay request error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"replay request error = %v", err) {
+		return
 	}
-	defer replayResponse.Body.Close()
 
-	if replayResponse.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("replay status = %d, want %d", replayResponse.StatusCode, http.StatusPaymentRequired)
+	defer replayResponse.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, replayResponse.StatusCode,
+		"replay status = %d, want %d", replayResponse.StatusCode, http.StatusPaymentRequired) {
+		return
 	}
+
 	body, err := io.ReadAll(replayResponse.Body)
-	if err != nil {
-		t.Fatalf("ReadAll(replayResponse.Body) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ReadAll(replayResponse.Body) error = %v", err) {
+		return
 	}
-	if !strings.Contains(string(body), "already used") {
-		t.Fatalf("replay response body = %q, want replay protection error", string(body))
+	if !assert.Containsf(t, string(body), "already used",
+		"replay response body = %q, want replay protection error", string(body)) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_HashCredentialRequiresSource(t *testing.T) {
@@ -300,8 +347,9 @@ func TestIntegrationChargeFlow_HashCredentialRequiresSource(t *testing.T) {
 		ChainID:        int64(chainID),
 		CredentialType: tempo.CredentialTypeHash,
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -310,43 +358,54 @@ func TestIntegrationChargeFlow_HashCredentialRequiresSource(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-hash")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	defer response.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, response.StatusCode,
+		"status = %d, want %d", response.StatusCode, http.StatusOK) {
+		return
 	}
 
 	authorization := transport.Authorization()
 	credential, err := mpp.ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
 
 	credential.Source = ""
 	replayRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/paid-hash", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewRequestWithContext() error = %v", err) {
+		return
 	}
+
 	replayRequest.Header.Set("Authorization", credential.ToAuthorization())
 	replayResponse, err := http.DefaultClient.Do(replayRequest)
-	if err != nil {
-		t.Fatalf("sourceless request error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"sourceless request error = %v", err) {
+		return
 	}
-	defer replayResponse.Body.Close()
 
-	if replayResponse.StatusCode == http.StatusOK {
-		t.Fatal("expected hash credential without source to be rejected")
+	defer replayResponse.Body.Close()
+	if !assert.NotEqual(t, http.StatusOK, replayResponse.StatusCode,
+		"expected hash credential without source to be rejected") {
+		return
 	}
+
 	body, err := io.ReadAll(replayResponse.Body)
-	if err != nil {
-		t.Fatalf("ReadAll(replayResponse.Body) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ReadAll(replayResponse.Body) error = %v", err) {
+		return
 	}
-	if !strings.Contains(string(body), "source") {
-		t.Fatalf("response body = %q, want source-related error", string(body))
+	if !assert.Containsf(t, string(body), "source",
+		"response body = %q, want source-related error", string(body)) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_ProofCredentialZeroAmount(t *testing.T) {
@@ -364,8 +423,9 @@ func TestIntegrationChargeFlow_ProofCredentialZeroAmount(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -374,35 +434,45 @@ func TestIntegrationChargeFlow_ProofCredentialZeroAmount(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-proof")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
+
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		assert.Failf(t, "", "status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		return
 	}
 	receiptHeader := response.Header.Get("Payment-Receipt")
-	if receiptHeader == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", receiptHeader,
+		"Payment-Receipt header missing") {
+		return
 	}
+
 	receipt, err := mpp.ParsePaymentReceipt(receiptHeader)
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Status != "success" {
-		t.Fatalf("receipt.Status = %q, want success", receipt.Status)
+	if !assert.Equalf(t, "success", receipt.Status,
+		"receipt.Status = %q, want success", receipt.Status) {
+		return
 	}
 
 	authorization := transport.Authorization()
 	credential, err := mpp.ParseCredential(authorization)
-	if err != nil {
-		t.Fatalf("ParseCredential() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseCredential() error = %v", err) {
+		return
 	}
-	if credential.Payload["type"] != string(tempo.CredentialTypeProof) {
-		t.Fatalf("credential payload type = %#v, want proof", credential.Payload["type"])
+	if !assert.Equalf(t, string(tempo.CredentialTypeProof), credential.Payload["type"],
+		"credential payload type = %#v, want proof", credential.Payload["type"]) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_ProofCredentialReplayProtected(t *testing.T) {
@@ -420,8 +490,9 @@ func TestIntegrationChargeFlow_ProofCredentialReplayProtected(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -430,41 +501,52 @@ func TestIntegrationChargeFlow_ProofCredentialReplayProtected(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-proof")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	defer response.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, response.StatusCode,
+		"status = %d, want %d", response.StatusCode, http.StatusOK) {
+		return
 	}
 
 	authorization := transport.Authorization()
-	if authorization == "" {
-		t.Fatal("retry authorization header missing")
+	if !assert.NotEqual(t, "", authorization,
+		"retry authorization header missing") {
+		return
 	}
 
 	replayRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/paid-proof", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewRequestWithContext() error = %v", err) {
+		return
 	}
+
 	replayRequest.Header.Set("Authorization", authorization)
 	replayResponse, err := http.DefaultClient.Do(replayRequest)
-	if err != nil {
-		t.Fatalf("replay request error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"replay request error = %v", err) {
+		return
 	}
-	defer replayResponse.Body.Close()
 
-	if replayResponse.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("replay status = %d, want %d", replayResponse.StatusCode, http.StatusPaymentRequired)
+	defer replayResponse.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, replayResponse.StatusCode,
+		"replay status = %d, want %d", replayResponse.StatusCode, http.StatusPaymentRequired) {
+		return
 	}
+
 	body, err := io.ReadAll(replayResponse.Body)
-	if err != nil {
-		t.Fatalf("ReadAll(replayResponse.Body) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ReadAll(replayResponse.Body) error = %v", err) {
+		return
 	}
-	if !strings.Contains(string(body), "already used") {
-		t.Fatalf("replay response body = %q, want replay protection error", string(body))
+	if !assert.Containsf(t, string(body), "already used",
+		"replay response body = %q, want replay protection error", string(body)) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_TransactionCredentialWithSplits(t *testing.T) {
@@ -483,8 +565,9 @@ func TestIntegrationChargeFlow_TransactionCredentialWithSplits(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -493,39 +576,50 @@ func TestIntegrationChargeFlow_TransactionCredentialWithSplits(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-splits")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
+
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		assert.Failf(t, "", "status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		return
 	}
 	receiptHeader := response.Header.Get("Payment-Receipt")
-	if receiptHeader == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", receiptHeader,
+		"Payment-Receipt header missing") {
+		return
 	}
+
 	receipt, err := mpp.ParsePaymentReceipt(receiptHeader)
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.Status != "success" {
-		t.Fatalf("receipt.Status = %q, want success", receipt.Status)
+	if !assert.Equalf(t, "success", receipt.Status,
+		"receipt.Status = %q, want success", receipt.Status) {
+		return
 	}
-	if receipt.Reference == "" {
-		t.Fatal("receipt.Reference is empty")
+	if !assert.NotEqual(t, "", receipt.Reference,
+		"receipt.Reference is empty") {
+		return
 	}
 
 	var body struct {
 		ExternalID string `json:"externalId"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
-		t.Fatalf("Decode(response.Body) error = %v", err)
+		assert.Failf(t, "", "Decode(response.Body) error = %v", err)
+		return
 	}
-	if body.ExternalID != "ext-splits-123" {
-		t.Fatalf("externalId = %q, want ext-splits-123", body.ExternalID)
+	if !assert.Equalf(t, "ext-splits-123", body.ExternalID,
+		"externalId = %q, want ext-splits-123", body.ExternalID) {
+		return
 	}
+
 }
 
 func TestIntegrationChargeFlow_ReceiptPropagatesExternalID(t *testing.T) {
@@ -544,8 +638,9 @@ func TestIntegrationChargeFlow_ReceiptPropagatesExternalID(t *testing.T) {
 		RPCURL:  rpcURL,
 		ChainID: int64(chainID),
 	})
-	if err != nil {
-		t.Fatalf("tempo/client.New() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"tempo/client.New() error = %v", err) {
+		return
 	}
 
 	transport := &captureTransport{inner: http.DefaultTransport}
@@ -554,29 +649,38 @@ func TestIntegrationChargeFlow_ReceiptPropagatesExternalID(t *testing.T) {
 		mppclient.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	response, err := client.Get(ctx, server.URL+"/paid-external-id")
-	if err != nil {
-		t.Fatalf("client.Get() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"client.Get() error = %v", err) {
+		return
 	}
+
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		assert.Failf(t, "", "status = %d, want %d, body = %s", response.StatusCode, http.StatusOK, body)
+		return
 	}
 	receiptHeader := response.Header.Get("Payment-Receipt")
-	if receiptHeader == "" {
-		t.Fatal("Payment-Receipt header missing")
+	if !assert.NotEqual(t, "", receiptHeader,
+		"Payment-Receipt header missing") {
+		return
 	}
+
 	receipt, err := mpp.ParsePaymentReceipt(receiptHeader)
-	if err != nil {
-		t.Fatalf("ParsePaymentReceipt() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParsePaymentReceipt() error = %v", err) {
+		return
 	}
-	if receipt.ExternalID != "ext-integration-123" {
-		t.Fatalf("receipt.ExternalID = %q, want ext-integration-123", receipt.ExternalID)
+	if !assert.Equalf(t, "ext-integration-123", receipt.ExternalID,
+		"receipt.ExternalID = %q, want ext-integration-123", receipt.ExternalID) {
+		return
 	}
-	if receipt.Reference == "" {
-		t.Fatal("receipt.Reference is empty")
+	if !assert.NotEqual(t, "", receipt.Reference,
+		"receipt.Reference is empty") {
+		return
 	}
+
 }
 
 func integrationRPCURL(t *testing.T) string {
@@ -599,7 +703,9 @@ func waitForRPC(t *testing.T, ctx context.Context, rpc tempo.RPCClient) uint64 {
 		}
 		time.Sleep(rpcReadinessPollInterval)
 	}
-	t.Fatalf("Tempo RPC at %s did not become ready before timeout; start the local devnet with `docker compose up -d` in mpp-go or set TEMPO_RPC_URL", integrationRPCURL(t))
+	assert.Failf(t, "", "Tempo RPC at %s did not become ready before timeout; start the local devnet with `docker compose up -d` in mpp-go or set TEMPO_RPC_URL", integrationRPCURL(t))
+	return *new(uint64)
+
 	return 0
 }
 
@@ -630,18 +736,24 @@ func fundAddress(t *testing.T, ctx context.Context, rpc tempo.RPCClient, address
 	}
 
 	devSigner, err := temposigner.NewSigner(integrationDevPrivateKey)
-	if err != nil {
-		t.Fatalf("NewSigner(dev key) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewSigner(dev key) error = %v", err) {
+		return
 	}
+
 	chainID, err := rpc.GetChainID(ctx)
-	if err != nil {
-		t.Fatalf("GetChainID(funding tx) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"GetChainID(funding tx) error = %v", err) {
+		return
 	}
+
 	gasPrice := mustGasPrice(t, ctx, rpc)
 	nonce, err := rpc.GetTransactionCount(ctx, devSigner.Address().Hex())
-	if err != nil {
-		t.Fatalf("GetTransactionCount(dev signer) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"GetTransactionCount(dev signer) error = %v", err) {
+		return
 	}
+
 	transferData := common.FromHex(tempo.EncodeTransfer(address.Hex(), integrationFundingAmount))
 	gasLimit := mustEstimateGas(t, ctx, rpc, devSigner.Address(), common.HexToAddress(integrationCurrency), transferData)
 	tx, err := tempotx.NewBuilder(new(big.Int).SetUint64(chainID)).
@@ -653,20 +765,27 @@ func fundAddress(t *testing.T, ctx context.Context, rpc tempo.RPCClient, address
 		SetFeeToken(common.HexToAddress(integrationCurrency)).
 		AddCall(common.HexToAddress(integrationCurrency), big.NewInt(0), transferData).
 		BuildAndValidate()
-	if err != nil {
-		t.Fatalf("BuildAndValidate(funding tx) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"BuildAndValidate(funding tx) error = %v", err) {
+		return
 	}
+
 	if err := tempotx.SignTransaction(tx, devSigner); err != nil {
-		t.Fatalf("SignTransaction(funding tx) error = %v", err)
+		assert.Failf(t, "", "SignTransaction(funding tx) error = %v", err)
+		return
 	}
 	serialized, err := tempotx.Serialize(tx, nil)
-	if err != nil {
-		t.Fatalf("Serialize(funding tx) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"Serialize(funding tx) error = %v", err) {
+		return
 	}
+
 	hash, err := rpc.SendRawTransaction(ctx, serialized)
-	if err != nil {
-		t.Fatalf("SendRawTransaction(funding tx) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"SendRawTransaction(funding tx) error = %v", err) {
+		return
 	}
+
 	waitForReceipt(t, ctx, rpc, hash)
 	waitForTokenBalance(t, ctx, rpc, address, integrationFundingAmount)
 }
@@ -675,20 +794,28 @@ func mustGasPrice(t *testing.T, ctx context.Context, rpc tempo.RPCClient) *big.I
 	t.Helper()
 
 	response, err := rpc.SendRequest(ctx, "eth_gasPrice")
-	if err != nil {
-		t.Fatalf("eth_gasPrice error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"eth_gasPrice error = %v", err) {
+		return *new(*big.Int)
 	}
+
 	if err := response.CheckError(); err != nil {
-		t.Fatalf("eth_gasPrice rpc error = %v", err)
+		assert.Failf(t, "", "eth_gasPrice rpc error = %v", err)
+		return *new(*big.Int)
+
 	}
 	value, ok := response.Result.(string)
-	if !ok {
-		t.Fatalf("eth_gasPrice result type = %T, want string", response.Result)
+	if !assert.Truef(t, ok,
+		"eth_gasPrice result type = %T, want string", response.Result) {
+		return *new(*big.Int)
 	}
+
 	parsed, err := tempo.ParseHexBigInt(value)
-	if err != nil {
-		t.Fatalf("ParseHexBigInt(eth_gasPrice) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseHexBigInt(eth_gasPrice) error = %v", err) {
+		return *new(*big.Int)
 	}
+
 	return parsed
 }
 
@@ -700,20 +827,28 @@ func mustEstimateGas(t *testing.T, ctx context.Context, rpc tempo.RPCClient, fro
 		"to":   to.Hex(),
 		"data": common.Bytes2Hex(data),
 	})
-	if err != nil {
-		t.Fatalf("eth_estimateGas error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"eth_estimateGas error = %v", err) {
+		return *new(uint64)
 	}
+
 	if err := response.CheckError(); err != nil {
-		t.Fatalf("eth_estimateGas rpc error = %v", err)
+		assert.Failf(t, "", "eth_estimateGas rpc error = %v", err)
+		return *new(uint64)
+
 	}
 	value, ok := response.Result.(string)
-	if !ok {
-		t.Fatalf("eth_estimateGas result type = %T, want string", response.Result)
+	if !assert.Truef(t, ok,
+		"eth_estimateGas result type = %T, want string", response.Result) {
+		return *new(uint64)
 	}
+
 	estimated, err := tempo.ParseHexUint64(value)
-	if err != nil {
-		t.Fatalf("ParseHexUint64(eth_estimateGas) error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"ParseHexUint64(eth_estimateGas) error = %v", err) {
+		return *new(uint64)
 	}
+
 	return estimated + 5_000
 }
 
@@ -728,7 +863,8 @@ func waitForTokenBalance(t *testing.T, ctx context.Context, rpc tempo.RPCClient,
 		}
 		time.Sleep(receiptPollingInterval)
 	}
-	t.Fatalf("token balance for %s did not reach %s", address.Hex(), minimum.String())
+	assert.Failf(t, "", "token balance for %s did not reach %s", address.Hex(), minimum.String())
+	return
 }
 
 func tokenBalanceOf(ctx context.Context, rpc tempo.RPCClient, address common.Address) (*big.Int, error) {
@@ -762,25 +898,31 @@ func waitForReceipt(t *testing.T, ctx context.Context, rpc tempo.RPCClient, hash
 		if err == nil {
 			if err := response.CheckError(); err == nil {
 				if receipt, ok := response.Result.(map[string]any); ok && len(receipt) > 0 {
-					if receipt["status"] != "0x1" {
-						t.Fatalf("receipt status for %s = %#v, want 0x1", hash, receipt["status"])
+					if !assert.Equalf(t, "0x1", receipt["status"],
+						"receipt status for %s = %#v, want 0x1", hash, receipt["status"]) {
+						return *new(map[string]any)
 					}
+
 					return receipt
 				}
 			}
 		}
 		time.Sleep(receiptPollingInterval)
 	}
-	t.Fatalf("transaction receipt not found for %s", hash)
+	assert.Failf(t, "", "transaction receipt not found for %s", hash)
+	return *new(map[string]any)
+
 	return nil
 }
 
 func newSigner(t *testing.T) *temposigner.Signer {
 	t.Helper()
 	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatalf("GenerateKey() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"GenerateKey() error = %v", err) {
+		return *new(*temposigner.Signer)
 	}
+
 	return temposigner.NewSignerFromKey(privateKey)
 }
 
@@ -791,8 +933,9 @@ func newPaidServer(t *testing.T, rpcURL string, chainID uint64, feePayerSigner *
 		RPCURL:         rpcURL,
 		FeePayerSigner: feePayerSigner,
 	})
-	if err != nil {
-		t.Fatalf("NewIntent() error = %v", err)
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return *new(*httptest.Server)
 	}
 
 	basicMethod := chargeserver.NewMethod(chargeserver.MethodConfig{


### PR DESCRIPTION
## Summary

- Convert Go tests across mpp-go packages to use testify assertions
- Update newly rebased test coverage to follow the same assertion style
