### PR TITLE
fix(server): reject multiple Payment credentials

### DIFF
--- a/.changelog/reject-multiple-payment-credentials.md
+++ b/.changelog/reject-multiple-payment-credentials.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject requests that include multiple `Authorization: Payment` credentials instead of silently selecting the first credential.

--- a/pkg/mpp/json.go
+++ b/pkg/mpp/json.go
@@ -3,6 +3,7 @@ package mpp
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -41,8 +42,32 @@ func ExtractAuthorizationScheme(header, scheme string) string {
 	return ""
 }
 
+// ExtractAuthorizationSchemeStrict returns a single authorization value that
+// matches scheme, or an error if the header includes multiple matching values.
+func ExtractAuthorizationSchemeStrict(header, scheme string) (string, error) {
+	var found string
+	for _, value := range SplitAuthenticate(header) {
+		value = strings.TrimSpace(value)
+		name, _, ok := strings.Cut(value, " ")
+		if !ok || !strings.EqualFold(name, scheme) {
+			continue
+		}
+		if found != "" {
+			return "", fmt.Errorf("mpp: multiple %s credentials", scheme)
+		}
+		found = value
+	}
+	return found, nil
+}
+
 // FindPaymentAuthorization returns the Payment credential from an Authorization
 // header. It tolerates comma-separated schemes and ignores non-Payment values.
 func FindPaymentAuthorization(header string) string {
 	return ExtractAuthorizationScheme(header, "Payment")
+}
+
+// FindPaymentAuthorizationStrict returns the Payment credential from an
+// Authorization header, or an error if more than one Payment credential exists.
+func FindPaymentAuthorizationStrict(header string) (string, error) {
+	return ExtractAuthorizationSchemeStrict(header, "Payment")
 }

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -325,7 +325,10 @@ func ParseCredential(header string) (*Credential, error) {
 		return nil, fmt.Errorf("mpp: Authorization header exceeds maximum size")
 	}
 
-	header = FindPaymentAuthorization(header)
+	header, err := FindPaymentAuthorizationStrict(header)
+	if err != nil {
+		return nil, err
+	}
 	if header == "" {
 		return nil, fmt.Errorf("mpp: expected Payment scheme")
 	}

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -144,6 +144,16 @@ func TestFindPaymentAuthorization(t *testing.T) {
 	}
 }
 
+func TestFindPaymentAuthorizationStrictRejectsMultiplePaymentCredentials(t *testing.T) {
+	t.Parallel()
+
+	_, err := FindPaymentAuthorizationStrict("Bearer token, Payment abc123, Payment def456")
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.Contains(t, err.Error(), "multiple Payment credentials")
+}
+
 func TestIsMethodName(t *testing.T) {
 	t.Parallel()
 
@@ -401,6 +411,11 @@ func TestParseCredential(t *testing.T) {
 			name:   "merged authorization header",
 			header: `Digest realm="alpha,beta", nonce="123", ` + credential.ToAuthorization(),
 			want:   credential,
+		},
+		{
+			name:    "multiple payment credentials",
+			header:  credential.ToAuthorization() + ", " + credential.ToAuthorization(),
+			wantErr: `multiple Payment credentials`,
 		},
 		{
 			name:    "missing payment scheme",

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -62,7 +62,11 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auth := r.Header.Get("Authorization")
-			paymentAuth := mpp.FindPaymentAuthorization(auth)
+			paymentAuth, err := mpp.FindPaymentAuthorizationStrict(auth)
+			if err != nil {
+				WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
+				return
+			}
 			body, err := ReadRequestBody(r)
 			if err != nil {
 				WritePaymentError(w, mpp.ErrBadRequest("failed to read request body"))

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -474,6 +474,42 @@ func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing
 	}
 }
 
+func TestComposeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
+	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	betaChallenge := findChallenge(t, resp, "beta")
+	resp.Body.Close()
+
+	credential := &mpp.Credential{
+		Challenge: betaChallenge.ToEcho(),
+		Source:    "did:key:z6Mktest",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", credential.ToAuthorization()+", "+credential.ToAuthorization())
+
+	paid, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer paid.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, paid.StatusCode)
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.NewDecoder(paid.Body).Decode(&problem))
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
+}
+
 func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *testing.T) {
 	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -215,6 +215,46 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	assert.Equal(t, originalBody, string(body))
 }
 
+func TestChargeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handlerCalled := false
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	challengeResponse, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	retry, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	retry.Header.Set("Authorization", credential.ToAuthorization()+", "+credential.ToAuthorization())
+
+	paidResponse, err := http.DefaultClient.Do(retry)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+
+	assert.False(t, handlerCalled)
+	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.NewDecoder(paidResponse.Body).Decode(&problem))
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
+}
+
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
 	handler := ChargeMiddleware(payment, ChargeParams{

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -96,7 +96,10 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	}
 
 	// 2. Extract the Payment credential from Authorization.
-	authHeader := mpp.FindPaymentAuthorization(params.Authorization)
+	authHeader, err := mpp.FindPaymentAuthorizationStrict(params.Authorization)
+	if err != nil {
+		return nil, mpp.ErrBadRequest(err.Error())
+	}
 	if authHeader == "" {
 		return &VerifyResult{Challenge: challenge}, nil
 	}


### PR DESCRIPTION
## Summary
- reject Authorization headers containing more than one `Payment` credential
- keep the existing first-match helper for compatibility and add a strict helper for parsing/server verification
- cover parser, ChargeMiddleware, and ComposeMiddleware regression cases

Fixes #64.

## Tests
- `go test ./pkg/mpp ./pkg/server -count=1`
- `go test ./...`
- `git diff --check`