### PR TITLE
feat: wallet-bound proof signatures

### DIFF
--- a/.changelog/wallet-bound-proof.md
+++ b/.changelog/wallet-bound-proof.md
@@ -1,0 +1,7 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Breaking Tempo proof credential wire format: zero-amount proofs are now wallet-bound. The canonical EIP-712 `Proof` message is now `account address` first, followed by `challengeId` and `realm`, and the MPP domain version is `"3"`, matching the mppx (TypeScript) SDK. Verifiers rebuild the digest from the credential `source` payer address, so proofs produced with the previous message shape/domain version are rejected; Go and TypeScript clients/servers must use the v3 proof format together. This closes cross-account replay for access keys authorized on multiple accounts.
+
+Breaking Go API: `ProofTypedDataHash` now requires an `account common.Address` parameter. `ProofTypedData` exposes the canonical wallet-bound typed data. Added cross-SDK digest/signature conformance coverage.

--- a/.changelog/wallet-bound-proof.md
+++ b/.changelog/wallet-bound-proof.md
@@ -2,6 +2,6 @@
 github.com/tempoxyz/mpp-go: patch
 ---
 
-Breaking Tempo proof credential wire format: zero-amount proofs are now wallet-bound. The canonical EIP-712 `Proof` message is now `account address` first, followed by `challengeId` and `realm`, and the MPP domain version is `"3"`, matching the mppx (TypeScript) SDK. Verifiers rebuild the digest from the credential `source` payer address, so proofs produced with the previous message shape/domain version are rejected; Go and TypeScript clients/servers must use the v3 proof format together. This closes cross-account replay for access keys authorized on multiple accounts.
+Wallet-bind Tempo zero-amount proofs to close cross-account replay. The EIP-712 `Proof` message now leads with the payer `account` address (then `challengeId`, `realm`) and the MPP domain version is `"3"`. Verifiers rebuild the digest from the credential `source`, so client and server must both use v3. `ProofTypedDataHash` now takes an `account common.Address`; `ProofTypedData` exposes the typed data.
 
