### PR TITLE
feat: add server body digest and route scope conformance

### DIFF
--- a/.changelog/server-body-digest-route-scope.md
+++ b/.changelog/server-body-digest-route-scope.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Bind server charge challenges to request bodies and framework route scope.

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -19,9 +19,8 @@ type ComposeConfig struct {
 
 // composedEntry is a frozen, pre-resolved config entry used at request time.
 type composedEntry struct {
-	mpp     *Mpp
-	params  ChargeParams
-	request map[string]any
+	mpp    *Mpp
+	params ChargeParams
 }
 
 // ComposeMiddleware creates an http.Handler middleware that supports multiple
@@ -51,14 +50,12 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 		if cfg.Mpp.realm != realm {
 			panic(fmt.Sprintf("server: ComposeConfig[%d] realm %q differs from [0] realm %q", i, cfg.Mpp.realm, realm))
 		}
-		request, err := cfg.Mpp.buildChargeRequest(cfg.Params)
-		if err != nil {
+		if _, err := cfg.Mpp.buildChargeRequest(cfg.Params); err != nil {
 			panic(fmt.Sprintf("server: ComposeConfig[%d] buildChargeRequest: %v", i, err))
 		}
 		entries[i] = composedEntry{
-			mpp:     cfg.Mpp,
-			params:  cfg.Params,
-			request: request,
+			mpp:    cfg.Mpp,
+			params: cfg.Params,
 		}
 	}
 
@@ -71,10 +68,11 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 				WritePaymentError(w, mpp.ErrBadRequest("failed to read request body"))
 				return
 			}
+			scope := ScopeFromHTTPRequest(r, "")
 
 			// No credential — fan out and merge all challenges.
 			if paymentAuth == "" {
-				composeChallenges(w, r, entries, realm, body)
+				composeChallenges(w, r, entries, realm, body, scope)
 				return
 			}
 
@@ -85,7 +83,7 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 				return
 			}
 
