### PR TITLE
fix(client): skip challenges with an unparseable expires instead of paying them

### DIFF
--- a/.changelog/client-expires-parse.md
+++ b/.changelog/client-expires-parse.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Fix the client challenge filter so a challenge whose `expires` cannot be parsed is skipped instead of treated as valid, preventing the client from paying a challenge the server is guaranteed to reject.

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -57,16 +57,16 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for i := range challenges {
 		ch := &challenges[i]
 		if ch.Expires != "" {
-			expiry, err := time.Parse(time.RFC3339, ch.Expires)
-			if err == nil && expiry.Before(now) {
+			expiry, err := parseChallengeExpiry(ch.Expires)
+			if err != nil {
+				// Unparseable expiry: the issuing server rejects such a
+				// credential (server.VerifyOrChallenge returns "invalid expires
+				// format"), so don't waste a payment on a challenge it would
+				// refuse. Skip it.
 				continue
 			}
-			// Also try the millisecond format used by mpp.Expires helpers.
-			if err != nil {
-				expiry, err = time.Parse("2006-01-02T15:04:05.000Z", ch.Expires)
-				if err == nil && expiry.Before(now) {
-					continue
-				}
+			if expiry.Before(now) {
+				continue
 			}
 		}
 		if m, ok := t.methods[ch.Method]; ok {
@@ -104,6 +104,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	retry.Header.Set("Authorization", cred.ToAuthorization())
 
 	return t.inner.RoundTrip(retry)
+}
+
+// parseChallengeExpiry parses a challenge expiry using RFC 3339 and the
+// millisecond format emitted by the mpp.Expires helpers.
+func parseChallengeExpiry(value string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02T15:04:05.000Z", value)
 }
 
 // cloneRequest creates a copy of the request suitable for retry.

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -184,6 +184,33 @@ func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
 
 }
 
+func TestTransport_RoundTrip_402UnparseableExpiresIsSkipped(t *testing.T) {
+	// A challenge whose expires cannot be parsed must not be paid: the issuing
+	// server would itself reject the resulting credential.
+	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil,
+		mpp.WithExpires("not-a-timestamp"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("bad expires"))
+	}))
+	defer srv.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+	// No parseable/valid challenge → original 402 returned, no payment made.
+	assert.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+	assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0 for unparseable expires", method.calls)
+}
+
 func TestTransport_RoundTrip_PostWithBody(t *testing.T) {
 	callCount := 0
 	var challenge *mpp.Challenge


### PR DESCRIPTION
Client: don't pay a challenge whose `expires` we can't parse

Context
  When the payment transport picks a challenge to satisfy, it filters out
  expired ones. The filter parsed `expires` with RFC 3339 and then, on failure,
  with the millisecond format used by the mpp.Expires helpers — but if *both*
  parses failed, neither `continue` ran and the challenge fell through as if it
  were valid, so the client went on to construct and submit a payment for it.

  That's the wrong direction to fail. The server side is strict: in
  server.VerifyOrChallenge an unparseable `expires` is rejected with
  "invalid expires format". So the client would sign (and, in hash mode,
  broadcast) a payment against a challenge the server is guaranteed to refuse.

Change
  Extract a `parseChallengeExpiry` helper (RFC 3339, then the millisecond
  format) and treat a parse failure as "skip this challenge" rather than
  "assume it's valid". A malformed `expires` now behaves like an expired one.

Verification
  Added `TestTransport_RoundTrip_402UnparseableExpiresIsSkipped`: a 402 whose
  challenge carries `expires="not-a-timestamp"` results in the original 402
  being returned and `CreateCredential` called zero times. Existing expiry and
  happy-path tests still pass.