### PR TITLE
fix(mpp): align Problem Details with core spec

### DIFF
--- a/.changelog/problem-details-core-spec.md
+++ b/.changelog/problem-details-core-spec.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Align spec-listed MPP Problem Details type URIs with the canonical `https://paymentauth.org/problems/` base URI, and return 402 for malformed credentials and invalid challenges.

--- a/pkg/mpp/errors.go
+++ b/pkg/mpp/errors.go
@@ -13,15 +13,15 @@ var ErrVerification = errors.New("payment verification failed")
 type ErrorType string
 
 const (
-	ErrorTypePaymentRequired     ErrorType = "https://mpp.dev/errors/payment-required"
-	ErrorTypeMalformedCredential ErrorType = "https://mpp.dev/errors/malformed-credential"
-	ErrorTypeInvalidChallenge    ErrorType = "https://mpp.dev/errors/invalid-challenge"
-	ErrorTypeVerificationFailed  ErrorType = "https://mpp.dev/errors/verification-failed"
-	ErrorTypePaymentExpired      ErrorType = "https://mpp.dev/errors/payment-expired"
+	ErrorTypePaymentRequired     ErrorType = "https://paymentauth.org/problems/payment-required"
+	ErrorTypeMalformedCredential ErrorType = "https://paymentauth.org/problems/malformed-credential"
+	ErrorTypeInvalidChallenge    ErrorType = "https://paymentauth.org/problems/invalid-challenge"
+	ErrorTypeVerificationFailed  ErrorType = "https://paymentauth.org/problems/verification-failed"
+	ErrorTypePaymentExpired      ErrorType = "https://paymentauth.org/problems/payment-expired"
 	ErrorTypeInvalidPayload      ErrorType = "https://mpp.dev/errors/invalid-payload"
 	ErrorTypeBadRequest          ErrorType = "https://mpp.dev/errors/bad-request"
-	ErrorTypePaymentInsufficient ErrorType = "https://mpp.dev/errors/payment-insufficient"
-	ErrorTypeMethodUnsupported   ErrorType = "https://mpp.dev/errors/method-unsupported"
+	ErrorTypePaymentInsufficient ErrorType = "https://paymentauth.org/problems/payment-insufficient"
+	ErrorTypeMethodUnsupported   ErrorType = "https://paymentauth.org/problems/method-unsupported"
 )
 
 // Title returns the default RFC 9457 title for the error type.