-			entry, ok, err := findMatchingEntry(entries, cred)
+			entry, ok, err := findMatchingEntry(entries, cred, scope)
 			if err != nil {
 				WritePaymentError(w, err)
 				return
@@ -97,6 +95,9 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 			params := entry.params
 			params.Authorization = paymentAuth
+			if len(scope) > 0 {
+				params.MppxScope = scope
+			}
 			if len(body) > 0 {
 				params.Body = body
 			}
@@ -118,11 +119,14 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 // composeChallenges issues a 402 with all configured challenges merged into
 // separate WWW-Authenticate header values.
-func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string, body []byte) {
+func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string, body []byte, scope map[string]string) {
 	var challenges []*mpp.Challenge
 	for _, entry := range entries {
 		params := entry.params
 		params.Authorization = ""
+		if len(scope) > 0 {
+			params.MppxScope = scope
+		}
 		if len(body) > 0 {
 			params.Body = body
 		}
@@ -166,7 +170,7 @@ func composeChallenges(w http.ResponseWriter, r *http.Request, entries []compose
 // findMatchingEntry selects the entry whose method, intent, and canonical
 // request match the credential. This allows multiple entries with the same
 // method+intent but different amounts, currencies, or opaque metadata.
-func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool, error) {
+func findMatchingEntry(entries []composedEntry, cred *mpp.Credential, scope map[string]string) (composedEntry, bool, error) {
 	echoedRequest, err := echoedRequestMap(cred)
 	if err != nil {
 		return composedEntry{}, false, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
@@ -181,7 +185,11 @@ func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedE
 		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
 			continue
 		}
-		if mpp.JSONEqual(echoedRequest, entry.request) && reflect.DeepEqual(cred.Challenge.Opaque, entry.params.Meta) {
+		request, err := entry.scopedRequest(scope)
+		if err != nil {
+			return composedEntry{}, false, err
+		}
+		if mpp.JSONEqual(echoedRequest, request) && reflect.DeepEqual(cred.Challenge.Opaque, entry.params.Meta) {
 			return entry, true, nil
 		}
 	}
@@ -199,4 +207,12 @@ func findMatchingEntry(entries []composedEntry, cred *mpp.Credential) (composedE
 	}
 
 	return composedEntry{}, false, nil
+}
+
+func (entry composedEntry) scopedRequest(scope map[string]string) (map[string]any, error) {
+	params := entry.params
+	if len(scope) > 0 {
+		params.MppxScope = scope
+	}
+	return entry.mpp.buildChargeRequest(params)
 }

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -66,10 +66,15 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auth := r.Header.Get("Authorization")
 			paymentAuth := mpp.FindPaymentAuthorization(auth)
+			body, err := ReadRequestBody(r)
+			if err != nil {
+				WritePaymentError(w, mpp.ErrBadRequest("failed to read request body"))
+				return
+			}
 
 			// No credential — fan out and merge all challenges.
 			if paymentAuth == "" {
-				composeChallenges(w, r, entries, realm)
+				composeChallenges(w, r, entries, realm, body)
 				return
 			}
 
@@ -92,6 +97,9 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 			params := entry.params
 			params.Authorization = paymentAuth
+			if len(body) > 0 {
+				params.Body = body
+			}
 
 			result, err := entry.mpp.Charge(r.Context(), params)
 			if err != nil {
@@ -110,11 +118,14 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 // composeChallenges issues a 402 with all configured challenges merged into
 // separate WWW-Authenticate header values.
-func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string) {
+func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string, body []byte) {
 	var challenges []*mpp.Challenge
 	for _, entry := range entries {
 		params := entry.params
 		params.Authorization = ""
+		if len(body) > 0 {
+			params.Body = body
+		}
 
 		result, err := entry.mpp.Charge(r.Context(), params)
 		if err != nil {

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,6 +111,29 @@ func payWith(t *testing.T, url string, challenge *mpp.Challenge) *http.Response 
 	return resp
 }
 
+func payWithBody(t *testing.T, url string, challenge *mpp.Challenge, body string) *http.Response {
+	t.Helper()
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mktest",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return *new(*http.Response)
+	}
+
+	req.Header.Set("Authorization", credential.ToAuthorization())
+	resp, err := http.DefaultClient.Do(req)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return *new(*http.Response)
+	}
+
+	return resp
+}
+
 // --- tests ---
 
 func TestComposeMiddleware_FansOutChallenges(t *testing.T) {
@@ -179,6 +203,62 @@ func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
 		return
 	}
 
+}
+
+func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	const originalBody = `{"query":"paid"}`
+	challengeReq, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(originalBody))
+	require.NoError(t, err)
+	challengeResp, err := http.DefaultClient.Do(challengeReq)
+	require.NoError(t, err)
+	defer challengeResp.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResp.StatusCode)
+
+	betaChallenge := findChallenge(t, challengeResp, "beta")
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), betaChallenge.Digest)
+
+	paid := payWithBody(t, srv.URL, betaChallenge, `{"query":"tampered"}`)
+	defer paid.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, paid.StatusCode)
+}
+
+func TestComposeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	handler := ComposeMiddleware(ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_, _ = io.WriteString(w, string(body))
+		}),
+	)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	const originalBody = `{"query":"paid"}`
+	challengeReq, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(originalBody))
+	require.NoError(t, err)
+	challengeResp, err := http.DefaultClient.Do(challengeReq)
+	require.NoError(t, err)
+	defer challengeResp.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResp.StatusCode)
+
+	challenge := findChallenge(t, challengeResp, "alpha")
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), challenge.Digest)
+
+	paid := payWithBody(t, srv.URL, challenge, originalBody)
+	defer paid.Body.Close()
+	require.Equal(t, http.StatusOK, paid.StatusCode)
+	body, err := io.ReadAll(paid.Body)
+	require.NoError(t, err)
+	assert.Equal(t, originalBody, string(body))
 }
 
 func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -205,6 +205,28 @@ func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
 
 }
 
