### PR TITLE
ci: support package changelog release notes

### DIFF
--- a/.changelog/reject-crlf-authenticate-format.md
+++ b/.changelog/reject-crlf-authenticate-format.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject CR/LF in `WWW-Authenticate` challenge formatting and built-in server challenge responses.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,21 @@ jobs:
         id: changelog
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          MODULE=$(awk '$1 == "module" { print $2; exit }' go.mod)
+          NOTES=$(awk -v version="$VERSION" -v module="$MODULE" '
+            /^## / {
+              if (found) exit
+              if ($0 ~ "^## \\[" version "\\]([[:space:]]|$)") {
+                found = 1
+                next
+              }
+              if (module != "" && ($0 == "## `" module "@" version "`" || $0 == "## " module "@" version)) {
+                found = 1
+                next
+              }
+            }
+            found { print }
+          ' CHANGELOG.md)
           echo "notes<<EOF" >> "$GITHUB_OUTPUT"
           echo "$NOTES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## `github.com/tempoxyz/mpp-go@0.1.2`
-
-### Patch Changes
-
-- Reject CR/LF in `WWW-Authenticate` challenge formatting and built-in server challenge responses. (by @EmmaJamieson-Hoare, [#46](https://github.com/tempoxyz/mpp-go/pull/46))
-
 ## `github.com/tempoxyz/mpp-go@0.1.1`
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

- Teach the tag release workflow to extract notes from package-style changelog headings.
- Move the CRLF fix note into a proper `.changelog` patch fragment.
- Remove the hand-written unreleased `0.1.2` changelog section so the changelogs release path can generate it.