### PR TITLE
fix: preserve receipt subscription IDs

### DIFF
--- a/.changelog/preserve-receipt-subscription-id.md
+++ b/.changelog/preserve-receipt-subscription-id.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Preserve `subscriptionId` when parsing and formatting payment receipts.

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -237,6 +237,7 @@ func TestReceiptRoundTrip(t *testing.T) {
 		"ref-123",
 		WithReceiptMethod("tempo"),
 		WithExternalID("ext-123"),
+		WithSubscriptionID("sub-123"),
 		WithExtra(map[string]any{"settled": true}),
 	)
 	if !assert.Equalf(t, "success", receipt.Status,
@@ -266,6 +267,10 @@ func TestReceiptRoundTrip(t *testing.T) {
 		"parsed.ExternalID = %q, want %q", parsed.ExternalID, receipt.ExternalID) {
 		return
 	}
+	if !assert.Equalf(t, receipt.SubscriptionID, parsed.SubscriptionID,
+		"parsed.SubscriptionID = %q, want %q", parsed.SubscriptionID, receipt.SubscriptionID) {
+		return
+	}
 	if !assert.Equalf(t, true, parsed.Extra["settled"],
 		"parsed.Extra[settled] = %#v, want true", parsed.Extra["settled"]) {
 		return
@@ -273,6 +278,38 @@ func TestReceiptRoundTrip(t *testing.T) {
 
 	if got, want := parsed.Timestamp.Format("2006-01-02T15:04:05.000Z"), receipt.Timestamp.Format("2006-01-02T15:04:05.000Z"); got != want {
 		assert.Failf(t, "", "parsed.Timestamp = %q, want %q", got, want)
+		return
+	}
+}
+
+func TestParsePaymentReceiptPreservesForeignSubscriptionID(t *testing.T) {
+	t.Parallel()
+
+	header := b64EncodeAny(map[string]any{
+		"status":         "success",
+		"method":         "tempo",
+		"timestamp":      "2026-01-01T00:00:00Z",
+		"reference":      "ref-123",
+		"subscriptionId": "sub-123",
+	})
+
+	parsed, err := ParseReceipt(header)
+	if !assert.NoErrorf(t, err,
+		"ParseReceipt() error = %v", err) {
+		return
+	}
+	if !assert.Equalf(t, "sub-123", parsed.SubscriptionID,
+		"parsed.SubscriptionID = %q, want sub-123", parsed.SubscriptionID) {
+		return
+	}
+
+	roundtripped, err := ParseReceipt(FormatReceipt(parsed))
+	if !assert.NoErrorf(t, err,
+		"ParseReceipt(FormatReceipt(parsed)) error = %v", err) {
+		return
+	}
+	if !assert.Equalf(t, "sub-123", roundtripped.SubscriptionID,
+		"roundtripped.SubscriptionID = %q, want sub-123", roundtripped.SubscriptionID) {
 		return
 	}
 }

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -499,6 +499,11 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		externalID = anyStr(v)
 	}
 
+	var subscriptionID string
+	if v, ok := data["subscriptionId"]; ok {
+		subscriptionID = anyStr(v)
+	}
+
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -507,12 +512,13 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	return &Receipt{
-		Status:     status,
-		Timestamp:  ts,
-		Reference:  reference,
-		Method:     method,
-		ExternalID: externalID,
-		Extra:      extra,
+		Status:         status,
+		Timestamp:      ts,
+		Reference:      reference,
+		Method:         method,
+		ExternalID:     externalID,
+		SubscriptionID: subscriptionID,
+		Extra:          extra,
 	}, nil
 }
 
@@ -530,6 +536,9 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if r.ExternalID != "" {
 		data["externalId"] = r.ExternalID
+	}
+	if r.SubscriptionID != "" {
+		data["subscriptionId"] = r.SubscriptionID
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra

--- a/pkg/mpp/receipt.go
+++ b/pkg/mpp/receipt.go
@@ -5,12 +5,13 @@ import "time"
 // Receipt represents a server-issued payment receipt sent via the
 // Payment-Receipt header.
 type Receipt struct {
-	Status     string         `json:"status"`
-	Timestamp  time.Time      `json:"timestamp"`
-	Reference  string         `json:"reference"`
-	Method     string         `json:"method,omitempty"`
-	ExternalID string         `json:"externalId,omitempty"`
-	Extra      map[string]any `json:"extra,omitempty"`
+	Status         string         `json:"status"`
+	Timestamp      time.Time      `json:"timestamp"`
+	Reference      string         `json:"reference"`
+	Method         string         `json:"method,omitempty"`
+	ExternalID     string         `json:"externalId,omitempty"`
+	SubscriptionID string         `json:"subscriptionId,omitempty"`
+	Extra          map[string]any `json:"extra,omitempty"`
 }
 
 // ReceiptOption configures optional fields when creating a Receipt.
@@ -24,6 +25,11 @@ func WithReceiptMethod(method string) ReceiptOption {
 // WithExternalID sets the external transaction ID on a Receipt.
 func WithExternalID(id string) ReceiptOption {
 	return func(r *Receipt) { r.ExternalID = id }
+}
+
+// WithSubscriptionID sets the server-issued subscription ID on a Receipt.
+func WithSubscriptionID(id string) ReceiptOption {
+	return func(r *Receipt) { r.SubscriptionID = id }
 }
 
 // WithExtra sets extra metadata on a Receipt.


### PR DESCRIPTION
Fixes #78.

## Summary

This keeps Tempo subscription receipt metadata from being dropped when Go code parses and re-emits a `Payment-Receipt` header.

The Rust SDK recently added `Receipt.subscription_id` / `subscriptionId` support, and subscription activation receipts can carry this server-issued identifier. `mpp-go` already preserves optional receipt metadata such as `externalId` and `extra`, but `subscriptionId` was not represented on `Receipt`, parsed from foreign receipts, or emitted when formatting receipts again.

## Changes

- Add `Receipt.SubscriptionID` with the JSON field name `subscriptionId`.
- Add `WithSubscriptionID(...)` for Go-created receipts.
- Preserve `subscriptionId` in `ParsePaymentReceipt` and `FormatPaymentReceipt`.
- Add regression coverage for both Go-created receipts and foreign SDK receipts that already include `subscriptionId`.

## Validation

- `go test ./pkg/mpp`
- `go test ./...`