+func TestComposeMiddlewareAutoScopesResourceAndQuery(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL+"/cart/123?view=full")
+	challenge := findChallenge(t, resp, "alpha")
+	resp.Body.Close()
+
+	scope, ok := challenge.Request["_mppx_scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/cart/123", scope["resource"])
+	assert.Equal(t, "view=full", scope["query"])
+
+	paid := payWith(t, srv.URL+"/cart/456?view=full", challenge)
+	defer paid.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, paid.StatusCode)
+}
+
 func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -31,6 +31,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 		return func(c echofw.Context) error {
 			chargeParams := params
 			chargeParams.Authorization = c.Request().Header.Get("Authorization")
+			chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request(), c.Path())
 			body, err := server.ReadRequestBody(c.Request())
 			if err != nil {
 				server.WritePaymentError(c.Response(), mpp.ErrBadRequest("failed to read request body"))

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -31,6 +31,14 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 		return func(c echofw.Context) error {
 			chargeParams := params
 			chargeParams.Authorization = c.Request().Header.Get("Authorization")
+			body, err := server.ReadRequestBody(c.Request())
+			if err != nil {
+				server.WritePaymentError(c.Response(), mpp.ErrBadRequest("failed to read request body"))
+				return nil
+			}
+			if len(body) > 0 {
+				chargeParams.Body = body
+			}
 
 			result, err := m.Charge(c.Request().Context(), chargeParams)
 			if err != nil {

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -119,6 +119,42 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
+	t.Parallel()
+
+	e := echofw.New()
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	e.GET("/paid/:id", func(c echofw.Context) error {
+		return c.String(http.StatusOK, "paid")
+	}, ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}))
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid/one?view=full", nil)
+	challengeResponse := httptest.NewRecorder()
+	e.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	scope, ok := challenge.Request["_mppx_scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/paid/:id", scope["route"])
+	assert.Equal(t, "/paid/one", scope["resource"])
+	assert.Equal(t, "view=full", scope["query"])
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid/two?view=full", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	e.ServeHTTP(paidResponse, paidRequest)
+
+	assert.NotEqual(t, http.StatusOK, paidResponse.Code)
+	assert.Empty(t, paidResponse.Header().Get("Payment-Receipt"))
+}
+
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -2,12 +2,15 @@ package echoadapter
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	echofw "github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 )
@@ -114,4 +117,69 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
 		return
 	}
+}
+
+func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
+	t.Parallel()
+
+	e := echofw.New()
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	e.POST("/paid", func(c echofw.Context) error {
+		_, _ = io.ReadAll(c.Request().Body)
+		return c.String(http.StatusOK, "paid")
+	}, ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}))
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse := httptest.NewRecorder()
+	e.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), challenge.Digest)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(`{"query":"tampered"}`))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	e.ServeHTTP(paidResponse, paidRequest)
+
+	assert.Equal(t, http.StatusBadRequest, paidResponse.Code)
+}
+
+func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
+	t.Parallel()
+
+	e := echofw.New()
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	e.POST("/paid", func(c echofw.Context) error {
+		body, _ := io.ReadAll(c.Request().Body)
+		return c.String(http.StatusOK, string(body))
+	}, ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}))
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse := httptest.NewRecorder()
+	e.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	e.ServeHTTP(paidResponse, paidRequest)
+
+	require.Equal(t, http.StatusOK, paidResponse.Code)
+	assert.Equal(t, originalBody, paidResponse.Body.String())
 }

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -32,6 +32,9 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 	return func(c *fiberfw.Ctx) error {
 		chargeParams := params
 		chargeParams.Authorization = c.Get("Authorization")
+		if body := c.Body(); len(body) > 0 {
+			chargeParams.Body = append([]byte(nil), body...)
+		}
 
 		result, err := m.Charge(c.UserContext(), chargeParams)
 		if err != nil {

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -32,6 +32,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 	return func(c *fiberfw.Ctx) error {
 		chargeParams := params
 		chargeParams.Authorization = c.Get("Authorization")
+		chargeParams.MppxScope = fiberScope(c)
 		if body := c.Body(); len(body) > 0 {
 			chargeParams.Body = append([]byte(nil), body...)
 		}
@@ -54,6 +55,23 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
 		return c.Next()
 	}
+}
+
+func fiberScope(c *fiberfw.Ctx) map[string]string {
+	scope := map[string]string{}
+	if route := c.Route(); route != nil && route.Path != "" {
+		scope["route"] = route.Path
+	}
+	if path := c.Path(); path != "" {
+		scope["resource"] = path
+	}
+	if query := string(c.Request().URI().QueryString()); query != "" {
+		scope["query"] = query
+	}
+	if len(scope) == 0 {
+		return nil
+	}
+	return scope
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	fiberfw "github.com/gofiber/fiber/v2"
@@ -114,6 +115,77 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		}
 	}
 
