### PR TITLE
ci: make changelog check read-only

### DIFF
--- a/.changelog/changelog-check-permissions.md
+++ b/.changelog/changelog-check-permissions.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Run the pull request changelog check with read-only permissions so forked PRs can pass after adding a changelog.

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   changelogs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       # fetch-depth: 0 is required so the action can `git diff origin/main...HEAD`
       # against the base branch.
@@ -17,11 +17,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      # NOTE: `ai: 'amp -x'` and the `AMP_API_KEY` env are still intentionally
-      # omitted. The check action's AI path runs
-      # `curl -sSL https://changelogs.sh | sh`, which installs the upstream
-      # `wevm/changelogs-rs` binary — that binary does not yet ship Go
-      # ecosystem support, so the AI generation step would error out with
-      # `could not detect workspace`. Re-enable AI suggestions once a
-      # Go-aware binary is published to `wevm/changelogs-rs/releases`.
-      - uses: tempoxyz/changelogs/check@master
+      - name: Require changelog
+        shell: bash
+        run: |
+          changelogs=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '.changelog/*.md' \
+            | grep -vE '(^|/)README\.md$' \
+            || true)
+
+          if [ -z "$changelogs" ]; then
+            echo "::error::Missing changelog entry under .changelog/*.md"
+            exit 1
+          fi
+
+          {
+            echo "Found changelog entries:"
+            echo "$changelogs"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation

Forked pull requests can add valid changelog entries but the current changelog workflow still fails when it tries to comment with a read-only fork token.

## Summary

- Replace `tempoxyz/changelogs/check` with an inline read-only changelog diff check
- Set workflow token permissions to `contents: read`
- Add a changelog entry for the CI behavior change


## Key design considerations

- Keep fork PR execution on `pull_request` instead of `pull_request_target`
- Avoid requiring write tokens or secrets for untrusted fork workflows
- Emit a normal Actions error when no changelog entry is present
