### PR TITLE
Validate client credential type

### DIFF
--- a/.changelog/validate-client-credential-type.md
+++ b/.changelog/validate-client-credential-type.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject unsupported Tempo client credential types during method construction instead of silently treating them as transaction credentials.

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -54,24 +54,37 @@ var _ mppclient.Method = (*Method)(nil)
 // New constructs a Tempo charge client method.
 func New(config Config) (*Method, error) {
 	switch config.CredentialType {
-	case "",
-		tempo.CredentialTypeTransaction,
-		tempo.CredentialTypeHash,
-		tempo.CredentialTypeProof:
+	case "", tempo.CredentialTypeTransaction, tempo.CredentialTypeHash, tempo.CredentialTypeProof:
 	default:
-		return nil, fmt.Errorf(
-			"tempo client: unsupported credential type %q",
-			config.CredentialType,
-		)
+		return nil, fmt.Errorf("tempo client: unsupported credential type %q", config.CredentialType)
 	}
-
-	if config.RPC == nil && config.RPCURL == "" &&
-		config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
-		return nil, fmt.Errorf(
-			"tempo client: unknown chain id %d; configure RPC or RPCURL explicitly",
-			config.ChainID,
-		)
+	if config.RPC == nil && config.RPCURL == "" && config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
+		return nil, fmt.Errorf("tempo client: unknown chain id %d; configure RPC or RPCURL explicitly", config.ChainID)
 	}
