### PR TITLE
Add strict method ID rejection vectors

### DIFF
--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -2,11 +2,12 @@ package mpp
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPaymentErrorConstructors(t *testing.T) {
@@ -202,72 +203,29 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",
 	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt status"),
-		"ParseReceipt() error = %v, want invalid status error", err) {
-		return
-	}
+	require.ErrorContains(t, err, "invalid receipt status")
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
 		"status": "success",
 	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "receipt missing reference"),
-		"ParseReceipt() error = %v, want missing reference error", err) {
-		return
-	}
+	require.ErrorContains(t, err, "receipt missing reference")
 
-	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status":    "success",
-		"method":    "Tempo",
-		"timestamp": "2026-01-01T00:00:00Z",
-		"reference": "ref-123",
-	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
-		"ParseReceipt() error = %v, want invalid method error", err) {
-		return
-	}
-
-	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status":    "success",
-		"method":    "tempo2",
-		"timestamp": "2026-01-01T00:00:00Z",
-		"reference": "ref-123",
-	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
-		"ParseReceipt() error = %v, want invalid method error", err) {
-		return
-	}
-
-	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status":    "success",
-		"method":    "tempo-pay",
-		"timestamp": "2026-01-01T00:00:00Z",
-		"reference": "ref-123",
-	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
-		"ParseReceipt() error = %v, want invalid method error", err) {
-		return
-	}
-
-	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status":    "success",
-		"method":    "tempo_pay",
-		"timestamp": "2026-01-01T00:00:00Z",
-		"reference": "ref-123",
-	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
-		"ParseReceipt() error = %v, want invalid method error", err) {
-		return
-	}
-
-	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status":    "success",
-		"method":    "tempo.pay",
-		"timestamp": "2026-01-01T00:00:00Z",
-		"reference": "ref-123",
-	}))
-	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
-		"ParseReceipt() error = %v, want invalid method error", err) {
-		return
+	for _, method := range []string{
+		"Tempo",
+		"tempo2",
+		"tempo-pay",
+		"tempo_pay",
+		"tempo.pay",
+	} {
+		t.Run(method, func(t *testing.T) {
+			_, err := ParseReceipt(b64EncodeAny(map[string]any{
+				"status":    "success",
+				"method":    method,
+				"timestamp": "2026-01-01T00:00:00Z",
+				"reference": "ref-123",
+			}))
+			require.ErrorContains(t, err, "invalid receipt method")
+		})
 	}
 
 }

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -239,6 +239,28 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
 		"status":    "success",
+		"method":    "tempo-pay",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
+		"ParseReceipt() error = %v, want invalid method error", err) {
+		return
+	}
+
+	_, err = ParseReceipt(b64EncodeAny(map[string]any{
+		"status":    "success",
+		"method":    "tempo_pay",
+		"timestamp": "2026-01-01T00:00:00Z",
+		"reference": "ref-123",
+	}))
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "invalid receipt method"),
+		"ParseReceipt() error = %v, want invalid method error", err) {
+		return
+	}
+
+	_, err = ParseReceipt(b64EncodeAny(map[string]any{
+		"status":    "success",
 		"method":    "tempo.pay",
 		"timestamp": "2026-01-01T00:00:00Z",
 		"reference": "ref-123",

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -307,6 +307,16 @@ func TestParseChallenge(t *testing.T) {
 			wantErr: `invalid challenge method`,
 		},
 		{
+			name:    "invalid underscore method",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo_pay", intent="charge", request="e30"`,
+			wantErr: `invalid challenge method`,
+		},
+		{
+			name:    "invalid dotted method",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo.pay", intent="charge", request="e30"`,
+			wantErr: `invalid challenge method`,
+		},
+		{
 			name:    "duplicate auth params",
 			header:  `Payment id="abc", realm="api.example.com", method="tempo", intent="charge", intent="session", request="e30"`,
 			wantErr: `duplicate auth-param`,
@@ -440,6 +450,16 @@ func TestParseCredential(t *testing.T) {
 		{
 			name:    "invalid punctuated method",
 			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo-pay", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
+			wantErr: `invalid credential challenge method`,
+		},
+		{
+			name:    "invalid underscore method",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo_pay", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
+			wantErr: `invalid credential challenge method`,
+		},
+		{
+			name:    "invalid dotted method",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo.pay", "intent": "charge", "request": "e30"}, "payload": map[string]any{}}),
 			wantErr: `invalid credential challenge method`,
 		},
 		{


### PR DESCRIPTION
## Summary
- Add missing strict method ID rejection vectors for `WWW-Authenticate` challenge parsing
- Add matching `Authorization` challenge echo rejection vectors
- Extend `Payment-Receipt` invalid method coverage to include dash and underscore cases

## Verification
- `mise exec go@1.26.3 -- gofmt -w pkg/mpp/parse_test.go pkg/mpp/errors_receipt_test.go`
- `mise exec go@1.26.3 -- go test ./pkg/mpp`