@@ -53,7 +53,7 @@ func (t ErrorType) Title() string {
 // Status returns the default HTTP status for the error type.
 func (t ErrorType) Status() int {
 	switch t {
-	case ErrorTypePaymentRequired, ErrorTypeVerificationFailed, ErrorTypePaymentExpired, ErrorTypePaymentInsufficient:
+	case ErrorTypePaymentRequired, ErrorTypeMalformedCredential, ErrorTypeInvalidChallenge, ErrorTypeVerificationFailed, ErrorTypePaymentExpired, ErrorTypePaymentInsufficient:
 		return http.StatusPaymentRequired
 	default:
 		return http.StatusBadRequest
@@ -113,12 +113,12 @@ func ErrPaymentRequired(realm, description string) *PaymentError {
 	return newPaymentError(ErrorTypePaymentRequired, detail)
 }
 
-// ErrMalformedCredential returns a 400 error for unparseable credentials.
+// ErrMalformedCredential returns a 402 error for unparseable credentials.
 func ErrMalformedCredential(reason string) *PaymentError {
 	return newPaymentError(ErrorTypeMalformedCredential, reason)
 }
 
-// ErrInvalidChallenge returns a 400 error for invalid or tampered challenges.
+// ErrInvalidChallenge returns a 402 error for invalid or tampered challenges.
 func ErrInvalidChallenge(challengeID, reason string) *PaymentError {
 	return newPaymentError(ErrorTypeInvalidChallenge, fmt.Sprintf("challenge %s: %s", challengeID, reason))
 }

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -37,14 +37,14 @@ func TestPaymentErrorConstructors(t *testing.T) {
 			name:   "malformed credential",
 			err:    ErrMalformedCredential("bad credential"),
 			want:   ErrorTypeMalformedCredential,
-			status: http.StatusBadRequest,
+			status: http.StatusPaymentRequired,
 			detail: "bad credential",
 		},
 		{
 			name:   "invalid challenge",
 			err:    ErrInvalidChallenge("challenge-1", "tampered"),
 			want:   ErrorTypeInvalidChallenge,
-			status: http.StatusBadRequest,
+			status: http.StatusPaymentRequired,
 			detail: "challenge challenge-1: tampered",
 		},
 		{
@@ -109,6 +109,30 @@ func TestPaymentErrorConstructors(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestProblemTypeURIsUseCanonicalBase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		got  ErrorType
+		want string
+	}{
+		{got: ErrorTypePaymentRequired, want: "https://paymentauth.org/problems/payment-required"},
+		{got: ErrorTypeMalformedCredential, want: "https://paymentauth.org/problems/malformed-credential"},
+		{got: ErrorTypeInvalidChallenge, want: "https://paymentauth.org/problems/invalid-challenge"},
+		{got: ErrorTypeVerificationFailed, want: "https://paymentauth.org/problems/verification-failed"},
+		{got: ErrorTypePaymentExpired, want: "https://paymentauth.org/problems/payment-expired"},
+		{got: ErrorTypePaymentInsufficient, want: "https://paymentauth.org/problems/payment-insufficient"},
+		{got: ErrorTypeMethodUnsupported, want: "https://paymentauth.org/problems/method-unsupported"},
+	}
+
+	for _, tt := range tests {
+		if !assert.Equalf(t, tt.want, string(tt.got),
+			"problem type URI = %q, want %q", tt.got, tt.want) {
+			return
+		}
 	}
 }
 

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -135,7 +135,7 @@ func composeChallenges(w http.ResponseWriter, r *http.Request, entries []compose
 	for _, challenge := range challenges {
 		header, err := challenge.ToAuthenticateStrict(realm)
 		if err != nil {
-			WritePaymentError(w, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+			WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
 			return
 		}
 		headers = append(headers, header)

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -406,9 +406,9 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 
 	defer paid.Body.Close()
 
-	if paid.StatusCode != http.StatusBadRequest {
+	if paid.StatusCode != http.StatusPaymentRequired {
 		body, _ := io.ReadAll(paid.Body)
-		assert.Failf(t, "", "status = %d, want %d; body = %s", paid.StatusCode, http.StatusBadRequest, body)
+		assert.Failf(t, "", "status = %d, want %d; body = %s", paid.StatusCode, http.StatusPaymentRequired, body)
 		return
 	}
 
@@ -489,7 +489,7 @@ func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Type string `json:"type"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&problem))
-	assert.Equal(t, string(mpp.ErrorTypeInvalidChallenge), problem.Type)
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
 }
 
 func TestComposeMiddleware_PanicsOnEmptyConfigs(t *testing.T) {

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -60,7 +60,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 func WriteChallenge(c *fiberfw.Ctx, challenge *mpp.Challenge, realm string) {
 	header, err := challenge.ToAuthenticateStrict(realm)
 	if err != nil {
-		WritePaymentError(c, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+		WritePaymentError(c, mpp.ErrBadRequest(err.Error()))
 		return
 	}
 

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -146,5 +146,5 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Type string `json:"type"`
 	}
 	require.NoError(t, json.NewDecoder(challengeResponse.Body).Decode(&problem))
-	assert.Equal(t, string(mpp.ErrorTypeInvalidChallenge), problem.Type)
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -74,7 +74,7 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 func WriteChallenge(w http.ResponseWriter, challenge *mpp.Challenge, realm string) {
 	header, err := challenge.ToAuthenticateStrict(realm)
 	if err != nil {
-		WritePaymentError(w, mpp.ErrInvalidChallenge(challenge.ID, err.Error()))
+		WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
 		return
 	}
 

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -115,5 +115,5 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 		Type string `json:"type"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&problem))
-	assert.Equal(t, string(mpp.ErrorTypeInvalidChallenge), problem.Type)
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
 }


### PR DESCRIPTION
## Summary
- use the canonical `https://paymentauth.org/problems/` base URI for core MPP Problem Details types
- return 402 for malformed credentials and invalid challenges
- keep challenge serialization failures as 400 Bad Request responses

Fixes #65.

## Tests
- `go test ./pkg/mpp ./pkg/server ./pkg/server/gin ./pkg/server/echo ./pkg/server/fiber -count=1`
- `go test ./...`
- `git diff --check`