+}
+
+func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
+	t.Parallel()
+
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+
+	app.Post("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
+		return c.SendString("paid")
+	})
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse, err := app.Test(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), challenge.Digest)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(`{"query":"tampered"}`))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := app.Test(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
+}
+
+func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
+	t.Parallel()
+
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+
+	app.Post("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
+		return c.SendString(string(c.Body()))
+	})
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse, err := app.Test(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := app.Test(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	require.Equal(t, http.StatusOK, paidResponse.StatusCode)
+
+	body, err := io.ReadAll(paidResponse.Body)
+	require.NoError(t, err)
+	assert.Equal(t, originalBody, string(body))
 }
 
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -117,6 +117,44 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 
 }
 
+func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
+	t.Parallel()
+
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+	app.Get("/paid/:id", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
+		return c.SendString("paid")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid/one?view=full", nil)
+	challengeResponse, err := app.Test(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	scope, ok := challenge.Request["_mppx_scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/paid/:id", scope["route"])
+	assert.Equal(t, "/paid/one", scope["resource"])
+	assert.Equal(t, "view=full", scope["query"])
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid/two?view=full", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := app.Test(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+
+	assert.NotEqual(t, http.StatusOK, paidResponse.StatusCode)
+	assert.Empty(t, paidResponse.Header.Get("Payment-Receipt"))
+}
+
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -30,6 +30,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 	return func(c *ginfw.Context) {
 		chargeParams := params
 		chargeParams.Authorization = c.GetHeader("Authorization")
+		chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request, c.FullPath())
 		body, err := server.ReadRequestBody(c.Request)
 		if err != nil {
 			server.WritePaymentError(c.Writer, mpp.ErrBadRequest("failed to read request body"))

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -30,6 +30,15 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 	return func(c *ginfw.Context) {
 		chargeParams := params
 		chargeParams.Authorization = c.GetHeader("Authorization")
+		body, err := server.ReadRequestBody(c.Request)
+		if err != nil {
+			server.WritePaymentError(c.Writer, mpp.ErrBadRequest("failed to read request body"))
+			c.Abort()
+			return
+		}
+		if len(body) > 0 {
+			chargeParams.Body = body
+		}
 
 		result, err := m.Charge(c.Request.Context(), chargeParams)
 		if err != nil {

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -100,6 +100,43 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
+	t.Parallel()
+
+	ginfw.SetMode(ginfw.TestMode)
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	router := ginfw.New()
+	router.GET("/paid/:id", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
+		c.String(http.StatusOK, "paid")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid/one?view=full", nil)
+	challengeResponse := httptest.NewRecorder()
+	router.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	scope, ok := challenge.Request["_mppx_scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/paid/:id", scope["route"])
+	assert.Equal(t, "/paid/one", scope["resource"])
+	assert.Equal(t, "view=full", scope["query"])
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid/two?view=full", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	router.ServeHTTP(paidResponse, paidRequest)
+
+	assert.NotEqual(t, http.StatusOK, paidResponse.Code)
+	assert.Empty(t, paidResponse.Header().Get("Payment-Receipt"))
+}
+
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -2,12 +2,15 @@ package ginadapter
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	ginfw "github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 )
@@ -95,4 +98,71 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
 		return
 	}
+}
+
+func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
+	t.Parallel()
+
+	ginfw.SetMode(ginfw.TestMode)
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	router := ginfw.New()
+	router.POST("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
+		_, _ = io.ReadAll(c.Request.Body)
+		c.String(http.StatusOK, "paid")
+	})
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse := httptest.NewRecorder()
+	router.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), challenge.Digest)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(`{"query":"tampered"}`))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	router.ServeHTTP(paidResponse, paidRequest)
+
+	assert.Equal(t, http.StatusBadRequest, paidResponse.Code)
+}
+
+func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
+	t.Parallel()
+
+	ginfw.SetMode(ginfw.TestMode)
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	router := ginfw.New()
+	router.POST("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
+		body, _ := io.ReadAll(c.Request.Body)
+		c.String(http.StatusOK, string(body))
+	})
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	challengeResponse := httptest.NewRecorder()
+	router.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(originalBody))
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	router.ServeHTTP(paidResponse, paidRequest)
+
+	require.Equal(t, http.StatusOK, paidResponse.Code)
+	assert.Equal(t, originalBody, paidResponse.Body.String())
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
@@ -45,6 +47,14 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			chargeParams := params
 			chargeParams.Authorization = r.Header.Get("Authorization")
