### PR TITLE
fix(mpp): strip CR/LF in default FormatAuthenticate to prevent header injection

### DIFF
--- a/.changelog/strip-crlf-format-authenticate.md
+++ b/.changelog/strip-crlf-format-authenticate.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Strip CR and LF characters in the default `FormatAuthenticate` path so a `Challenge` field containing `\r\n` (e.g. `Description`, `Realm`) can no longer split the `WWW-Authenticate` header and inject a response. `FormatAuthenticateStrict` continues to reject such values with an error.

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -312,6 +312,10 @@ func b64EncodeRequest(request map[string]any) string {
 }
 
 func escapeQuoted(value string) string {
+	// Strip CR and LF unconditionally so the non-strict FormatAuthenticate can
+	// never emit a header value that splits the HTTP response. FormatAuthenticateStrict
+	// rejects such values earlier with an error; this keeps the default path safe too.
+	value = strings.NewReplacer("\r", "", "\n", "").Replace(value)
 	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
 }
 
@@ -499,11 +503,6 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		externalID = anyStr(v)
 	}
 
-	var subscriptionID string
-	if v, ok := data["subscriptionId"]; ok {
-		subscriptionID = anyStr(v)
-	}
-
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -512,13 +511,12 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	return &Receipt{
-		Status:         status,
-		Timestamp:      ts,
-		Reference:      reference,
-		Method:         method,
-		ExternalID:     externalID,
-		SubscriptionID: subscriptionID,
-		Extra:          extra,
+		Status:     status,
+		Timestamp:  ts,
+		Reference:  reference,
+		Method:     method,
+		ExternalID: externalID,
+		Extra:      extra,
 	}, nil
 }
 
@@ -536,9 +534,6 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if r.ExternalID != "" {
 		data["externalId"] = r.ExternalID
-	}
-	if r.SubscriptionID != "" {
-		data["subscriptionId"] = r.SubscriptionID
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -503,6 +503,11 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		externalID = anyStr(v)
 	}
 
+	var subscriptionID string
+	if v, ok := data["subscriptionId"]; ok {
+		subscriptionID = anyStr(v)
+	}
+
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -511,12 +516,13 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	return &Receipt{
-		Status:     status,
-		Timestamp:  ts,
-		Reference:  reference,
-		Method:     method,
-		ExternalID: externalID,
-		Extra:      extra,
+		Status:         status,
+		Timestamp:      ts,
+		Reference:      reference,
+		Method:         method,
+		ExternalID:     externalID,
+		SubscriptionID: subscriptionID,
+		Extra:          extra,
 	}, nil
 }
 
@@ -534,6 +540,9 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if r.ExternalID != "" {
 		data["externalId"] = r.ExternalID
+	}
+	if r.SubscriptionID != "" {
+		data["subscriptionId"] = r.SubscriptionID
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -258,6 +258,27 @@ func TestFormatAuthenticateStrictRejectsCRLF(t *testing.T) {
 	}
 }
 
+func TestFormatAuthenticateStripsCRLF(t *testing.T) {
+	t.Parallel()
+
+	challenge := NewChallenge("secret", "api.example.com", "tempo", "charge",
+		map[string]any{"amount": "100"},
+		WithDescription("Line one\r\nX-Injected: pwned"))
+
+	got := challenge.ToAuthenticate("api.example.com")
+
+	// The non-strict formatter must never emit CR or LF; otherwise the value
+	// could split the HTTP response when written to a header.
+	assert.NotContains(t, got, "\r", "header value must not contain CR")
+	assert.NotContains(t, got, "\n", "header value must not contain LF")
+
+	// The result must still be a well-formed, parseable challenge.
+	parsed, err := ParseChallenge(got)
+	require.NoError(t, err)
+	assert.NotContains(t, parsed.Description, "\r")
+	assert.NotContains(t, parsed.Description, "\n")
+}
+
 func TestParseChallenge(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
fix: strip CR/LF in the default `FormatAuthenticate` (header-injection hardening)

WHAT
----
`escapeQuoted` escapes `\` and `"` but passes control characters through
untouched. The CR/LF guard lives only in the `add` closure and only fires when
`rejectCRLF == true` — which is set exclusively by `FormatAuthenticateStrict`.
The default `Challenge.ToAuthenticate` / `FormatAuthenticate` call
`formatAuthenticate(..., false)`, so a `Challenge` field containing `\r\n`
(e.g. `Description`, `Realm`) is emitted verbatim into the `WWW-Authenticate`
value.

IMPACT
------
Written to an HTTP response, an embedded CRLF splits the header and allows
response/header injection (e.g. smuggling `X-Injected:` or a second response).
The maintainers clearly know these values are dangerous — there is a whole
Strict variant plus `TestFormatAuthenticateStrictRejectsCRLF` — but the default,
most-used formatter was left unsafe.

REPRO (before this change)
--------------------------
    ch := mpp.NewChallenge("secret", "api.example.com", "tempo", "charge",
        map[string]any{"amount": "100"},
        mpp.WithDescription("Line one\r\nX-Injected: pwned"))
    ch.ToAuthenticate("api.example.com")   // => header value contains a raw CRLF

FIX
---
Strip CR and LF in `escapeQuoted` unconditionally. This makes the non-strict
formatter safe by construction while leaving `FormatAuthenticateStrict`'s
error-on-CRLF behavior intact (it rejects such input before `escapeQuoted` is
even reached, so the strip is a no-op there).

TEST
----
`TestFormatAuthenticateStripsCRLF` (pkg/mpp/parse_test.go): a challenge with a
CRLF-laden description is formatted via the non-strict path; the test asserts
the output contains no CR/LF and still parses back into a valid challenge.