+	signer := config.Signer
+	if signer == nil {
+		if config.PrivateKey == "" {
+			return nil, fmt.Errorf("tempo client: signer or private key is required")
+		}
+		resolved, err := temposigner.NewSigner(config.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+		signer = resolved
+	}
+	chainID := config.ChainID
+	if chainID == 0 {
+		chainID = tempo.InferChainIDFromRPCURL(config.RPCURL)
+	}
+	return &Method{
+		signer:         signer,
+		rpc:            config.RPC,
+		rpcURL:         config.RPCURL,
+		chainID:        chainID,
+		clientID:       config.ClientID,
+		credentialType: config.CredentialType,
+	}, nil
+}
 
 // Name returns the method token used in Challenges and Credentials.
 func (m *Method) Name() string {

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -53,33 +53,25 @@ var _ mppclient.Method = (*Method)(nil)
 
 // New constructs a Tempo charge client method.
 func New(config Config) (*Method, error) {
-	if config.RPC == nil && config.RPCURL == "" && config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
-		return nil, fmt.Errorf("tempo client: unknown chain id %d; configure RPC or RPCURL explicitly", config.ChainID)
+	switch config.CredentialType {
+	case "",
+		tempo.CredentialTypeTransaction,
+		tempo.CredentialTypeHash,
+		tempo.CredentialTypeProof:
+	default:
+		return nil, fmt.Errorf(
+			"tempo client: unsupported credential type %q",
+			config.CredentialType,
+		)
 	}
-	signer := config.Signer
-	if signer == nil {
-		if config.PrivateKey == "" {
-			return nil, fmt.Errorf("tempo client: signer or private key is required")
-		}
-		resolved, err := temposigner.NewSigner(config.PrivateKey)
-		if err != nil {
-			return nil, err
-		}
-		signer = resolved
+
+	if config.RPC == nil && config.RPCURL == "" &&
+		config.ChainID != 0 && !tempo.IsKnownChainID(config.ChainID) {
+		return nil, fmt.Errorf(
+			"tempo client: unknown chain id %d; configure RPC or RPCURL explicitly",
+			config.ChainID,
+		)
 	}
-	chainID := config.ChainID
-	if chainID == 0 {
-		chainID = tempo.InferChainIDFromRPCURL(config.RPCURL)
-	}
-	return &Method{
-		signer:         signer,
-		rpc:            config.RPC,
-		rpcURL:         config.RPCURL,
-		chainID:        chainID,
-		clientID:       config.ClientID,
-		credentialType: config.CredentialType,
-	}, nil
-}
 
 // Name returns the method token used in Challenges and Credentials.
 func (m *Method) Name() string {

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -186,21 +186,6 @@ func TestNewInfersChainIDFromRPCURL(t *testing.T) {
 
 }
 
-func TestNewRejectsUnsupportedCredentialType(t *testing.T) {
-	t.Parallel()
-
-	_, err := New(Config{
-		PrivateKey:     testPrivateKey,
-		CredentialType: tempo.CredentialType("invalid"),
-	})
-
-	assert.EqualError(
-		t,
-		err,
-		`tempo client: unsupported credential type "invalid"`,
-	)
-}
-
 func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
 	t.Parallel()
 
@@ -210,6 +195,16 @@ func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
 		return
 	}
 
+}
+
+func TestNewRejectsUnsupportedCredentialType(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(Config{
+		PrivateKey:     testPrivateKey,
+		CredentialType: tempo.CredentialType("invalid"),
+	})
+	assert.EqualError(t, err, `tempo client: unsupported credential type "invalid"`)
 }
 
 func TestCreateCredentialRejectsUnknownChallengeChainWithoutRPC(t *testing.T) {

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -186,6 +186,21 @@ func TestNewInfersChainIDFromRPCURL(t *testing.T) {
 
 }
 
+func TestNewRejectsUnsupportedCredentialType(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(Config{
+		PrivateKey:     testPrivateKey,
+		CredentialType: tempo.CredentialType("invalid"),
+	})
+
+	assert.EqualError(
+		t,
+		err,
+		`tempo client: unsupported credential type "invalid"`,
+	)
+}
+
 func TestNewRejectsUnknownChainWithoutRPC(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -135,6 +135,74 @@ func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
 
 }
 
+func TestNormalizeChargeRequest_RejectsUnsupportedModes(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeChargeRequest(ChargeRequestParams{
+		Amount:         "1",
+		Currency:       "0x20c0000000000000000000000000000000000001",
+		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		SupportedModes: []ChargeMode{"bogus"},
+	})
+	if !assert.ErrorContainsf(t, err, `unsupported mode "bogus"`,
+		"NormalizeChargeRequest() error = %v, want unsupported mode error", err) {
+		return
+	}
+
+}
+
+func TestParseChargeRequest_RejectsInvalidChainIDAndModes(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"amount":    "100",
+		"currency":  "0x20c0000000000000000000000000000000000001",
+		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+	}
+
+	tests := []struct {
+		name          string
+		methodDetails map[string]any
+		wantErr       string
+	}{
+		{
+			name:          "fractional chain id",
+			methodDetails: map[string]any{"chainId": float64(42431.5)},
+			wantErr:       "chainId must be an integer",
+		},
+		{
+			name:          "malformed string chain id",
+			methodDetails: map[string]any{"chainId": "42431abc"},
+			wantErr:       `invalid chainId "42431abc"`,
+		},
+		{
+			name:          "unsupported mode",
+			methodDetails: map[string]any{"supportedModes": []any{"push", "bogus"}},
+			wantErr:       `unsupported mode "bogus"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := map[string]any{}
+			for key, value := range base {
+				input[key] = value
+			}
+			input["methodDetails"] = tt.methodDetails
+
+			_, err := ParseChargeRequest(input)
+			if !assert.ErrorContainsf(t, err, tt.wantErr,
+				"ParseChargeRequest() error = %v, want substring %q", err, tt.wantErr) {
+				return
+			}
+
+		})
+	}
+}
+
 func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/request.go
+++ b/pkg/tempo/request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,6 +157,9 @@ func NormalizeChargeRequest(params ChargeRequestParams) (ChargeRequest, error) {
 	if err != nil {
 		return ChargeRequest{}, err
 	}
+	if err := validateSupportedModes(params.SupportedModes); err != nil {
+		return ChargeRequest{}, err
+	}
 	splits, err := normalizeSplits(params.Splits, decimals, amount)
 	if err != nil {
 		return ChargeRequest{}, err
@@ -206,7 +210,9 @@ func ParseChargeRequest(input map[string]any) (ChargeRequest, error) {
 		return ChargeRequest{}, err
 	}
 	if raw, ok := input["methodDetails"].(map[string]any); ok {
-		if chainID, ok := asInt64(raw["chainId"]); ok {
+		if chainID, ok, err := asInt64(raw["chainId"]); err != nil {
+			return ChargeRequest{}, err
+		} else if ok {
 			request.MethodDetails.ChainID = &chainID
 		}
 		request.MethodDetails.FeePayer = asBool(raw["feePayer"])
@@ -219,7 +225,10 @@ func ParseChargeRequest(input map[string]any) (ChargeRequest, error) {
 		if err != nil {
 			return ChargeRequest{}, err
 		}
-		request.MethodDetails.SupportedModes = parseModes(raw["supportedModes"])
+		request.MethodDetails.SupportedModes, err = parseModes(raw["supportedModes"])
+		if err != nil {
+			return ChargeRequest{}, err
+		}
 	}
 	if err := validateCanonicalSplits(request.Amount, request.MethodDetails.Splits); err != nil {
 		return ChargeRequest{}, err
@@ -404,45 +413,71 @@ func asBool(value any) bool {
 	}
 }
 
-func asInt64(value any) (int64, bool) {
+func asInt64(value any) (int64, bool, error) {
 	switch typed := value.(type) {
 	case int:
-		return int64(typed), true
+		return int64(typed), true, nil
 	case int64:
-		return typed, true
+		return typed, true, nil
 	case float64:
-		return int64(typed), true
+		if typed != float64(int64(typed)) {
+			return 0, false, fmt.Errorf("tempo: chainId must be an integer")
+		}
+		return int64(typed), true, nil
 	case string:
 		if typed == "" {
-			return 0, false
+			return 0, false, nil
 		}
-		var result int64
-		_, err := fmt.Sscan(typed, &result)
-		return result, err == nil
+		result, err := strconv.ParseInt(typed, 10, 64)
+		if err != nil {
+			return 0, false, fmt.Errorf("tempo: invalid chainId %q", typed)
+		}
+		return result, true, nil
 	default:
-		return 0, false
+		return 0, false, nil
 	}
 }
 
-func parseModes(value any) []ChargeMode {
+func parseModes(value any) ([]ChargeMode, error) {
 	rawModes, ok := value.([]any)
 	if !ok {
-		if strings, ok := value.([]string); ok {
-			modes := make([]ChargeMode, 0, len(strings))
-			for _, mode := range strings {
-				modes = append(modes, ChargeMode(mode))
+		if rawStrings, ok := value.([]string); ok {
+			modes := make([]ChargeMode, 0, len(rawStrings))
+			for _, mode := range rawStrings {
+				parsed := ChargeMode(mode)
+				if !isSupportedMode(parsed) {
+					return nil, fmt.Errorf("tempo: unsupported mode %q", mode)
+				}
+				modes = append(modes, parsed)
 			}
-			return modes
+			return modes, nil
 		}
-		return nil
+		return nil, nil
 	}
 	modes := make([]ChargeMode, 0, len(rawModes))
 	for _, mode := range rawModes {
 		if value := asString(mode); value != "" {
-			modes = append(modes, ChargeMode(value))
+			parsed := ChargeMode(value)
+			if !isSupportedMode(parsed) {
+				return nil, fmt.Errorf("tempo: unsupported mode %q", value)
+			}
+			modes = append(modes, parsed)
 		}
 	}
-	return modes
+	return modes, nil
+}
+
+func isSupportedMode(mode ChargeMode) bool {
+	return mode == ChargeModePull || mode == ChargeModePush
+}
+
+func validateSupportedModes(modes []ChargeMode) error {
+	for _, mode := range modes {
+		if !isSupportedMode(mode) {
+			return fmt.Errorf("tempo: unsupported mode %q", mode)
+		}
+	}
+	return nil
 }
 
 func normalizeSplits(splits []SplitParams, decimals int, totalAmount string) ([]Split, error) {


### PR DESCRIPTION
# Reject unsupported Tempo client credential types

## Summary

- validate `Config.CredentialType` in `chargeclient.New`
- preserve the empty value as the existing transaction default
- add regression coverage for an unsupported value

## Why

Unknown credential types previously survived construction and could be
silently serialized as transaction credentials. Failing at construction makes
configuration mistakes explicit and prevents unintended credential behavior.

## Testing

```text
go test ./pkg/tempo/client
go test ./...
go vet ./...
```