+			body, err := ReadRequestBody(r)
+			if err != nil {
+				WritePaymentError(w, mpp.ErrBadRequest("failed to read request body"))
+				return
+			}
+			if len(body) > 0 {
+				chargeParams.Body = body
+			}
 
 			result, err := m.Charge(r.Context(), chargeParams)
 			if err != nil {
@@ -60,6 +70,20 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 			serveVerified(next, w, r, result.Credential, result.Receipt)
 		})
 	}
+}
+
+// ReadRequestBody reads and restores r.Body so middleware can verify body digests
+// without consuming the body before the protected handler runs.
+func ReadRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
 }
 
 func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, credential *mpp.Credential, receipt *mpp.Receipt) {

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
@@ -16,6 +17,32 @@ const (
 	credentialKey contextKey = iota
 	receiptKey
 )
+
+// ScopeFromHTTPRequest returns the framework scope bound into charge requests.
+func ScopeFromHTTPRequest(r *http.Request, route string) map[string]string {
+	scope := map[string]string{}
+	if route == "" {
+		route = r.Pattern
+	}
+	if method, path, ok := strings.Cut(route, " "); ok && method != "" && path != "" {
+		route = path
+	}
+	if route != "" {
+		scope["route"] = route
+	}
+	if r.URL != nil {
+		if r.URL.Path != "" {
+			scope["resource"] = r.URL.Path
+		}
+		if r.URL.RawQuery != "" {
+			scope["query"] = r.URL.RawQuery
+		}
+	}
+	if len(scope) == 0 {
+		return nil
+	}
+	return scope
+}
 
 // ContextWithPayment stores the verified payment objects on a request context.
 func ContextWithPayment(ctx context.Context, credential *mpp.Credential, receipt *mpp.Receipt) context.Context {
@@ -47,6 +74,7 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			chargeParams := params
 			chargeParams.Authorization = r.Header.Get("Authorization")
+			chargeParams.MppxScope = ScopeFromHTTPRequest(r, "")
 			body, err := ReadRequestBody(r)
 			if err != nil {
 				WritePaymentError(w, mpp.ErrBadRequest("failed to read request body"))

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,6 +93,43 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 		assert.Failf(t, "", "response body = %q, want %q", got, "did:key:z6Mkrdemo:0xreceipt")
 		return
 	}
+}
+
+func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, "paid")
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(originalBody))
+	require.NoError(t, err)
+
+	challengeResponse, err := http.DefaultClient.Do(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.BodyDigest.Compute([]byte(originalBody)), challenge.Digest)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	retry, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(`{"query":"tampered"}`))
+	require.NoError(t, err)
+	retry.Header.Set("Authorization", credential.ToAuthorization())
+
+	paidResponse, err := http.DefaultClient.Do(retry)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
 }
 
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -95,6 +95,45 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "paid")
+	}))
+	mux := http.NewServeMux()
+	mux.Handle("GET /paid/{id}", handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	challengeResponse, err := http.Get(server.URL + "/paid/one?view=full")
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	scope, ok := challenge.Request["_mppx_scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/paid/{id}", scope["route"])
+	assert.Equal(t, "/paid/one", scope["resource"])
+	assert.Equal(t, "view=full", scope["query"])
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	paidRequest, err := http.NewRequest(http.MethodGet, server.URL+"/paid/two?view=full", nil)
+	require.NoError(t, err)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := http.DefaultClient.Do(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	assert.NotEqual(t, http.StatusOK, paidResponse.StatusCode)
+	assert.Empty(t, paidResponse.Header.Get("Payment-Receipt"))
+}
+
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -132,6 +132,44 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
 }
 
