### PR TITLE
fix(server): return fresh challenge on verification failure

### DIFF
--- a/.changelog/fresh-challenge-on-verification-failure.md
+++ b/.changelog/fresh-challenge-on-verification-failure.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Return a fresh `WWW-Authenticate: Payment` challenge when payment credential verification fails, allowing clients to retry with the current challenge.

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -108,6 +108,10 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 			result, err := entry.mpp.Charge(r.Context(), params)
 			if err != nil {
+				if result != nil && result.Challenge != nil {
+					WritePaymentErrorWithChallenge(w, err, result.Challenge, realm)
+					return
+				}
 				WritePaymentError(w, err)
 				return
 			}

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -43,6 +43,10 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 
 			result, err := m.Charge(c.Request().Context(), chargeParams)
 			if err != nil {
+				if result != nil && result.Challenge != nil {
+					server.WritePaymentErrorWithChallenge(c.Response(), err, result.Challenge, m.Realm())
+					return nil
+				}
 				server.WritePaymentError(c.Response(), err)
 				return nil
 			}

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -39,6 +39,10 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 
 		result, err := m.Charge(c.UserContext(), chargeParams)
 		if err != nil {
+			if result != nil && result.Challenge != nil {
+				WritePaymentErrorWithChallenge(c, err, result.Challenge, m.Realm())
+				return nil
+			}
 			WritePaymentError(c, err)
 			return nil
 		}
@@ -72,6 +76,23 @@ func fiberScope(c *fiberfw.Ctx) map[string]string {
 		return nil
 	}
 	return scope
+}
+
+// WritePaymentErrorWithChallenge serializes an MPP error with a fresh retry challenge.
+func WritePaymentErrorWithChallenge(c *fiberfw.Ctx, err error, challenge *mpp.Challenge, realm string) {
+	if challenge == nil {
+		WritePaymentError(c, err)
+		return
+	}
+
+	header, headerErr := challenge.ToAuthenticateStrict(realm)
+	if headerErr != nil {
+		WritePaymentError(c, mpp.ErrInvalidChallenge(challenge.ID, headerErr.Error()))
+		return
+	}
+
+	c.Set("WWW-Authenticate", header)
+	WritePaymentError(c, err)
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -43,6 +43,11 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 
 		result, err := m.Charge(c.Request.Context(), chargeParams)
 		if err != nil {
+			if result != nil && result.Challenge != nil {
+				server.WritePaymentErrorWithChallenge(c.Writer, err, result.Challenge, m.Realm())
+				c.Abort()
+				return
+			}
 			server.WritePaymentError(c.Writer, err)
 			c.Abort()
 			return

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -86,6 +86,10 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 
 			result, err := m.Charge(r.Context(), chargeParams)
 			if err != nil {
+				if result != nil && result.Challenge != nil {
+					WritePaymentErrorWithChallenge(w, err, result.Challenge, m.realm)
+					return
+				}
 				WritePaymentError(w, err)
 				return
 			}
@@ -124,6 +128,23 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 	w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
 
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// WritePaymentErrorWithChallenge serializes an MPP error with a fresh retry challenge.
+func WritePaymentErrorWithChallenge(w http.ResponseWriter, err error, challenge *mpp.Challenge, realm string) {
+	if challenge == nil {
+		WritePaymentError(w, err)
+		return
+	}
+
+	header, headerErr := challenge.ToAuthenticateStrict(realm)
+	if headerErr != nil {
+		WritePaymentError(w, mpp.ErrInvalidChallenge(challenge.ID, headerErr.Error()))
+		return
+	}
+
+	w.Header().Set("WWW-Authenticate", header)
+	WritePaymentError(w, err)
 }
 
 // WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -22,6 +23,22 @@ func (middlewareTestMethod) Name() string { return "tempo" }
 
 func (middlewareTestMethod) Intents() map[string]Intent {
 	return map[string]Intent{"charge": verifyTestIntent{}}
+}
+
+type verificationFailedMethod struct{}
+
+func (verificationFailedMethod) Name() string { return "tempo" }
+
+func (verificationFailedMethod) Intents() map[string]Intent {
+	return map[string]Intent{"charge": verificationFailedIntent{}}
+}
+
+type verificationFailedIntent struct{}
+
+func (verificationFailedIntent) Name() string { return "charge" }
+
+func (verificationFailedIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
+	return nil, mpp.ErrVerificationFailed("bad proof")
 }
 
 func TestChargeMiddleware_EndToEnd(t *testing.T) {
@@ -213,6 +230,44 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	body, err := io.ReadAll(paidResponse.Body)
 	require.NoError(t, err)
 	assert.Equal(t, originalBody, string(body))
+}
+
+func TestChargeMiddlewareReturnsFreshChallengeOnVerificationFailure(t *testing.T) {
+	payment := New(verificationFailedMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "handler should not be called")
+	}))
+
+	challengeReq := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResp := httptest.NewRecorder()
+	handler.ServeHTTP(challengeResp, challengeReq)
+	require.Equal(t, http.StatusPaymentRequired, challengeResp.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResp.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	req.Header.Set("Authorization", credential.ToAuthorization())
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusPaymentRequired, resp.Code)
+	require.NotEmpty(t, resp.Header().Get("WWW-Authenticate"))
+	_, err = mpp.ParseChallenge(resp.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, "application/problem+json", resp.Header().Get("Content-Type"))
+	assert.Equal(t, "no-store", resp.Header().Get("Cache-Control"))
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&problem))
+	assert.Equal(t, string(mpp.ErrorTypeVerificationFailed), problem.Type)
 }
 
 func TestChargeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -170,6 +170,13 @@ func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, e
 		Expires:       params.Expires,
 	})
 	if err != nil {
+		if result != nil {
+			return &ChargeResult{
+				Challenge:  result.Challenge,
+				Credential: result.Credential,
+				Receipt:    result.Receipt,
+			}, err
+		}
 		return nil, err
 	}
 

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"time"
 
