### PR TITLE
fix: prevent transfer log dedup reuse

### DIFF
--- a/.changelog/tempo-transfer-log-dedup.md
+++ b/.changelog/tempo-transfer-log-dedup.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Fix Tempo receipt verification so paired TransferWithMemo logs cannot reuse the same base Transfer log during deduplication.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,9 @@ TEMPO_RPC_URL=http://localhost:8545 make integration  # Run integration tests
 
 ## Changelogs
 
-Add release notes as new files under `.changelog/`; do not edit `CHANGELOG.md`
-directly. Use the full Go module path in frontmatter:
+Every PR should add a release note as a new Markdown file under `.changelog/`
+(singular); do not use `.changelogs/` or edit `CHANGELOG.md` directly. Use the
+full Go module path in frontmatter:
 
 ```markdown
 ---

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -515,7 +515,10 @@ func receiptMatches(receipt map[string]any, credential *mpp.Credential, request 
 		}
 		actual = append(actual, decoded)
 	}
-	actual = canonicalReceiptTransfers(actual)
+	actual, ok = canonicalReceiptTransfers(actual)
+	if !ok {
+		return false
+	}
 	return matchTransfers(actual, expected, credential.Challenge.Realm, credential.Challenge.ID)
 }
 
@@ -534,15 +537,17 @@ func isFeeControllerTransfer(fromAddress, recipient, amount string, expected []e
 // Tempo TIP-20 emits a standard Transfer alongside TransferWithMemo for the same
 // logical payment. Collapse those paired logs so receipt matching counts the
 // payment once while still rejecting unrelated extra transfers.
-func canonicalReceiptTransfers(transfers []decodedTransfer) []decodedTransfer {
+func canonicalReceiptTransfers(transfers []decodedTransfer) ([]decodedTransfer, bool) {
 	canonical := append([]decodedTransfer(nil), transfers...)
 	skipped := make([]bool, len(canonical))
 	for index, transfer := range canonical {
 		if !transfer.hasMemo {
 			continue
 		}
-		if paired := pairedTransferIndex(canonical, index); paired >= 0 {
+		if paired := pairedTransferIndex(canonical, index, skipped); paired >= 0 {
 			skipped[paired] = true
+		} else {
+			return nil, false
 		}
 	}
 	result := make([]decodedTransfer, 0, len(canonical))
@@ -552,13 +557,13 @@ func canonicalReceiptTransfers(transfers []decodedTransfer) []decodedTransfer {
 		}
 		result = append(result, transfer)
 	}
-	return result
+	return result, true
 }
 
-func pairedTransferIndex(transfers []decodedTransfer, memoIndex int) int {
+func pairedTransferIndex(transfers []decodedTransfer, memoIndex int, skipped []bool) int {
 	withMemo := transfers[memoIndex]
 	for index, transfer := range transfers {
-		if index == memoIndex || transfer.hasMemo {
+		if index == memoIndex || transfer.hasMemo || skipped[index] {
 			continue
 		}
 		if transfer.amount == withMemo.amount && strings.EqualFold(transfer.recipient, withMemo.recipient) {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -1132,6 +1132,43 @@ func TestFetchReceipt_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestCanonicalReceiptTransfers_PairsDuplicateMemoTransfersWithDistinctBaseLogs(t *testing.T) {
+	t.Parallel()
+
+	transfers := []decodedTransfer{
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x01", recipient: testRecipient},
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x02", recipient: testRecipient},
+	}
+
+	got, ok := canonicalReceiptTransfers(transfers)
+	want := []decodedTransfer{
+		{amount: "500000", hasMemo: true, memo: "0x01", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x02", recipient: testRecipient},
+	}
+
+	assert.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestCanonicalReceiptTransfers_RejectsUnpairedMemoTransfers(t *testing.T) {
+	t.Parallel()
+
+	transfers := []decodedTransfer{
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x01", recipient: testRecipient},
+		{amount: "500000", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x02", recipient: testRecipient},
+		{amount: "500000", hasMemo: true, memo: "0x03", recipient: testRecipient},
+	}
+
+	got, ok := canonicalReceiptTransfers(transfers)
+
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
 func newClientMethod(t *testing.T, rpc tempo.RPCClient, credentialType tempo.CredentialType) *chargeclient.Method {
 	t.Helper()
 	method, err := chargeclient.New(chargeclient.Config{


### PR DESCRIPTION
## Motivation

Tempo receipt verification should not allow multiple `TransferWithMemo` logs to reuse the same base `Transfer` log during deduplication, because that can leave spoofed extra transfers in the canonical receipt set.

## Summary

- Track already-paired base transfer logs while canonicalizing receipt transfers.
- Reject reused base transfer candidates when pairing `TransferWithMemo` logs.
- Add a regression test for duplicate memo transfers with identical amount and recipient.


## Key design considerations

- Keeps the existing deduplication model intact while making pairing stateful.
- Preserves order and matching behavior for legitimate one-to-one base/memo log pairs.