+func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, string(body))
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	const originalBody = `{"query":"paid"}`
+	challengeRequest, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(originalBody))
+	require.NoError(t, err)
+
+	challengeResponse, err := http.DefaultClient.Do(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	retry, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(originalBody))
+	require.NoError(t, err)
+	retry.Header.Set("Authorization", credential.ToAuthorization())
+
+	paidResponse, err := http.DefaultClient.Do(retry)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	require.Equal(t, http.StatusOK, paidResponse.StatusCode)
+	body, err := io.ReadAll(paidResponse.Body)
+	require.NoError(t, err)
+	assert.Equal(t, originalBody, string(body))
+}
+
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
 	handler := ChargeMiddleware(payment, ChargeParams{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -86,6 +86,8 @@ type ChargeParams struct {
 	ChainID int
 	// Meta stores opaque Challenge metadata.
 	Meta map[string]string
+	// MppxScope binds framework route/resource/query context into the request.
+	MppxScope map[string]string
 }
 
 // ChargeResult is either a Challenge or a verified (Credential, Receipt) pair.
@@ -106,7 +108,12 @@ func (r *ChargeResult) IsChallenge() bool {
 // buildChargeRequest produces the canonical request map for a charge operation.
 func (m *Mpp) buildChargeRequest(params ChargeParams) (map[string]any, error) {
 	if builder, ok := m.method.(ChargeRequestBuilder); ok {
-		return builder.BuildChargeRequest(params)
+		request, err := builder.BuildChargeRequest(params)
+		if err != nil {
+			return nil, err
+		}
+		applyMppxScope(request, params.MppxScope)
+		return request, nil
 	}
 	request := map[string]any{
 		"amount":   params.Amount,
@@ -127,7 +134,15 @@ func (m *Mpp) buildChargeRequest(params ChargeParams) (map[string]any, error) {
 	if params.Memo != "" {
 		request["memo"] = params.Memo
 	}
+	applyMppxScope(request, params.MppxScope)
 	return request, nil
+}
+
+func applyMppxScope(request map[string]any, scope map[string]string) {
+	if len(scope) == 0 {
+		return
+	}
+	request["_mppx_scope"] = scope
 }
 
 // Charge handles a charge intent with human-readable amounts.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,8 @@ type ChargeParams struct {
 	Recipient string
 	// ExternalID is copied into the request and echoed back in the Receipt.
 	ExternalID string
+	// Body is the actual request body to bind via the challenge digest.
+	Body any
 	// Expires overrides the default Challenge expiry.
 	Expires string
 	// Description is exposed in the server-generated Challenge.
@@ -144,6 +146,7 @@ func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, e
 		Authorization: params.Authorization,
 		Intent:        intent,
 		Request:       request,
+		Body:          params.Body,
 		Realm:         m.realm,
 		SecretKey:     m.secretKey,
 		Method:        m.method.Name(),

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -17,6 +17,10 @@ type VerifyParams struct {
 	Intent Intent
 	// Request is the canonical request shape the Challenge binds to.
 	Request map[string]any
+	// Body is the actual request body bytes/string/object the digest binds to.
+	// When set, issued challenges include a body digest and submitted
+	// credentials must echo a digest matching this value.
+	Body any
 	// Realm is the expected server realm.
 	Realm string
 	// SecretKey signs and verifies Challenge IDs.
@@ -71,6 +75,9 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	}
 	if params.Meta != nil {
 		opts = append(opts, mpp.WithMeta(params.Meta))
+	}
+	if params.Body != nil {
+		opts = append(opts, mpp.WithDigest(mpp.BodyDigest.Compute(params.Body)))
 	}
 
 	challenge := mpp.NewChallenge(
@@ -149,6 +156,9 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 			"credential opaque metadata does not match this route's requirements",
 		)
 	}
+	if err := verifyBodyDigest(echoed.ID, echoed.Digest, params.Body); err != nil {
+		return nil, err
+	}
 
 	// 7. Check expiry.
 	if echoed.Expires != "" {
@@ -179,6 +189,25 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		Credential: credential,
 		Receipt:    receipt,
 	}, nil
+}
+
+func verifyBodyDigest(challengeID, digest string, body any) error {
+	if body == nil {
+		if digest != "" {
+			return mpp.ErrInvalidChallenge(
+				challengeID,
+				"body digest present but request body was not provided",
+			)
+		}
+		return nil
+	}
+	if digest == "" {
+		return mpp.ErrInvalidChallenge(challengeID, "missing body digest")
+	}
+	if !mpp.BodyDigest.Verify(digest, body) {
+		return mpp.ErrInvalidChallenge(challengeID, "body digest mismatch")
+	}
+	return nil
 }
 
 // echoedRequestMap decodes the echoed request from a credential's challenge echo.

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -172,6 +172,9 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 			"credential opaque metadata does not match this route's requirements",
 		)
 	}
+	if params.Body != nil && echoed.Digest == "" {
+		return &VerifyResult{Challenge: challenge}, nil
+	}
 	if err := verifyBodyDigest(echoed.ID, echoed.Digest, params.Body); err != nil {
 		return nil, err
 	}

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -56,8 +56,9 @@ type VerifyResult struct {
 //  5. Constant-time compare IDs
 //  6. Verify echoed fields match (realm, method, intent name, request)
 //  7. Check expiry
-//  8. Call intent.Verify
-//  9. Return result
+//  8. Verify body digest, if present
+//  9. Call intent.Verify
+//  10. Return result
 func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult, error) {
 	expires := params.Expires
 	if expires == "" {
@@ -150,17 +151,8 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	if echoed.Expires == "" {
 		return nil, mpp.ErrInvalidChallenge(echoed.ID, "missing required expires")
 	}
-	if !reflect.DeepEqual(echoed.Opaque, challenge.Opaque) {
-		return nil, mpp.ErrInvalidChallenge(
-			echoed.ID,
-			"credential opaque metadata does not match this route's requirements",
-		)
-	}
-	if err := verifyBodyDigest(echoed.ID, echoed.Digest, params.Body); err != nil {
-		return nil, err
-	}
-
-	// 7. Check expiry.
+	// 7. Check expiry before body-digest validation so expired credentials
+	// consistently return the payment-expired 402 path.
 	if echoed.Expires != "" {
 		expiresTime, err := time.Parse(time.RFC3339, echoed.Expires)
 		if err != nil {
@@ -174,8 +166,17 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 			return nil, mpp.ErrPaymentExpired(echoed.Expires)
 		}
 	}
+	if !reflect.DeepEqual(echoed.Opaque, challenge.Opaque) {
+		return nil, mpp.ErrInvalidChallenge(
+			echoed.ID,
+			"credential opaque metadata does not match this route's requirements",
+		)
+	}
+	if err := verifyBodyDigest(echoed.ID, echoed.Digest, params.Body); err != nil {
+		return nil, err
+	}
 
-	// 8. Call intent.Verify.
+	// 9. Call intent.Verify.
 	receipt, err := params.Intent.Verify(ctx, credential, params.Request)
 	if err != nil {
 		if pe, ok := err.(*mpp.PaymentError); ok {

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -199,6 +199,44 @@ func TestVerifyOrChallenge_RejectsMismatchedBodyDigest(t *testing.T) {
 	}
 }
 
+func TestVerifyOrChallenge_ReissuesChallengeForLegacyCredentialOnBodyRequest(t *testing.T) {
+	request := map[string]any{"amount": "100"}
+	body := []byte(`{"query":"paid"}`)
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Body:          body,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       challenge.Expires,
+	})
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge() error = %v", err) {
+		return
+	}
+	if !assert.NotNilf(t, result.Challenge,
+		"expected fresh body-digest challenge, got %#v", result) {
+		return
+	}
+	assert.Nil(t, result.Receipt)
+	assert.Equal(t, mpp.BodyDigest.Compute(body), result.Challenge.Digest)
+}
+
 func TestVerifyOrChallenge_ExpiredDigestCredentialReturnsPaymentExpired(t *testing.T) {
 	request := map[string]any{"amount": "100"}
 	challenge := mpp.NewChallenge(

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -128,6 +128,76 @@ func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
 
 }
 
+func TestVerifyOrChallenge_VerifiesBodyDigest(t *testing.T) {
+	request := map[string]any{"amount": "100"}
+	body := []byte(`{"query":"paid"}`)
+	digest := mpp.BodyDigest.Compute(body)
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithDigest(digest),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Body:          body,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       challenge.Expires,
+	})
+	if !assert.NoErrorf(t, err,
+		"VerifyOrChallenge() error = %v", err) {
+		return
+	}
+	if !assert.Falsef(t, result.Receipt == nil || result.Receipt.Reference != "0xreceipt",
+		"expected successful receipt, got %#v", result) {
+		return
+	}
+}
+
+func TestVerifyOrChallenge_RejectsMismatchedBodyDigest(t *testing.T) {
+	request := map[string]any{"amount": "100"}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithDigest(mpp.BodyDigest.Compute([]byte(`{"query":"paid"}`))),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Body:          []byte(`{"query":"tampered"}`),
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       challenge.Expires,
+	})
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "body digest mismatch"),
+		"VerifyOrChallenge() error = %v, want body digest mismatch", err) {
+		return
+	}
+}
+
 func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 	request := map[string]any{
 		"amount":    "100",

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -196,6 +197,41 @@ func TestVerifyOrChallenge_RejectsMismatchedBodyDigest(t *testing.T) {
 		"VerifyOrChallenge() error = %v, want body digest mismatch", err) {
 		return
 	}
+}
+
+func TestVerifyOrChallenge_ExpiredDigestCredentialReturnsPaymentExpired(t *testing.T) {
+	request := map[string]any{"amount": "100"}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithDigest(mpp.BodyDigest.Compute([]byte(`{"query":"paid"}`))),
+		mpp.WithExpires("2020-01-01T00:00:00Z"),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Body:          []byte(`{"query":"tampered"}`),
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       challenge.Expires,
+	})
+
+	paymentErr, ok := err.(*mpp.PaymentError)
+	if !assert.Truef(t, ok, "VerifyOrChallenge() error = %T %v, want PaymentError", err, err) {
+		return
+	}
+	assert.Equal(t, mpp.ErrorTypePaymentExpired, paymentErr.Type)
+	assert.Equal(t, http.StatusPaymentRequired, paymentErr.Status)
 }
 
 func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {


### PR DESCRIPTION
## Summary
- bind server-side challenges to request body digests across middleware/adapters
- bind challenges to framework route/resource/query scope to reject same-price cross-resource replay
- add conformance coverage for net/http, compose, Echo, Fiber, and Gin paths

## Testing
- Not run locally: go toolchain is unavailable in this environment (`go: command not found`).