### PR TITLE
fix(server): set Cache-Control: private on paid responses in gin/echo/fiber adapters

### DIFF
--- a/.changelog/adapter-cache-control-private.md
+++ b/.changelog/adapter-cache-control-private.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Set `Cache-Control: private` on paid responses in the gin, echo, and fiber adapters. Previously these adapters set only `Payment-Receipt`, so behind a CDN/proxy heuristic caching could leak a payer's receipt and paid body to unpaid clients. The net/http middleware already applied this directive; the adapters now match it.

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -56,6 +56,9 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 			c.SetRequest(c.Request().WithContext(ctx))
 			c.Set(credentialKey, result.Credential)
 			c.Set(receiptKey, result.Receipt)
+			// Mark the paid response as private so shared caches never serve a
+			// Payment-Receipt to a different client, mirroring server.serveVerified.
+			c.Response().Header().Set("Cache-Control", "private")
 			c.Response().Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
 			return next(c)
 		}

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -119,6 +119,39 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddlewareMarksPaidResponsePrivate(t *testing.T) {
+	t.Parallel()
+
+	e := echofw.New()
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	e.GET("/paid", func(c echofw.Context) error {
+		return c.String(http.StatusOK, "paid")
+	}, ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}))
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResponse := httptest.NewRecorder()
+	e.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	e.ServeHTTP(paidResponse, paidRequest)
+
+	require.Equal(t, http.StatusOK, paidResponse.Code)
+	require.NotEmpty(t, paidResponse.Header().Get("Payment-Receipt"))
+	assert.Equal(t, "private", paidResponse.Header().Get("Cache-Control"),
+		"paid response with a Payment-Receipt must be marked Cache-Control: private")
+}
+
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -52,6 +52,9 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.SetUserContext(ctx)
 		c.Locals(credentialKey, result.Credential)
 		c.Locals(receiptKey, result.Receipt)
+		// Mark the paid response as private so shared caches never serve a
+		// Payment-Receipt to a different client, mirroring server.serveVerified.
+		c.Set("Cache-Control", "private")
 		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
 		return c.Next()
 	}

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -117,6 +117,41 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 
 }
 
+func TestChargeMiddlewareMarksPaidResponsePrivate(t *testing.T) {
+	t.Parallel()
+
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
+		return c.SendString("paid")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResponse, err := app.Test(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := app.Test(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+
+	require.Equal(t, http.StatusOK, paidResponse.StatusCode)
+	require.NotEmpty(t, paidResponse.Header.Get("Payment-Receipt"))
+	assert.Equal(t, "private", paidResponse.Header.Get("Cache-Control"),
+		"paid response with a Payment-Receipt must be marked Cache-Control: private")
+}
+
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -58,6 +58,9 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 		c.Request = c.Request.WithContext(ctx)
 		c.Set(credentialKey, result.Credential)
 		c.Set(receiptKey, result.Receipt)
+		// Mark the paid response as private so shared caches never serve a
+		// Payment-Receipt to a different client, mirroring server.serveVerified.
+		c.Writer.Header().Set("Cache-Control", "private")
 		c.Writer.Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
 		c.Next()
 	}

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -100,6 +100,40 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddlewareMarksPaidResponsePrivate(t *testing.T) {
+	t.Parallel()
+
+	ginfw.SetMode(ginfw.TestMode)
+	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	router := ginfw.New()
+	router.GET("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
+		c.String(http.StatusOK, "paid")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResponse := httptest.NewRecorder()
+	router.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	router.ServeHTTP(paidResponse, paidRequest)
+
+	require.Equal(t, http.StatusOK, paidResponse.Code)
+	require.NotEmpty(t, paidResponse.Header().Get("Payment-Receipt"))
+	assert.Equal(t, "private", paidResponse.Header().Get("Cache-Control"),
+		"paid response with a Payment-Receipt must be marked Cache-Control: private")
+}
+
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Set `Cache-Control: private` on paid responses in the Gin, Echo, and Fiber adapters

**Type:** Security fix · **Severity:** High · **Area:** `pkg/server/{gin,echo,fiber}`

## Summary

The `net/http` middleware marks every successfully-paid response as
`Cache-Control: private` so that a shared cache can never hand one payer's
`Payment-Receipt` (and the paid body) to a different client. The three
framework adapters re-implement the success path inline and set the
`Payment-Receipt` header **without** the accompanying cache directive. This PR
brings all three adapters back in line with the core middleware and locks the
behavior in with a regression test per adapter.

## Why this matters

`serveVerified` in [pkg/server/middleware.go](pkg/server/middleware.go) is
explicit about the invariant:

```go
// Mark the paid response as private so shared caches never serve a
// Payment-Receipt to a different client. This mirrors the MPP spec
// (mpp.dev/protocol) and the rust reference implementation.
w.Header().Set("Cache-Control", "private")
w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
```

The Gin, Echo, and Fiber `ChargeMiddleware` handlers each set only
`Payment-Receipt`. When such a server sits behind a CDN or reverse proxy, a
`200 OK` on a `GET` route with a `Payment-Receipt` header and no cache
directives is eligible for **heuristic caching** (RFC 9111 §4.2.2). A shared
cache may then replay the paid body and another user's receipt to an unrelated,
unpaid client — precisely the leak the core middleware was written to prevent.

Three of the four officially supported stacks were affected; only the raw
`net/http` path (and `ComposeMiddleware`, which routes through `serveVerified`)
was protected.

## The fix

Add `Cache-Control: private` alongside the `Payment-Receipt` header in each
adapter's verified branch, using each framework's native header API:

| Adapter | Call |
| --- | --- |
| Gin   | `c.Writer.Header().Set("Cache-Control", "private")` |
| Echo  | `c.Response().Header().Set("Cache-Control", "private")` |
| Fiber | `c.Set("Cache-Control", "private")` |
