### PR TITLE
fix(fiber): verify against the request context instead of context.Background()

### DIFF
--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -1,6 +1,7 @@
 package fiberadapter
 
 import (
+	"context"
 	"encoding/json"
 
 	fiberfw "github.com/gofiber/fiber/v2"
@@ -37,7 +38,12 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 			chargeParams.Body = append([]byte(nil), body...)
 		}
 
-		result, err := m.Charge(c.UserContext(), chargeParams)
+		// Verify against the request-scoped context rather than the inert
+		// context.Background() that c.UserContext() defaults to. The fasthttp
+		// request context (c.Context()) cancels on server shutdown and carries
+		// request-scoped values into Intent.Verify's I/O; the net/http, echo,
+		// and gin adapters all pass the live request context, so mirror that.
+		result, err := m.Charge(chargeContext(c), chargeParams)
 		if err != nil {
 			WritePaymentError(c, err)
 			return nil
@@ -55,6 +61,19 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
 		return c.Next()
 	}
+}
+
+// chargeContext returns the context used for verification. It prefers a context
+// installed by earlier middleware via SetUserContext (so request-scoped values
+// still propagate), but otherwise uses the fasthttp request context, which —
+// unlike the default background UserContext — is cancelled when the request
+// ends. This keeps deadline/cancellation propagation consistent with the
+// net/http, echo, and gin adapters.
+func chargeContext(c *fiberfw.Ctx) context.Context {
+	if uc := c.UserContext(); uc != nil && uc != context.Background() {
+		return uc
+	}
+	return c.Context()
 }
 
 func fiberScope(c *fiberfw.Ctx) map[string]string {

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -32,6 +32,70 @@ func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[strin
 	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
 }
 
+// ctxCapturingMethod records whether the context passed to Verify is the inert
+// background context, so a test can assert the middleware forwards the
+// request-scoped context instead.
+type ctxCapturingMethod struct {
+	isBackground chan bool
+}
+
+func (ctxCapturingMethod) Name() string { return "tempo" }
+
+func (m ctxCapturingMethod) Intents() map[string]server.Intent {
+	return map[string]server.Intent{"charge": ctxCapturingIntent{isBackground: m.isBackground}}
+}
+
+type ctxCapturingIntent struct{ isBackground chan bool }
+
+func (ctxCapturingIntent) Name() string { return "charge" }
+
+func (i ctxCapturingIntent) Verify(ctx context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
+	select {
+	case i.isBackground <- ctx == context.Background():
+	default:
+	}
+	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
+}
+
+func TestChargeMiddlewareUsesRequestContextNotBackground(t *testing.T) {
+	t.Parallel()
+
+	isBackground := make(chan bool, 1)
+	payment := server.New(ctxCapturingMethod{isBackground: isBackground}, "api.example.com", "secret-key")
+	app := fiberfw.New()
+	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
+		return c.SendString("paid")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeResponse, err := app.Test(challengeRequest)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Source:    "did:key:z6Mkrdemo",
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := app.Test(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	require.Equal(t, http.StatusOK, paidResponse.StatusCode)
+
+	select {
+	case background := <-isBackground:
+		assert.False(t, background,
+			"Verify received context.Background(); the request-scoped context (which cancels on server shutdown and carries request values) must be forwarded instead")
+	default:
+		t.Fatal("Verify was not called")
+	}
+}
+
 func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# fiber adapter: verify against the request context, not `context.Background()`

## Observation

The Fiber `ChargeMiddleware` verified payments with `c.UserContext()`:

```go
result, err := m.Charge(c.UserContext(), chargeParams)
```

In Fiber v2, `Ctx.UserContext()` lazily initializes to `context.Background()`
when no earlier middleware set one. So `Intent.Verify` — which performs the
network I/O that talks to the chain/RPC — runs under a context that never
cancels and carries no request-scoped values. Every other binding passes the
live request context:

- net/http — `r.Context()`
- echo — `c.Request().Context()`
- gin — `c.Request.Context()`

Fiber was the odd one out.

## Scope, honestly

fasthttp does **not** offer per-request cancellation: `RequestCtx.Done()` is
closed only on server *shutdown* (see fasthttp `server.go` — "RequestCtx.s.done
is only closed when the server is shutting down"), and returns `nil` otherwise.
So this change does not add client-disconnect cancellation — that isn't
available under fasthttp. What it fixes is handing `Verify` the fully inert
`context.Background()`: after this change verification runs under the fasthttp
request context, which propagates **server-shutdown** cancellation and exposes
request-scoped values, consistent with the other adapters.

## Change

`m.Charge(chargeContext(c), chargeParams)`, where `chargeContext` prefers a
context explicitly installed via `SetUserContext` (preserving values set by
earlier middleware) and otherwise falls back to `c.Context()` (the fasthttp
request context) instead of the default background context.

## Test

`TestChargeMiddlewareUsesRequestContextNotBackground` captures, inside a stub
`Verify`, whether the received context is `context.Background()` and asserts it
is **not**. This fails on the old `c.UserContext()` code path (which hands over
`Background`) and passes after the change. `go test ./pkg/server/fiber/` → ok.