### PR TITLE
fix(server): bound the pre-auth request-body read

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -4,12 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
+
+// MaxRequestBodyBytes caps how many bytes ReadRequestBody buffers from a
+// request body. The middleware reads the body before payment is verified (to
+// compute/validate the body digest), so an unbounded read lets an
+// unauthenticated client exhaust server memory with a large body. Set to 0 to
+// disable the limit.
+var MaxRequestBodyBytes int64 = 1 << 20 // 1 MiB
 
 type contextKey int
 
@@ -101,14 +109,25 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 }
 
 // ReadRequestBody reads and restores r.Body so middleware can verify body digests
-// without consuming the body before the protected handler runs.
+// without consuming the body before the protected handler runs. The read is
+// bounded by MaxRequestBodyBytes; a larger body yields an error so callers can
+// reject it instead of buffering it into memory.
 func ReadRequestBody(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return nil, nil
 	}
-	body, err := io.ReadAll(r.Body)
+	var reader io.Reader = r.Body
+	if MaxRequestBodyBytes > 0 {
+		// Read one extra byte so we can distinguish "exactly at the limit" from
+		// "over the limit".
+		reader = io.LimitReader(r.Body, MaxRequestBodyBytes+1)
+	}
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
+	}
+	if MaxRequestBodyBytes > 0 && int64(len(body)) > MaxRequestBodyBytes {
+		return nil, fmt.Errorf("mpp: request body exceeds %d bytes", MaxRequestBodyBytes)
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	return body, nil

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -101,6 +101,48 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestReadRequestBodyEnforcesLimit(t *testing.T) {
+	prev := MaxRequestBodyBytes
+	MaxRequestBodyBytes = 16
+	defer func() { MaxRequestBodyBytes = prev }()
+
+	// At the limit: allowed and fully preserved.
+	exact := strings.Repeat("a", 16)
+	r := httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(exact))
+	body, err := ReadRequestBody(r)
+	require.NoError(t, err)
+	assert.Equal(t, exact, string(body))
+	restored, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	assert.Equal(t, exact, string(restored), "body must be restored for the handler")
+
+	// Over the limit: rejected without buffering the whole body.
+	tooBig := strings.Repeat("a", 17)
+	r = httptest.NewRequest(http.MethodPost, "/paid", strings.NewReader(tooBig))
+	_, err = ReadRequestBody(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestChargeMiddlewareRejectsOversizedBody(t *testing.T) {
+	prev := MaxRequestBodyBytes
+	MaxRequestBodyBytes = 32
+	defer func() { MaxRequestBodyBytes = prev }()
+
+	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "application/json", strings.NewReader(strings.Repeat("x", 1024)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"oversized body must be rejected before verification")
+}
+
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
# Bound the pre-auth request-body read (`ReadRequestBody`)

**Problem.** `ReadRequestBody` calls `io.ReadAll(r.Body)` with no size limit, and
the charge middleware calls it on *every* request — before any credential is
checked — so it can compute/validate the body digest. Headers are already capped
at 16 KB (`pkg/mpp/parse.go`), but the body is not. An unauthenticated client
can POST arbitrarily large bodies to any protected route and force the server to
buffer each one in memory before it even returns the free `402`. That's a
memory-exhaustion DoS reachable without holding a payment credential. The core
`net/http` path plus the Gin and Echo adapters all funnel through
`ReadRequestBody` and are affected; Fiber reads via `c.Body()` (fasthttp bounds
that itself) and is not.

**Fix.**
- Add `server.MaxRequestBodyBytes` (default **1 MiB**, `0` disables).
- `ReadRequestBody` now reads through `io.LimitReader(r.Body, limit+1)` and
  returns an error when the body exceeds the limit, instead of buffering it all.
- Callers already translate that error into `ErrBadRequest` → **HTTP 400**, so no
  call-site changes are needed. The body is still fully restored for the handler
  when it's within bounds.

**Compatibility.** Default limit is generous (1 MiB) and tunable per deployment;
existing in-bounds requests behave exactly as before. Setting
`MaxRequestBodyBytes = 0` restores the old unbounded behavior for anyone who
needs it.

**Tests added** (`pkg/server/middleware_test.go`):
- `TestReadRequestBodyEnforcesLimit` — a body exactly at the limit is accepted
  and restored intact; one byte over is rejected with an `exceeds` error.
- `TestChargeMiddlewareRejectsOversizedBody` — an oversized POST to a protected
  route returns `400` before verification runs.

`go test ./pkg/server/` → `ok`.