### PR TITLE
fix: reject malformed Payment auth parameters

### DIFF
--- a/.changelog/strict-auth-param-parser.md
+++ b/.changelog/strict-auth-param-parser.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject malformed `WWW-Authenticate: Payment` auth-param lists instead of silently accepting trailing bare parameters or missing separators.

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -505,7 +505,11 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	if v, ok := data["externalId"]; ok {
 		externalID = anyStr(v)
 	}
-
+ 
+	var subscriptionID string
+	if v, ok := data["subscriptionId"]; ok {
+   		 subscriptionID = anyStr(v)
+	}
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -519,6 +523,7 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		Reference:  reference,
 		Method:     method,
 		ExternalID: externalID,
+		SubscriptionID: subscriptionID,
 		Extra:      extra,
 	}, nil
 }
@@ -537,6 +542,9 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if r.ExternalID != "" {
 		data["externalId"] = r.ExternalID
+	}
+	if r.SubscriptionID != "" {
+		data["subscriptionId"] = r.SubscriptionID
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -36,7 +36,7 @@ func parseAuthParams(s string) (map[string]string, error) {
 			i++
 		}
 		if i >= len(s) || s[i] != '=' {
-			break
+			return nil, fmt.Errorf("mpp: malformed auth-param")
 		}
 		i++
 
@@ -53,6 +53,13 @@ func parseAuthParams(s string) (map[string]string, error) {
 		}
 		params[key] = value
 		i = next
+
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		if i < len(s) && s[i] != ',' {
+			return nil, fmt.Errorf("mpp: malformed auth-param separator")
+		}
 	}
 	return params, nil
 }
@@ -499,11 +506,6 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		externalID = anyStr(v)
 	}
 
-	var subscriptionID string
-	if v, ok := data["subscriptionId"]; ok {
-		subscriptionID = anyStr(v)
-	}
-
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -512,13 +514,12 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	return &Receipt{
-		Status:         status,
-		Timestamp:      ts,
-		Reference:      reference,
-		Method:         method,
-		ExternalID:     externalID,
-		SubscriptionID: subscriptionID,
-		Extra:          extra,
+		Status:     status,
+		Timestamp:  ts,
+		Reference:  reference,
+		Method:     method,
+		ExternalID: externalID,
+		Extra:      extra,
 	}, nil
 }
 
@@ -536,9 +537,6 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if r.ExternalID != "" {
 		data["externalId"] = r.ExternalID
-	}
-	if r.SubscriptionID != "" {
-		data["subscriptionId"] = r.SubscriptionID
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -505,11 +505,12 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	if v, ok := data["externalId"]; ok {
 		externalID = anyStr(v)
 	}
- 
+
 	var subscriptionID string
 	if v, ok := data["subscriptionId"]; ok {
-   		 subscriptionID = anyStr(v)
+		subscriptionID = anyStr(v)
 	}
+
 	var extra map[string]any
 	if v, ok := data["extra"]; ok {
 		if m, ok := v.(map[string]any); ok {
@@ -518,13 +519,13 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	return &Receipt{
-		Status:     status,
-		Timestamp:  ts,
-		Reference:  reference,
-		Method:     method,
-		ExternalID: externalID,
+		Status:         status,
+		Timestamp:      ts,
+		Reference:      reference,
+		Method:         method,
+		ExternalID:     externalID,
 		SubscriptionID: subscriptionID,
-		Extra:      extra,
+		Extra:          extra,
 	}, nil
 }
 

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -332,6 +332,16 @@ func TestParseChallenge(t *testing.T) {
 			wantErr: `malformed auth-param`,
 		},
 		{
+			name:    "malformed trailing auth param",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo", intent="charge", request="e30", expires`,
+			wantErr: `malformed auth-param`,
+		},
+		{
+			name:    "missing comma between auth params",
+			header:  `Payment id="abc" realm="api.example.com", method="tempo", intent="charge", request="e30"`,
+			wantErr: `malformed auth-param separator`,
+		},
+		{
 			name:    "invalid request encoding",
 			header:  `Payment id="abc", realm="api.example.com", method="tempo", intent="charge", request="not-base64"`,
 			wantErr: `invalid request field`,


### PR DESCRIPTION
## Title

fix: reject malformed Payment auth-param lists

## Summary

This PR tightens `WWW-Authenticate: Payment` parsing so malformed auth-param lists are rejected instead of being partially accepted.

## Problem

`parseAuthParams` previously stopped parsing when it saw a key without `=`, returning the params parsed so far. That allowed a malformed challenge with a trailing bare auth-param to be accepted if all required fields appeared before the malformed tail.

It also accepted adjacent quoted params without a comma separator, such as:

```http
Payment id="abc" realm="api.example.com", method="tempo", intent="charge", request="e30"
```

## Solution

- Return `mpp: malformed auth-param` when a parsed auth-param key is not followed by `=`.
- After parsing a value, require the next non-OWS byte to be either `,` or end-of-input.
- Add regression coverage in `TestParseChallenge` for:
  - trailing bare auth-param;
  - missing comma between auth-params.

## Testing

```bash
gofmt -w pkg/mpp/parse.go pkg/mpp/parse_test.go
go test ./pkg/mpp -run 'TestParseChallenge|TestSplitAuthenticate|TestFindPaymentAuthorization'
go test ./pkg/mpp
go test ./...
```
