### PR TITLE
fix(tempo): decode bare 0x to zero in ParseHexUint64 for parity with ParseHexBigInt

### DIFF
--- a/.changelog/hex-uint-parity.md
+++ b/.changelog/hex-uint-parity.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Decode a bare `0x` (and empty) hex quantity as zero in `ParseHexUint64`, matching `ParseHexBigInt` so both JSON-RPC integer decoders agree on zero-value forms returned by lenient nodes.

--- a/pkg/tempo/rpc.go
+++ b/pkg/tempo/rpc.go
@@ -27,9 +27,15 @@ func NewRPCClient(rpcURL string) RPCClient {
 	return temporpc.New(rpcURL)
 }
 
-// ParseHexUint64 decodes a JSON-RPC hex integer into uint64.
+// ParseHexUint64 decodes a JSON-RPC hex integer into uint64. A bare "0x" (or an
+// empty string) decodes to 0, matching ParseHexBigInt; some JSON-RPC nodes
+// return "0x" for a zero-valued quantity.
 func ParseHexUint64(value string) (uint64, error) {
-	return strconv.ParseUint(strings.TrimPrefix(value, "0x"), 16, 64)
+	trimmed := strings.TrimPrefix(value, "0x")
+	if trimmed == "" {
+		return 0, nil
+	}
+	return strconv.ParseUint(trimmed, 16, 64)
 }
 
 // ParseHexBigInt decodes a JSON-RPC hex integer into a big.Int.

--- a/pkg/tempo/rpc_test.go
+++ b/pkg/tempo/rpc_test.go
@@ -1,0 +1,51 @@
+package tempo
+
+import "testing"
+
+func TestParseHexUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "with prefix", input: "0x1a", want: 26},
+		{name: "without prefix", input: "ff", want: 255},
+		{name: "zero", input: "0x0", want: 0},
+		{name: "bare 0x decodes to zero", input: "0x", want: 0},
+		{name: "empty decodes to zero", input: "", want: 0},
+		{name: "invalid", input: "0xzz", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHexUint64(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseHexUint64(%q) = %d, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseHexUint64(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseHexUint64(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseHexZeroValueParity locks in that both hex decoders agree on the
+// zero-value forms a lenient JSON-RPC node might return.
+func TestParseHexZeroValueParity(t *testing.T) {
+	for _, input := range []string{"0x", ""} {
+		u, err := ParseHexUint64(input)
+		if err != nil || u != 0 {
+			t.Fatalf("ParseHexUint64(%q) = (%d, %v), want (0, nil)", input, u, err)
+		}
+		b, err := ParseHexBigInt(input)
+		if err != nil || b.Sign() != 0 {
+			t.Fatalf("ParseHexBigInt(%q) = (%v, %v), want (0, nil)", input, b, err)
+		}
+	}
+}


### PR DESCRIPTION
### `ParseHexUint64`: accept bare `0x` like `ParseHexBigInt` does

The two JSON-RPC hex integer decoders in `pkg/tempo/rpc.go` disagreed on the
zero-value forms a lenient node may return:

| input | `ParseHexBigInt` | `ParseHexUint64` (before) |
| ----- | ---------------- | ------------------------- |
| `"0x"` | `0, nil`         | **error** (`ParseUint("")`) |
| `""`   | `0, nil`         | **error**                 |

`ParseHexBigInt` special-cases an empty trimmed string and returns `0`;
`ParseHexUint64` handed `""` straight to `strconv.ParseUint`, which errors. A
node that returns `"0x"` for a zero quantity would therefore be decoded fine by
one helper and rejected by the other. `ParseHexUint64` is used by the client's
gas estimation (`pkg/tempo/client/method.go`), so this could fail an otherwise
valid request.

**Fix:** treat an empty trimmed value as `0` in `ParseHexUint64`, giving both
decoders identical zero-value behavior.

**Tests (new `pkg/tempo/rpc_test.go`):**
- `TestParseHexUint64` — table covering prefixed/unprefixed/zero/`0x`/empty/invalid.
- `TestParseHexZeroValueParity` — asserts `ParseHexUint64` and `ParseHexBigInt`
  agree (both `0, nil`) on `"0x"` and `""`.

`go test ./pkg/tempo/ -run ParseHex` → ok.