@@ -107,14 +108,17 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	// 3. Parse credential.
 	credential, err := mpp.ParseCredential(authHeader)
 	if err != nil {
-		return nil, mpp.ErrMalformedCredential(err.Error())
+		return challengeResultError(challenge, mpp.ErrMalformedCredential(err.Error()))
 	}
 
 	// 4-5. Recompute expected challenge ID and constant-time compare.
 	// Reconstruct the echoed challenge request from base64.
 	echoedRequest, err := echoedRequestMap(credential)
 	if err != nil {
-		return nil, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
+		return challengeResultError(
+			challenge,
+			mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err)),
+		)
 	}
 
 	echoedChallenge := mpp.NewChallenge(
@@ -127,32 +131,35 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	)
 
 	if !mpp.ConstantTimeEqual(credential.Challenge.ID, echoedChallenge.ID) {
-		return nil, mpp.ErrInvalidChallenge(
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(
 			credential.Challenge.ID,
 			"challenge was not issued by this server",
-		)
+		))
 	}
 
 	// 6. Verify echoed fields match.
 	echoed := &credential.Challenge
 	if echoed.Realm != params.Realm {
-		return nil, mpp.ErrInvalidChallenge(echoed.ID, "realm mismatch")
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(echoed.ID, "realm mismatch"))
 	}
 	if echoed.Method != params.Method {
-		return nil, mpp.ErrInvalidChallenge(echoed.ID, "method mismatch")
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(echoed.ID, "method mismatch"))
 	}
 	if echoed.Intent != params.Intent.Name() {
-		return nil, mpp.ErrInvalidChallenge(echoed.ID, "intent mismatch")
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(echoed.ID, "intent mismatch"))
 	}
 
 	if !mpp.JSONEqual(echoedRequest, params.Request) {
-		return nil, mpp.ErrInvalidChallenge(
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(
 			echoed.ID,
 			"credential request does not match this route's requirements",
-		)
+		))
 	}
 	if echoed.Expires == "" {
-		return nil, mpp.ErrInvalidChallenge(echoed.ID, "missing required expires")
+		return challengeResultError(
+			challenge,
+			mpp.ErrInvalidChallenge(echoed.ID, "missing required expires"),
+		)
 	}
 	// 7. Check expiry before body-digest validation so expired credentials
 	// consistently return the payment-expired 402 path.
@@ -162,33 +169,39 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 			// Try the millisecond format used by mpp.Expires helpers.
 			expiresTime, err = time.Parse("2006-01-02T15:04:05.000Z", echoed.Expires)
 			if err != nil {
-				return nil, mpp.ErrInvalidChallenge(echoed.ID, "invalid expires format")
+				return challengeResultError(
+					challenge,
+					mpp.ErrInvalidChallenge(echoed.ID, "invalid expires format"),
+				)
 			}
 		}
 		if time.Now().UTC().After(expiresTime) {
-			return nil, mpp.ErrPaymentExpired(echoed.Expires)
+			return challengeResultError(challenge, mpp.ErrPaymentExpired(echoed.Expires))
 		}
 	}
 	if !reflect.DeepEqual(echoed.Opaque, challenge.Opaque) {
-		return nil, mpp.ErrInvalidChallenge(
+		return challengeResultError(challenge, mpp.ErrInvalidChallenge(
 			echoed.ID,
 			"credential opaque metadata does not match this route's requirements",
-		)
+		))
 	}
 	if params.Body != nil && echoed.Digest == "" {
 		return &VerifyResult{Challenge: challenge}, nil
 	}
 	if err := verifyBodyDigest(echoed.ID, echoed.Digest, params.Body); err != nil {
-		return nil, err
+		return challengeResultError(challenge, err)
 	}
 
 	// 9. Call intent.Verify.
 	receipt, err := params.Intent.Verify(ctx, credential, params.Request)
 	if err != nil {
 		if pe, ok := err.(*mpp.PaymentError); ok {
-			return nil, pe
+			if pe.Status != http.StatusPaymentRequired {
+				return nil, pe
+			}
+			return challengeResultError(challenge, pe)
 		}
-		return nil, mpp.ErrVerificationFailed(err.Error())
+		return challengeResultError(challenge, mpp.ErrVerificationFailed(err.Error()))
 	}
 
 	// 9. Return result.
@@ -196,6 +209,10 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		Credential: credential,
 		Receipt:    receipt,
 	}, nil
+}
+
+func challengeResultError(challenge *mpp.Challenge, err error) (*VerifyResult, error) {
+	return &VerifyResult{Challenge: challenge}, err
 }
 
 func verifyBodyDigest(challengeID, digest string, body any) error {


### PR DESCRIPTION
Closes #68.

## Summary

- return the freshly generated retry challenge alongside 402 credential-validation errors
- serialize that challenge in `WWW-Authenticate` for server, composed, Gin, Echo, and Fiber middleware paths
- keep non-402 errors challenge-free
- add regression coverage for `verification-failed` responses

## Testing

- `go test ./pkg/server -run TestChargeMiddlewareReturnsFreshChallengeOnVerificationFailure -count=1`
- `go test ./pkg/server -run 'TestChargeMiddlewareReturnsFreshChallengeOnVerificationFailure|TestChargeMiddlewareRejectsMultiplePaymentCredentials' -count=1`
- `go test ./pkg/server/fiber ./pkg/server/gin ./pkg/server/echo -count=1`
- `go test ./...`
- `go build ./...`