### PR TITLE
ci: Add GitHub Actions scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 7
     groups:
       go-deps:
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -14,11 +14,12 @@ jobs:
       # fetch-depth: 0 + fetch-tags: true so the Go ecosystem can read prior
       # vX.Y.Z tags when computing the next version, and so the action can diff
       # CHANGELOG.md.
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
-      - uses: tempoxyz/changelogs@master
+      - uses: tempoxyz/changelogs@466632795bfca34dc9bb7f7bcab9f50c6e3f3726 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -3,6 +3,8 @@ name: Changelogs
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - ".github/**"
 
 permissions:
   contents: read
@@ -23,13 +25,6 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
-          non_ci_changes=$(echo "$changed" | grep -vE '^\.github/' || true)
-          if [ -z "$non_ci_changes" ]; then
-            echo "Only .github changes detected; skipping changelog requirement"
-            exit 0
-          fi
-
           changelogs=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '.changelog/*.md' \
             | grep -vE '(^|/)README\.md$' \
             || true)

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -13,14 +13,17 @@ jobs:
     steps:
       # fetch-depth: 0 is required so the action can `git diff origin/main...HEAD`
       # against the base branch.
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Require changelog
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          changelogs=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '.changelog/*.md' \
+          changelogs=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '.changelog/*.md' \
             | grep -vE '(^|/)README\.md$' \
             || true)
 

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -23,6 +23,13 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          non_ci_changes=$(echo "$changed" | grep -vE '^\.github/' || true)
+          if [ -z "$non_ci_changes" ]; then
+            echo "Only .github changes detected; skipping changelog requirement"
+            exit 0
+          fi
+
           changelogs=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '.changelog/*.md' \
             | grep -vE '(^|/)README\.md$' \
             || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Resolve Tempo image digest
         id: tempo-digest
         run: |
-          digest=$(docker buildx imagetools inspect ghcr.io/tempoxyz/tempo:${TEMPO_TAG} --raw | sha256sum | cut -d' ' -f1)
+          digest=$(docker buildx imagetools inspect "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" --raw | sha256sum | cut -d' ' -f1)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Tempo Docker image
@@ -102,8 +102,8 @@ jobs:
       - name: Pull and cache Tempo image
         if: steps.docker-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ghcr.io/tempoxyz/tempo:${TEMPO_TAG}
-          docker save ghcr.io/tempoxyz/tempo:${TEMPO_TAG} -o /tmp/tempo-image.tar
+          docker pull "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}"
+          docker save "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" -o /tmp/tempo-image.tar
 
       - name: Start Tempo devnet
         run: docker compose up -d

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@924710544d534332220d164bfa5747340bb85f93
     with:
       protocol-paths: |
         pkg/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@924710544d534332220d164bfa5747340bb85f93
     with:
       adapter: go
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -35,9 +35,11 @@ jobs:
             }
             found { print }
           ' CHANGELOG.md)
-          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$NOTES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,10 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          body: ${{ steps.changelog.outputs.notes }}
-          generate_release_notes: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTES: ${{ steps.changelog.outputs.notes }}
+        run: |
+          notes_file="$(mktemp)"
+          printf '%s\n' "$NOTES" > "$notes_file"
+          gh release create "$GITHUB_REF_NAME" --notes-file "$notes_file"

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -13,12 +13,12 @@ on:
   schedule:
     - cron: "19 7 * * 1"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scan:
     name: Scan GitHub Actions
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
     permissions:
+      actions: read
       contents: read

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -1,0 +1,24 @@
+name: Scan GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "19 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan GitHub Actions
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- add the pinned `tempoxyz/gh-actions` GitHub Actions scanner workflow
- fix existing zizmor/actionlint findings without adding ignore baselines
- pin mutable reusable workflow/action refs and move unsafe template expressions through env where needed

Prompted by: @0xalpharush

## Validation
- `uvx zizmor --offline .github/workflows`: passes locally
- `actionlint`: passes locally
