### PR TITLE
feat: add hint field to PaymentError problem details

### DIFF
--- a/.changelog/error-hints.md
+++ b/.changelog/error-hints.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Add `Hint` field to `PaymentError` problem details. `PaymentRequired`, `MalformedCredential`, and `MethodUnsupported` errors now include a default hint pointing users to wallet documentation.

--- a/pkg/mpp/errors.go
+++ b/pkg/mpp/errors.go
@@ -11,9 +11,9 @@ var ErrVerification = errors.New("payment verification failed")
 
 // Default hints for error types that support them.
 const (
-	HintPaymentRequired    = "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md"
+	HintPaymentRequired     = "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md"
 	HintMalformedCredential = "Use a supported wallet to construct valid credentials for one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md"
-	HintMethodUnsupported  = HintPaymentRequired
+	HintMethodUnsupported   = HintPaymentRequired
 )
 
 // ErrorType identifies a machine-readable MPP problem type.

--- a/pkg/mpp/errors.go
+++ b/pkg/mpp/errors.go
@@ -9,6 +9,13 @@ import (
 // ErrVerification is a sentinel error for payment verification failures.
 var ErrVerification = errors.New("payment verification failed")
 
+// Default hints for error types that support them.
+const (
+	HintPaymentRequired    = "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md"
+	HintMalformedCredential = "Use a supported wallet to construct valid credentials for one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md"
+	HintMethodUnsupported  = HintPaymentRequired
+)
+
 // ErrorType identifies a machine-readable MPP problem type.
 type ErrorType string
 
@@ -66,6 +73,7 @@ type PaymentError struct {
 	Title  string    `json:"title"`
 	Status int       `json:"status"`
 	Detail string    `json:"detail"`
+	Hint   string    `json:"hint,omitempty"`
 }
 
 func (e *PaymentError) Error() string {
@@ -101,6 +109,9 @@ func (e *PaymentError) ProblemDetails(challengeID string) map[string]any {
 	if challengeID != "" {
 		m["challengeId"] = challengeID
 	}
+	if e.Hint != "" {
+		m["hint"] = e.Hint
+	}
 	return m
 }
 
@@ -110,12 +121,16 @@ func ErrPaymentRequired(realm, description string) *PaymentError {
 	if description != "" {
 		detail = description
 	}
-	return newPaymentError(ErrorTypePaymentRequired, detail)
+	pe := newPaymentError(ErrorTypePaymentRequired, detail)
+	pe.Hint = HintPaymentRequired
+	return pe
 }
 
 // ErrMalformedCredential returns a 402 error for unparseable credentials.
 func ErrMalformedCredential(reason string) *PaymentError {
-	return newPaymentError(ErrorTypeMalformedCredential, reason)
+	pe := newPaymentError(ErrorTypeMalformedCredential, reason)
+	pe.Hint = HintMalformedCredential
+	return pe
 }
 
 // ErrInvalidChallenge returns a 402 error for invalid or tampered challenges.
@@ -150,5 +165,7 @@ func ErrPaymentInsufficient(reason string) *PaymentError {
 
 // ErrMethodUnsupported returns a 400 error for unsupported payment methods.
 func ErrMethodUnsupported(method string) *PaymentError {
-	return newPaymentError(ErrorTypeMethodUnsupported, fmt.Sprintf("payment method %q is not supported", method))
+	pe := newPaymentError(ErrorTypeMethodUnsupported, fmt.Sprintf("payment method %q is not supported", method))
+	pe.Hint = HintMethodUnsupported
+	return pe
 }

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -171,6 +171,65 @@ func TestPaymentErrorHelpers(t *testing.T) {
 	}
 }
 
+func TestPaymentErrorHints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *PaymentError
+		hint string
+	}{
+		{
+			name: "payment required has hint",
+			err:  ErrPaymentRequired("api.example.com", ""),
+			hint: HintPaymentRequired,
+		},
+		{
+			name: "malformed credential has hint",
+			err:  ErrMalformedCredential("bad"),
+			hint: HintMalformedCredential,
+		},
+		{
+			name: "method unsupported has hint",
+			err:  ErrMethodUnsupported("stripe"),
+			hint: HintMethodUnsupported,
+		},
+		{
+			name: "verification failed has no hint",
+			err:  ErrVerificationFailed("sig mismatch"),
+			hint: "",
+		},
+		{
+			name: "bad request has no hint",
+			err:  ErrBadRequest("invalid"),
+			hint: "",
+		},
+		{
+			name: "payment expired has no hint",
+			err:  ErrPaymentExpired("2026-01-01T00:00:00Z"),
+			hint: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.hint, tt.err.Hint,
+				"err.Hint = %q, want %q", tt.err.Hint, tt.hint)
+
+			problem := tt.err.ProblemDetails("")
+			if tt.hint != "" {
+				assert.Equalf(t, tt.hint, problem["hint"],
+					"problem[hint] = %q, want %q", problem["hint"], tt.hint)
+			} else {
+				assert.Nilf(t, problem["hint"],
+					"problem[hint] = %v, want nil", problem["hint"])
+			}
+		})
+	}
+}
+
 func TestReceiptRoundTrip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Same as https://github.com/wevm/mppx/pull/600 but for our Go SDK. Adds an optional `hint` to the problem details response body for `PaymentRequiredError`, `MalformedCredentialError`, and `PaymentMethodUnsupportedError`. I expect this to help an agent without prior context on MPP to better unblock themself.