### PR TITLE
fix(client): refuse standalone Transport auto-pay after a redirect

### DIFF
--- a/.changelog/transport-redirect-guard.md
+++ b/.changelog/transport-redirect-guard.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Refuse standalone `Transport` auto-pay after a redirect. A `Transport` used with a bare `http.Client` (no `CheckRedirect`) had none of `Client.Do`'s cross-origin redirect protection, so a redirect to an attacker origin could be auto-paid. The Transport now fails closed on any redirect-produced request when no trusted origin is pinned in the context.

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -170,6 +170,16 @@ func sameOriginURL(requestURL *url.URL, origin string) bool {
 func validatePaymentOrigin(req *http.Request, challenge *mpp.Challenge) error {
 	origin := paymentOrigin(req.Context())
 	if origin == "" {
+		// Standalone Transport: no trusted origin was pinned into the context
+		// (that only happens when the Transport is driven through Client.Do).
+		// We cannot compare against the caller's intended origin, so fall back
+		// to the request URL — but first refuse if this request was produced by
+		// a redirect. net/http sets Request.Response only on redirect
+		// follow-ups, so its presence means the caller never chose this origin
+		// and we must not auto-pay it.
+		if req.Response != nil {
+			return fmt.Errorf("mpp: refusing payment after redirect to %q; drive the Transport through client.Client for redirect-safe payments", requestOrigin(req.URL))
+		}
 		origin = requestOrigin(req.URL)
 	}
 	if !sameOriginURL(req.URL, origin) {

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -354,6 +354,69 @@ func TestTransport_RoundTrip_RejectsOriginMismatchFromContext(t *testing.T) {
 
 }
 
+func TestTransport_RoundTrip_StandaloneRefusesRedirectedPayment(t *testing.T) {
+	// A standalone Transport (no Client.Do wrapper) plugged into a redirect
+	// following http.Client must not auto-pay an origin reached via redirect.
+	var challenge *mpp.Challenge
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer attacker.Close()
+	challenge = challengeForURL(t, attacker.URL, "tempo", nil)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	// The natural, unguarded way to use the exported Transport.
+	hc := &http.Client{Transport: tr}
+	req, _ := http.NewRequest(http.MethodGet, origin.URL, nil)
+	_, err := hc.Do(req)
+
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "refusing payment after redirect"),
+		"Do() error = %v, want redirect-payment refusal", err) {
+		return
+	}
+	if !assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0", method.calls) {
+		return
+	}
+}
+
+func TestTransport_RoundTrip_StandaloneDirectRequestStillPays(t *testing.T) {
+	// A standalone Transport must keep working for a direct (non-redirected)
+	// request: the request URL is the origin the caller chose.
+	var challenge *mpp.Challenge
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	hc := &http.Client{Transport: tr}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := hc.Do(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, method.calls)
+}
+
 func TestClient_Get(t *testing.T) {
 	var challenge *mpp.Challenge
 


### PR DESCRIPTION
## fix: standalone `Transport` must not auto-pay an origin reached via redirect

### The problem, as an attack

1. A developer wires the exported payment transport into a plain client — the
   documented, obvious usage:

   ```go
   tr := client.NewTransport(methods, nil)
   hc := &http.Client{Transport: tr}
   resp, _ := hc.Get("https://good.example.com/resource")
   ```

2. `good.example.com` (compromised, MITM'd, or just carrying an open redirect)
   answers `302 Location: https://attacker.example.com/pay`.
3. The bare `http.Client` has no `CheckRedirect`, so it follows to the attacker
   and calls `tr.RoundTrip` again — now with `req.URL = attacker`.
4. The attacker returns `402` with a perfectly valid challenge: recipient =
   attacker address, amount = whatever they like.
5. `validatePaymentOrigin` finds no trusted origin in the context (that is only
   seeded by `Client.Do`), falls back to `origin = requestOrigin(req.URL)`, and
   compares the attacker URL **against itself** — which always passes.
6. `CreateCredential` signs (and, in hash mode, broadcasts) a payment to the
   attacker. Funds move.

The redirect protections all live in `Client.Do` (it pins the origin into the
request context and installs a cross-origin `CheckRedirect`). The exported
`Transport`/`NewTransport` — a legitimate integration point for a custom
`http.Client` — ships with neither, and the context fallback silently defeats
the one check `RoundTrip` does run.

### The fix

A `RoundTripper` cannot see the redirect chain the way `Client.Do` can. But it
can see one thing: `net/http` sets `Request.Response` **only** on a request that
was produced by following a redirect. So when the Transport is used standalone
(no origin pinned in the context) we fail closed on exactly that signal:

```go
if req.Response != nil {
    return fmt.Errorf("mpp: refusing payment after redirect to %q; ...", requestOrigin(req.URL))
}
origin = requestOrigin(req.URL)
```

- **Direct request, standalone Transport** → `req.Response == nil` → pays the
  origin the caller actually chose. Unchanged behavior.
- **Redirected request, standalone Transport** → `req.Response != nil` →
  refuses. Attack closed.
- **Via `Client.Do`** → the context already carries the trusted origin, so the
  existing same-origin comparison handles every hop, including the first.

### Tests

Two new tests in `pkg/client/transport_test.go`:

- `TestTransport_RoundTrip_StandaloneRefusesRedirectedPayment` — drives a
  standalone `Transport` through a redirect-following `http.Client` from a
  benign origin to an attacker origin, and asserts the request is refused with
  **zero** calls to `CreateCredential`. Fails before the patch.
- `TestTransport_RoundTrip_StandaloneDirectRequestStillPays` — guards the happy
  path so the fail-closed check doesn't over-block direct requests.

`go test ./pkg/client/...` → `ok`.