### PR TITLE
test: align invalid challenge middleware statuses

### DIFF
--- a/.changelog/main-ci-invalid-challenge-tests.md
+++ b/.changelog/main-ci-invalid-challenge-tests.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Align middleware invalid-challenge test expectations with the core problem details status code.

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -224,7 +224,7 @@ func TestComposeMiddlewareAutoScopesResourceAndQuery(t *testing.T) {
 
 	paid := payWith(t, srv.URL+"/cart/456?view=full", challenge)
 	defer paid.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, paid.StatusCode)
+	assert.Equal(t, http.StatusPaymentRequired, paid.StatusCode)
 }
 
 func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
@@ -250,7 +250,7 @@ func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 
 	paid := payWithBody(t, srv.URL, betaChallenge, `{"query":"tampered"}`)
 	defer paid.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, paid.StatusCode)
+	assert.Equal(t, http.StatusPaymentRequired, paid.StatusCode)
 }
 
 func TestComposeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -185,7 +185,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	paidResponse := httptest.NewRecorder()
 	e.ServeHTTP(paidResponse, paidRequest)
 
-	assert.Equal(t, http.StatusBadRequest, paidResponse.Code)
+	assert.Equal(t, http.StatusPaymentRequired, paidResponse.Code)
 }
 
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -187,7 +187,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	require.NoError(t, err)
 	defer paidResponse.Body.Close()
 
-	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
+	assert.Equal(t, http.StatusPaymentRequired, paidResponse.StatusCode)
 }
 
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -168,7 +168,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	paidResponse := httptest.NewRecorder()
 	router.ServeHTTP(paidResponse, paidRequest)
 
-	assert.Equal(t, http.StatusBadRequest, paidResponse.Code)
+	assert.Equal(t, http.StatusPaymentRequired, paidResponse.Code)
 }
 
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -174,7 +174,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	paidResponse, err := http.DefaultClient.Do(retry)
 	require.NoError(t, err)
 	defer paidResponse.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, paidResponse.StatusCode)
+	assert.Equal(t, http.StatusPaymentRequired, paidResponse.StatusCode)
 }
 
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {


### PR DESCRIPTION
## Motivation

`main` CI is failing because middleware tests still expect invalid challenge responses to use HTTP 400 after the core problem details status mapping changed to HTTP 402.

## Summary

- Update core, composed, Echo, Fiber, and Gin middleware tests to expect `402 Payment Required` for invalid echoed challenge/body digest credentials.
- Add the required changelog entry.

## Key design considerations

- Keep production code unchanged because the current status mapping already matches the core problem details behavior.
- Leave true bad-request test cases expecting HTTP 400.