-Breaking Go API: `ProofTypedDataHash` now requires an `account common.Address` parameter. `ProofTypedData` exposes the canonical wallet-bound typed data. Added cross-SDK digest/signature conformance coverage.
+Note: v3 is not yet interoperable with the mppx (TypeScript) SDK, which still uses v2 (`Proof = [challengeId, realm]`, no `account`).

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -246,7 +246,8 @@ func (m *Method) buildTransfer(
 }
 
 func (m *Method) signProof(chainID int64, challengeID, realm string) (string, error) {
-	hash, err := tempo.ProofTypedDataHash(chainID, challengeID, realm)
+	// Bind the proof to the signing wallet, echoed as the credential source.
+	hash, err := tempo.ProofTypedDataHash(chainID, m.signer.Address(), challengeID, realm)
 	if err != nil {
 		return "", fmt.Errorf("tempo client: build proof payload: %w", err)
 	}

--- a/pkg/tempo/proof.go
+++ b/pkg/tempo/proof.go
@@ -13,9 +13,12 @@ func ProofSource(chainID int64, address common.Address) string {
 	return fmt.Sprintf("did:pkh:eip155:%d:%s", chainID, address.Hex())
 }
 
-// ProofTypedDataHash returns the EIP-712 digest for a Tempo proof credential.
-func ProofTypedDataHash(chainID int64, challengeID, realm string) (common.Hash, error) {
-	typedData := apitypes.TypedData{
+// ProofTypedData builds the EIP-712 typed data for a Tempo zero-amount proof
+// credential. The Proof struct includes the payer wallet (account) so the
+// signature commits to a specific payer and cannot be replayed against a
+// different account.
+func ProofTypedData(chainID int64, account common.Address, challengeID, realm string) apitypes.TypedData {
+	return apitypes.TypedData{
 		Types: apitypes.Types{
 			"EIP712Domain": {
 				{Name: "name", Type: "string"},
@@ -23,6 +26,7 @@ func ProofTypedDataHash(chainID int64, challengeID, realm string) (common.Hash, 
 				{Name: "chainId", Type: "uint256"},
 			},
 			"Proof": {
+				{Name: "account", Type: "address"},
 				{Name: "challengeId", Type: "string"},
 				{Name: "realm", Type: "string"},
 			},
@@ -30,15 +34,21 @@ func ProofTypedDataHash(chainID int64, challengeID, realm string) (common.Hash, 
 		PrimaryType: "Proof",
 		Domain: apitypes.TypedDataDomain{
 			Name:    "MPP",
-			Version: "1",
+			Version: "3",
 			ChainId: math.NewHexOrDecimal256(chainID),
 		},
 		Message: apitypes.TypedDataMessage{
+			"account":     account.Hex(),
 			"challengeId": challengeID,
 			"realm":       realm,
 		},
 	}
-	hash, _, err := apitypes.TypedDataAndHash(typedData)
+}
+
+// ProofTypedDataHash returns the EIP-712 digest for a Tempo proof credential,
+// bound to the payer wallet (account). See [ProofTypedData].
+func ProofTypedDataHash(chainID int64, account common.Address, challengeID, realm string) (common.Hash, error) {
+	hash, _, err := apitypes.TypedDataAndHash(ProofTypedData(chainID, account, challengeID, realm))
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/pkg/tempo/proof_rpc_test.go
+++ b/pkg/tempo/proof_rpc_test.go
@@ -36,27 +36,34 @@ func TestProofHelpers(t *testing.T) {
 		return
 	}
 
-	hash1, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
+	hash1, err := ProofTypedDataHash(42431, address, "challenge-1", "api.example.com")
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() error = %v", err) {
 		return
 	}
 
-	hash2, err := ProofTypedDataHash(42431, "challenge-1", "api.example.com")
+	hash2, err := ProofTypedDataHash(42431, address, "challenge-1", "api.example.com")
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() repeat error = %v", err) {
 		return
 	}
 
-	hash3, err := ProofTypedDataHash(42431, "challenge-2", "api.example.com")
+	hash3, err := ProofTypedDataHash(42431, address, "challenge-2", "api.example.com")
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() different challenge error = %v", err) {
 		return
 	}
 
-	hash4, err := ProofTypedDataHash(42431, "challenge-1", "other.example.com")
+	hash4, err := ProofTypedDataHash(42431, address, "challenge-1", "other.example.com")
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() different realm error = %v", err) {
+		return
+	}
+
+	otherAccount := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+	hash5, err := ProofTypedDataHash(42431, otherAccount, "challenge-1", "api.example.com")
+	if !assert.NoErrorf(t, err,
+		"ProofTypedDataHash() different account error = %v", err) {
 		return
 	}
 	if !assert.Equalf(t, hash2, hash1,
@@ -72,7 +79,11 @@ func TestProofHelpers(t *testing.T) {
 		"hash1 = %s, want different hash from hash4 %s", hash1.Hex(), hash4.Hex()) {
 		return
 	}
-
+	// Wallet binding: a different payer account yields a different digest.
+	if !assert.NotEqualf(t, hash5, hash1,
+		"hash1 = %s, want different hash from hash5 %s", hash1.Hex(), hash5.Hex()) {
+		return
+	}
 }
 
 func TestParseHexHelpersAndClientConstruction(t *testing.T) {

--- a/pkg/tempo/proof_vectors_test.go
+++ b/pkg/tempo/proof_vectors_test.go
@@ -1,0 +1,50 @@
+package tempo
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProofTypedDataHashCrossSDKVector pins the proof digest to a fixed vector
+// so the wire format cannot drift.
+func TestProofTypedDataHashCrossSDKVector(t *testing.T) {
+	t.Parallel()
+
+	const (
+		chainID     = int64(42431)
+		challengeID = "kM9xPqWvT2nJrHsY4aDfEb"
+		realm       = "api.example.com"
+		// account is derived from private key 0x01*32; wantDigest is the
+		// corresponding pinned proof digest.
+		account    = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
+		wantDigest = "0x3860a700a55e02ad3c2dc047e92489feceecbdb0a801d948e1d9f0b61ea9bc3f"
+	)
+
+	got, err := ProofTypedDataHash(chainID, common.HexToAddress(account), challengeID, realm)
+	assert.NoError(t, err)
+	assert.Equalf(t, wantDigest, got.Hex(), "proof digest must match the pinned vector")
+}
+
+// TestProofTypedDataHashWalletBinding checks that the digest is bound to the
+// payer account: swapping the account yields a different digest.
+func TestProofTypedDataHashWalletBinding(t *testing.T) {
+	t.Parallel()
+
+	const (
+		chainID     = int64(42431)
+		challengeID = "kM9xPqWvT2nJrHsY4aDfEb"
+		realm       = "api.example.com"
+	)
+	accountA := common.HexToAddress("0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1")
+	accountB := common.HexToAddress("0x000000000000000000000000000000000000bEEF")
+
+	hashA, err := ProofTypedDataHash(chainID, accountA, challengeID, realm)
+	assert.NoError(t, err)
+	hashB, err := ProofTypedDataHash(chainID, accountB, challengeID, realm)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, hashA.Hex(), hashB.Hex(),
+		"different payer accounts must produce different proof digests")
+}

--- a/pkg/tempo/proof_vectors_test.go
+++ b/pkg/tempo/proof_vectors_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestProofTypedDataHashCrossSDKVector pins the proof digest to a fixed vector
-// so the wire format cannot drift.
-func TestProofTypedDataHashCrossSDKVector(t *testing.T) {
+// TestProofTypedDataHashPinnedVector pins the proof digest to a fixed value so
+// the wire format cannot drift.
+func TestProofTypedDataHashPinnedVector(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -17,14 +17,14 @@ func TestProofTypedDataHashCrossSDKVector(t *testing.T) {
 		challengeID = "kM9xPqWvT2nJrHsY4aDfEb"
 		realm       = "api.example.com"
 		// account is derived from private key 0x01*32; wantDigest is the
-		// corresponding pinned proof digest.
+		// proof digest this Go implementation produces for those inputs.
 		account    = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
 		wantDigest = "0x3860a700a55e02ad3c2dc047e92489feceecbdb0a801d948e1d9f0b61ea9bc3f"
 	)
 
 	got, err := ProofTypedDataHash(chainID, common.HexToAddress(account), challengeID, realm)
 	assert.NoError(t, err)
-	assert.Equalf(t, wantDigest, got.Hex(), "proof digest must match the pinned vector")
+	assert.Equalf(t, wantDigest, got.Hex(), "proof digest must match the pinned Go wire-format value")
 }
 
 // TestProofTypedDataHashWalletBinding checks that the digest is bound to the

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -216,7 +216,9 @@ func (i *Intent) verifyProof(
 	if source.chainID != chainID {
 		return nil, mpp.ErrInvalidPayload("credential source chain id does not match the challenge")
 	}
-	proofHash, err := tempo.ProofTypedDataHash(chainID, credential.Challenge.ID, credential.Challenge.Realm)
+	// Bind the digest to the claimed payer so a proof cannot be replayed
+	// against a different account (e.g. via a shared access key).
+	proofHash, err := tempo.ProofTypedDataHash(chainID, common.HexToAddress(source.address), credential.Challenge.ID, credential.Challenge.Realm)
 	if err != nil {
 		return nil, mpp.ErrVerificationFailed("failed to construct proof payload")
 	}
@@ -741,6 +743,14 @@ func recoverProofSigner(proofHash common.Hash, encoded string, source common.Add
 		}
 		if rootAccount != source {
 			return common.Address{}, fmt.Errorf("keychain proof root mismatch")
+		}
+		// Normalize the inner recovery id to 0/1, as RecoverAddress requires
+		// (the encoded byte may be a legacy 27/28 v value).
+		if innerSignature.YParity >= 27 {
+			innerSignature.YParity -= 27
+		}
+		if innerSignature.YParity > 1 {
+			return common.Address{}, fmt.Errorf("invalid recovery id")
 		}
 		payload := make([]byte, 0, 1+len(proofHash.Bytes())+len(rootAccount.Bytes()))
 		payload = append(payload, keychain.KeychainSignatureType)

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -303,7 +303,7 @@ func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {
 		"NewSigner(access key) error = %v", err) {
 		return
 	}
-	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
+	proofHash, err := tempo.ProofTypedDataHash(42431, rootSigner.Address(), challenge.ID, challenge.Realm)
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() error = %v", err) {
 		return
@@ -376,7 +376,7 @@ func TestChargeFlow_ProofCredentialWithAccessKeyWithoutExpiry(t *testing.T) {
 		"NewSigner(access key) error = %v", err) {
 		return
 	}
-	proofHash, err := tempo.ProofTypedDataHash(42431, challenge.ID, challenge.Realm)
+	proofHash, err := tempo.ProofTypedDataHash(42431, rootSigner.Address(), challenge.ID, challenge.Realm)
 	if !assert.NoErrorf(t, err,
 		"ProofTypedDataHash() error = %v", err) {
 		return

--- a/pkg/tempo/server/proof_interop_test.go
+++ b/pkg/tempo/server/proof_interop_test.go
@@ -1,0 +1,155 @@
+package chargeserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	"github.com/tempoxyz/tempo-go/pkg/keychain"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+// encodePlainProofSignature serializes a secp256k1 signature into the 65-byte
+// (r || s || yParity) form used by plain (non-keychain) Tempo proof credentials.
+func encodePlainProofSignature(t *testing.T, signer *temposigner.Signer, hash common.Hash) string {
+	t.Helper()
+	sig, err := signer.Sign(hash)
+	assert.NoError(t, err)
+	raw := make([]byte, 65)
+	sig.R.FillBytes(raw[:32])
+	sig.S.FillBytes(raw[32:64])
+	raw[64] = sig.YParity
+	return hexutil.Encode(raw)
+}
+
+// TestVerifyProof_RejectsCrossAccountAccessKeyReplay checks that a proof signed
+// for root account A cannot be replayed by claiming a different root account B,
+// even when the same access key is active for both.
+func TestVerifyProof_RejectsCrossAccountAccessKeyReplay(t *testing.T) {
+	ctx := context.Background()
+	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+		Amount:    "0",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+	})
+	assert.NoError(t, err)
+	challenge := buildChallenge(t, request)
+
+	rootA, err := temposigner.NewSigner(testPrivateKey)
+	assert.NoError(t, err)
+	accessKey, err := temposigner.NewSigner(feePayerKey)
+	assert.NoError(t, err)
+	// Root account B is a distinct payer the attacker wants to impersonate.
+	rootB := common.HexToAddress("0x000000000000000000000000000000000000bEEF")
+	assert.NotEqual(t, rootA.Address(), rootB)
+
+	// Access key signs a plain (non-keychain) proof bound to root account A.
+	proofHashA, err := tempo.ProofTypedDataHash(42431, rootA.Address(), challenge.ID, challenge.Realm)
+	assert.NoError(t, err)
+	signature := encodePlainProofSignature(t, accessKey, proofHashA)
+
+	// Honest submission (source = A) verifies. A fresh intent/store per case
+	// avoids replay-store interference.
+	{
+		rpc := newMockRPC(request)
+		rpc.callResult = encodeActiveKeyInfo(accessKey.Address(), time.Now().Add(time.Hour).Unix())
+		intent, err := NewIntent(IntentConfig{RPC: rpc})
+		assert.NoError(t, err)
+		credential := &mpp.Credential{
+			Challenge: challenge.ToEcho(),
+			Payload: tempo.ChargeCredentialPayload{
+				Type:      tempo.CredentialTypeProof,
+				Signature: signature,
+			}.Map(),
+			Source: tempo.ProofSource(42431, rootA.Address()),
+		}
+		_, err = intent.Verify(ctx, credential, request.Map())
+		assert.NoErrorf(t, err, "honest proof bound to A must verify")
+	}
+
+	// Replay (source = B): the same access key is active for B too (mock returns
+	// it as active), but the replay must still be rejected.
+	{
+		rpc := newMockRPC(request)
+		rpc.callResult = encodeActiveKeyInfo(accessKey.Address(), time.Now().Add(time.Hour).Unix())
+		intent, err := NewIntent(IntentConfig{RPC: rpc})
+		assert.NoError(t, err)
+		credential := &mpp.Credential{
+			Challenge: challenge.ToEcho(),
+			Payload: tempo.ChargeCredentialPayload{
+				Type:      tempo.CredentialTypeProof,
+				Signature: signature,
+			}.Map(),
+			Source: tempo.ProofSource(42431, rootB),
+		}
+		_, err = intent.Verify(ctx, credential, request.Map())
+		assert.Errorf(t, err, "cross-account replay against B must be rejected")
+		assert.Contains(t, err.Error(), "proof signature does not match source")
+	}
+}
+
+// TestRecoverProofSigner_AcceptsMppxSignatureVector pins a known proof
+// signature (v=27/28) and checks it recovers to the bound wallet, exercising
+// the digest and the y-parity normalization in recoverProofSigner.
+func TestRecoverProofSigner_AcceptsMppxSignatureVector(t *testing.T) {
+	t.Parallel()
+
+	account := common.HexToAddress("0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1")
+	const (
+		chainID     = int64(42431)
+		challengeID = "kM9xPqWvT2nJrHsY4aDfEb"
+		realm       = "api.example.com"
+		// Conformance vector: proof signature with a legacy v=27/28 byte.
+		mppxSignature = "0x53f5d64d9f995e841b4212639b2e17e508e96752e10316df3814a16443dcbdb626c082190a4c3ecc3148101eb443d15bd83b579380b1be735a9c99f0df36c9fe1b"
+	)
+
+	proofHash, err := tempo.ProofTypedDataHash(chainID, account, challengeID, realm)
+	assert.NoError(t, err)
+
+	signer, err := recoverProofSigner(proofHash, mppxSignature, account)
+	assert.NoError(t, err)
+	assert.Equalf(t, account.Hex(), signer.Hex(),
+		"mppx proof signature must recover to the bound wallet")
+}
+
+// TestRecoverProofSigner_KeychainAcceptsLegacyVRecoveryByte checks that a
+// keychain-v2 proof whose inner secp256k1 signature uses the legacy v=27/28
+// recovery byte still recovers to the access-key address. Without recovery-byte
+// normalization in the keychain path this fails, because RecoverAddress
+// requires a 0/1 yParity.
+func TestRecoverProofSigner_KeychainAcceptsLegacyVRecoveryByte(t *testing.T) {
+	t.Parallel()
+
+	rootSigner, err := temposigner.NewSigner(testPrivateKey)
+	assert.NoError(t, err)
+	accessKey, err := temposigner.NewSigner(feePayerKey)
+	assert.NoError(t, err)
+
+	proofHash, err := tempo.ProofTypedDataHash(42431, rootSigner.Address(), "challenge-1", "api.example.com")
+	assert.NoError(t, err)
+
+	// Build the keychain-v2 inner signing payload and sign it with the access key.
+	v2Payload := make([]byte, 0, 1+32+common.AddressLength)
+	v2Payload = append(v2Payload, keychain.KeychainSignatureType)
+	v2Payload = append(v2Payload, proofHash.Bytes()...)
+	v2Payload = append(v2Payload, rootSigner.Address().Bytes()...)
+	inner, err := accessKey.Sign(crypto.Keccak256Hash(v2Payload))
+	assert.NoError(t, err)
+
+	// Force a legacy v=27/28 recovery byte.
+	inner.YParity += 27
+	keychainSig := keychain.BuildKeychainSignature(inner, rootSigner.Address())
+
+	signer, err := recoverProofSigner(proofHash, hexutil.Encode(keychainSig), rootSigner.Address())
+	assert.NoError(t, err)
+	assert.Equalf(t, accessKey.Address().Hex(), signer.Hex(),
+		"keychain proof with legacy v byte must recover to the access key")
+}

--- a/pkg/tempo/server/proof_interop_test.go
+++ b/pkg/tempo/server/proof_interop_test.go
@@ -96,10 +96,11 @@ func TestVerifyProof_RejectsCrossAccountAccessKeyReplay(t *testing.T) {
 	}
 }
 
-// TestRecoverProofSigner_AcceptsMppxSignatureVector pins a known proof
-// signature (v=27/28) and checks it recovers to the bound wallet, exercising
-// the digest and the y-parity normalization in recoverProofSigner.
-func TestRecoverProofSigner_AcceptsMppxSignatureVector(t *testing.T) {
+// TestRecoverProofSigner_AcceptsLegacyVSignatureVector pins a known proof
+// signature with a legacy v=27/28 recovery byte and checks it recovers to the
+// bound wallet, exercising the digest and the y-parity normalization in
+// recoverProofSigner.
+func TestRecoverProofSigner_AcceptsLegacyVSignatureVector(t *testing.T) {
 	t.Parallel()
 
 	account := common.HexToAddress("0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1")
@@ -107,17 +108,17 @@ func TestRecoverProofSigner_AcceptsMppxSignatureVector(t *testing.T) {
 		chainID     = int64(42431)
 		challengeID = "kM9xPqWvT2nJrHsY4aDfEb"
 		realm       = "api.example.com"
-		// Conformance vector: proof signature with a legacy v=27/28 byte.
-		mppxSignature = "0x53f5d64d9f995e841b4212639b2e17e508e96752e10316df3814a16443dcbdb626c082190a4c3ecc3148101eb443d15bd83b579380b1be735a9c99f0df36c9fe1b"
+		// Proof signature with a legacy v=27/28 recovery byte.
+		legacyVSignature = "0x53f5d64d9f995e841b4212639b2e17e508e96752e10316df3814a16443dcbdb626c082190a4c3ecc3148101eb443d15bd83b579380b1be735a9c99f0df36c9fe1b"
 	)
 
 	proofHash, err := tempo.ProofTypedDataHash(chainID, account, challengeID, realm)
 	assert.NoError(t, err)
 
-	signer, err := recoverProofSigner(proofHash, mppxSignature, account)
+	signer, err := recoverProofSigner(proofHash, legacyVSignature, account)
 	assert.NoError(t, err)
 	assert.Equalf(t, account.Hex(), signer.Hex(),
-		"mppx proof signature must recover to the bound wallet")
+		"legacy-v proof signature must recover to the bound wallet")
 }
 
 // TestRecoverProofSigner_KeychainAcceptsLegacyVRecoveryByte checks that a


### PR DESCRIPTION
Part of OSS-307

Bind Tempo zero-amount proof signatures to the payer wallet by adding `account` to the EIP-712 `Proof` message (domain v3). Verifiers rebuild the digest from the credential source, closing cross-account access-key replay.