### PR TITLE
fix: prevent transfer log dedup reuse

### DIFF
--- a/.changelog/default-expires-verification.md
+++ b/.changelog/default-expires-verification.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject credentials that omit `expires` when verifying challenges with the default expiry policy.

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -161,6 +161,37 @@ func TestVerifyOrChallenge_RejectsMissingExpires(t *testing.T) {
 
 }
 
+func TestVerifyOrChallenge_RejectsMissingDefaultExpires(t *testing.T) {
+	request := map[string]any{
+		"amount":    "100",
+		"currency":  "0xabc",
+		"recipient": "0xdef",
+	}
+	tampered := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+	)
+	credential := &mpp.Credential{
+		Challenge: tampered.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	_, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing required expires") {
+		t.Fatalf("VerifyOrChallenge() error = %v, want missing required expires", err)
+	}
+}
+
 func TestVerifyOrChallenge_AllowsDynamicExpiresOverrides(t *testing.T) {
 	request := map[string]any{
 		"amount":    "100",

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -539,7 +539,7 @@ func canonicalReceiptTransfers(transfers []decodedTransfer) []decodedTransfer {
 		if !transfer.hasMemo {
 			continue
 		}
-		if paired := pairedTransferIndex(canonical, index); paired >= 0 {
+		if paired := pairedTransferIndex(canonical, index, skipped); paired >= 0 {
 			skipped[paired] = true
 		}
 	}
@@ -553,10 +553,10 @@ func canonicalReceiptTransfers(transfers []decodedTransfer) []decodedTransfer {
 	return result
 }
 
-func pairedTransferIndex(transfers []decodedTransfer, memoIndex int) int {
+func pairedTransferIndex(transfers []decodedTransfer, memoIndex int, skipped []bool) int {
 	withMemo := transfers[memoIndex]
 	for index, transfer := range transfers {
-		if index == memoIndex || transfer.hasMemo {
+		if index == memoIndex || transfer.hasMemo || skipped[index] {
 			continue
 		}
 		if transfer.amount == withMemo.amount && strings.EqualFold(transfer.recipient, withMemo.recipient) {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -1101,6 +1101,25 @@ func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestCanonicalReceiptTransfers_PairsDuplicateMemoTransfersWithDistinctBaseLogs(t *testing.T) {
+	t.Parallel()
+
+	transfers := []decodedTransfer{
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x01", recipient: testRecipient},
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x02", recipient: testRecipient},
+	}
+
+	got := canonicalReceiptTransfers(transfers)
+	want := []decodedTransfer{
+		{amount: "500000", hasMemo: true, memo: "0x01", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x02", recipient: testRecipient},
+	}
+
+	assert.Equal(t, want, got)
+}
+
 func newClientMethod(t *testing.T, rpc tempo.RPCClient, credentialType tempo.CredentialType) *chargeclient.Method {
 	t.Helper()
 	method, err := chargeclient.New(chargeclient.Config{


### PR DESCRIPTION
## Motivation

Tempo receipt verification should not allow multiple `TransferWithMemo` logs to reuse the same base `Transfer` log during deduplication, because that can leave spoofed extra transfers in the canonical receipt set.

## Summary

- Track already-paired base transfer logs while canonicalizing receipt transfers.
- Reject reused base transfer candidates when pairing `TransferWithMemo` logs.
- Add a regression test for duplicate memo transfers with identical amount and recipient.


## Key design considerations

- Keeps the existing deduplication model intact while making pairing stateful.
- Preserves order and matching behavior for legitimate one-to-one base/memo log pairs.