### PR TITLE
fix: reject padded Tempo calldata

### DIFF
--- a/.changelog/fee-payer-calldata-padding.md
+++ b/.changelog/fee-payer-calldata-padding.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject padded Tempo transfer calldata by requiring exact TIP-20 ABI lengths during shared calldata matching and server-side transaction validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,15 @@ go run ./examples/charge-basic                       # Run charge-basic example
 TEMPO_RPC_URL=http://localhost:8545 make integration  # Run integration tests
 ```
 
+## Changelogs
+
+Add release notes as new files under `.changelog/`; do not edit `CHANGELOG.md`
+directly. Use the full Go module path in frontmatter:
+
+```markdown
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Description of the change.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Reject padded Tempo transfer calldata by requiring exact TIP-20 ABI lengths during shared calldata matching and server-side transaction validation. (by @BrendanRyan, [#70](https://github.com/tempoxyz/mpp-go/pull/70))
 - Reject CR/LF in `WWW-Authenticate` challenge formatting and built-in server challenge responses. (by @EmmaJamieson-Hoare, [#49](https://github.com/tempoxyz/mpp-go/pull/49))
 
 ## `github.com/tempoxyz/mpp-go@0.1.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Patch Changes
 
-- Reject padded Tempo transfer calldata by requiring exact TIP-20 ABI lengths during shared calldata matching and server-side transaction validation. (by @BrendanRyan, [#70](https://github.com/tempoxyz/mpp-go/pull/70))
 - Reject CR/LF in `WWW-Authenticate` challenge formatting and built-in server challenge responses. (by @EmmaJamieson-Hoare, [#49](https://github.com/tempoxyz/mpp-go/pull/49))
 
 ## `github.com/tempoxyz/mpp-go@0.1.1`

--- a/pkg/tempo/abi.go
+++ b/pkg/tempo/abi.go
@@ -37,10 +37,13 @@ func EncodeTransferWithMemo(recipient string, amount *big.Int, memo string) (str
 // MatchTransferCalldata reports whether calldata satisfies the canonical Tempo charge transfer.
 func MatchTransferCalldata(dataHex string, request ChargeRequest, realm, challengeID string) bool {
 	dataHex = strings.TrimPrefix(strings.ToLower(dataHex), "0x")
-	if len(dataHex) < 8+64+64 {
+	if len(dataHex) < 8 {
 		return false
 	}
 	selector := dataHex[:8]
+	if selector != TransferWithMemoSelector || len(dataHex) != TransferWithMemoCalldataLength*2 {
+		return false
+	}
 	toAddress := "0x" + dataHex[8+24:8+64]
 	amount := new(big.Int)
 	amount.SetString(dataHex[72:136], 16)
@@ -48,21 +51,11 @@ func MatchTransferCalldata(dataHex string, request ChargeRequest, realm, challen
 		return false
 	}
 	expectedMemo := request.MethodDetails.Memo
-	switch selector {
-	case TransferSelector:
-		return false
-	case TransferWithMemoSelector:
-		if len(dataHex) < 8+64+64+64 {
-			return false
-		}
-		memo := "0x" + dataHex[136:200]
-		if expectedMemo != "" {
-			return strings.EqualFold(memo, expectedMemo)
-		}
-		return VerifyAttributionServer(memo, realm) && VerifyAttributionChallenge(memo, challengeID)
-	default:
-		return false
+	memo := "0x" + dataHex[136:200]
+	if expectedMemo != "" {
+		return strings.EqualFold(memo, expectedMemo)
 	}
+	return VerifyAttributionServer(memo, realm) && VerifyAttributionChallenge(memo, challengeID)
 }
 
 func padAddress(value string) string {

--- a/pkg/tempo/constants.go
+++ b/pkg/tempo/constants.go
@@ -22,6 +22,10 @@ const (
 	TransferSelector = "a9059cbb"
 	// TransferWithMemoSelector is the Tempo transfer-with-memo selector.
 	TransferWithMemoSelector = "95777d59"
+	// TransferCalldataLength is the exact byte length of transfer(address,uint256).
+	TransferCalldataLength = 4 + 32 + 32
+	// TransferWithMemoCalldataLength is the exact byte length of transferWithMemo(address,uint256,bytes32).
+	TransferWithMemoCalldataLength = 4 + 32 + 32 + 32
 	// MainnetUSDCAddress is Circle's USDC contract on Tempo mainnet.
 	MainnetUSDCAddress = "0x20C000000000000000000000b9537d11c60E8b50"
 )

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -191,6 +191,10 @@ func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
 		"MatchTransferCalldata() = false, want true for explicit memo") {
 		return
 	}
+	if !assert.False(t, MatchTransferCalldata(calldata+"01", explicitRequest, "ignored.example.com", "ignored-challenge"),
+		"MatchTransferCalldata() = true, want false for padded explicit memo calldata") {
+		return
+	}
 
 	implicitRequest := explicitRequest
 	implicitRequest.MethodDetails.Memo = ""
@@ -202,6 +206,10 @@ func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
 	}
 	if !assert.True(t, MatchTransferCalldata(attributedCalldata, implicitRequest, "api.example.com", "challenge-1"),
 		"MatchTransferCalldata() = false, want true for attribution memo") {
+		return
+	}
+	if !assert.False(t, MatchTransferCalldata(attributedCalldata+"01", implicitRequest, "api.example.com", "challenge-1"),
+		"MatchTransferCalldata() = true, want false for padded attribution memo calldata") {
 		return
 	}
 	if !assert.False(t, MatchTransferCalldata(attributedCalldata, implicitRequest, "other.example.com", "challenge-1"),

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -615,20 +615,30 @@ func expectedTransfers(request tempo.ChargeRequest) []expectedTransfer {
 
 func decodeCallTransfer(data []byte) (decodedTransfer, bool) {
 	dataHex := strings.TrimPrefix(strings.ToLower(common.Bytes2Hex(data)), "0x")
-	if len(dataHex) < 8+64+64 {
+	if len(dataHex) < 8 {
+		return decodedTransfer{}, false
+	}
+	selector := dataHex[:8]
+	switch selector {
+	case tempo.TransferSelector:
+		if len(dataHex) != tempo.TransferCalldataLength*2 {
+			return decodedTransfer{}, false
+		}
+	case tempo.TransferWithMemoSelector:
+		if len(dataHex) != tempo.TransferWithMemoCalldataLength*2 {
+			return decodedTransfer{}, false
+		}
+	default:
 		return decodedTransfer{}, false
 	}
 	decoded := decodedTransfer{
 		recipient: common.HexToAddress("0x" + dataHex[8+24:8+64]).Hex(),
 		amount:    new(big.Int).SetBytes(common.FromHex("0x" + dataHex[72:136])).String(),
 	}
-	switch dataHex[:8] {
+	switch selector {
 	case tempo.TransferSelector:
 		return decoded, true
 	case tempo.TransferWithMemoSelector:
-		if len(dataHex) < 8+64+64+64 {
-			return decodedTransfer{}, false
-		}
 		decoded.hasMemo = true
 		decoded.memo = "0x" + dataHex[136:200]
 		return decoded, true

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -35,6 +35,37 @@ const (
 	testReceiptHash = "0xabc123"
 )
 
+func TestDecodeCallTransferRejectsPaddedCalldata(t *testing.T) {
+	t.Parallel()
+
+	amount := big.NewInt(1000000)
+	transferData := common.FromHex(tempo.EncodeTransfer(testRecipient, amount))
+	if _, ok := decodeCallTransfer(transferData); !assert.True(t, ok,
+		"decodeCallTransfer() = false, want true for exact transfer calldata") {
+		return
+	}
+	if _, ok := decodeCallTransfer(append(append([]byte(nil), transferData...), 0x01)); !assert.False(t, ok,
+		"decodeCallTransfer() = true, want false for padded transfer calldata") {
+		return
+	}
+
+	memo := "0x" + strings.Repeat("ab", 32)
+	transferWithMemo, err := tempo.EncodeTransferWithMemo(testRecipient, amount, memo)
+	if !assert.NoError(t, err,
+		"EncodeTransferWithMemo() returned an unexpected error") {
+		return
+	}
+	transferWithMemoData := common.FromHex(transferWithMemo)
+	if _, ok := decodeCallTransfer(transferWithMemoData); !assert.True(t, ok,
+		"decodeCallTransfer() = false, want true for exact transferWithMemo calldata") {
+		return
+	}
+	if _, ok := decodeCallTransfer(append(append([]byte(nil), transferWithMemoData...), 0x01)); !assert.False(t, ok,
+		"decodeCallTransfer() = true, want false for padded transferWithMemo calldata") {
+		return
+	}
+}
+
 type mockRPC struct {
 	chainID          uint64
 	nonce            uint64


### PR DESCRIPTION
## Motivation

Fee-payer sponsorship validates Tempo transfer calldata before signing or accepting submitted transactions. Padded calldata must be rejected by exact length so trailing bytes cannot inflate intrinsic calldata gas while preserving decoded transfer arguments.

## Summary

- Add exact TIP-20 transfer calldata length constants.
- Reject padded transfer and transferWithMemo calldata in shared matching and server transaction decoding.
- Add regressions for padded explicit memo, attribution memo, transfer, and transferWithMemo calldata.

## Key design considerations

- Preserve existing attribution and explicit memo matching semantics.
- Apply the length check before parsing transfer arguments so padded calls never reach payment matching.