### PR TITLE
Alidate supported modes

### DIFF
--- a/.changelog/validate-tempo-supported-modes.md
+++ b/.changelog/validate-tempo-supported-modes.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject unsupported Tempo charge modes when normalizing or parsing requests instead of creating challenges that no client flow can satisfy.

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -100,6 +100,28 @@ func TestNormalizeChargeRequest_RejectsInvalidMemo(t *testing.T) {
 
 }
 
+func TestChargeRequestRejectsUnsupportedModes(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeChargeRequest(ChargeRequestParams{
+		Amount:         "1",
+		Currency:       "0x20c0000000000000000000000000000000000001",
+		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		SupportedModes: []ChargeMode{"invalid"},
+	})
+	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
+
+	_, err = ParseChargeRequest(map[string]any{
+		"amount":    "1000000",
+		"currency":  "0x20c0000000000000000000000000000000000001",
+		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		"methodDetails": map[string]any{
+			"supportedModes": []any{"pull", "invalid"},
+		},
+	})
+	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
+}
+
 func TestNormalizeChargeRequest_RejectsNegativeDecimals(t *testing.T) {
 	t.Parallel()
 
@@ -135,74 +157,6 @@ func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
 
 }
 
-func TestNormalizeChargeRequest_RejectsUnsupportedModes(t *testing.T) {
-	t.Parallel()
-
-	_, err := NormalizeChargeRequest(ChargeRequestParams{
-		Amount:         "1",
-		Currency:       "0x20c0000000000000000000000000000000000001",
-		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
-		SupportedModes: []ChargeMode{"bogus"},
-	})
-	if !assert.ErrorContainsf(t, err, `unsupported mode "bogus"`,
-		"NormalizeChargeRequest() error = %v, want unsupported mode error", err) {
-		return
-	}
-
-}
-
-func TestParseChargeRequest_RejectsInvalidChainIDAndModes(t *testing.T) {
-	t.Parallel()
-
-	base := map[string]any{
-		"amount":    "100",
-		"currency":  "0x20c0000000000000000000000000000000000001",
-		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
-	}
-
-	tests := []struct {
-		name          string
-		methodDetails map[string]any
-		wantErr       string
-	}{
-		{
-			name:          "fractional chain id",
-			methodDetails: map[string]any{"chainId": float64(42431.5)},
-			wantErr:       "chainId must be an integer",
-		},
-		{
-			name:          "malformed string chain id",
-			methodDetails: map[string]any{"chainId": "42431abc"},
-			wantErr:       `invalid chainId "42431abc"`,
-		},
-		{
-			name:          "unsupported mode",
-			methodDetails: map[string]any{"supportedModes": []any{"push", "bogus"}},
-			wantErr:       `unsupported mode "bogus"`,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			input := map[string]any{}
-			for key, value := range base {
-				input[key] = value
-			}
-			input["methodDetails"] = tt.methodDetails
-
-			_, err := ParseChargeRequest(input)
-			if !assert.ErrorContainsf(t, err, tt.wantErr,
-				"ParseChargeRequest() error = %v, want substring %q", err, tt.wantErr) {
-				return
-			}
-
-		})
-	}
-}
-
 func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 	t.Parallel()
 
@@ -232,28 +186,6 @@ func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 		return
 	}
 
-}
-
-func TestChargeRequestRejectsUnsupportedModes(t *testing.T) {
-	t.Parallel()
-
-	_, err := NormalizeChargeRequest(ChargeRequestParams{
-		Amount:         "1",
-		Currency:       "0x20c0000000000000000000000000000000000001",
-		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
-		SupportedModes: []ChargeMode{"invalid"},
-	})
-	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
-
-	_, err = ParseChargeRequest(map[string]any{
-		"amount":    "1000000",
-		"currency":  "0x20c0000000000000000000000000000000000001",
-		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
-		"methodDetails": map[string]any{
-			"supportedModes": []any{"pull", "invalid"},
-		},
-	})
-	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
 }
 
 func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -135,6 +135,74 @@ func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
 
 }
 
+func TestNormalizeChargeRequest_RejectsUnsupportedModes(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeChargeRequest(ChargeRequestParams{
+		Amount:         "1",
+		Currency:       "0x20c0000000000000000000000000000000000001",
+		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		SupportedModes: []ChargeMode{"bogus"},
+	})
+	if !assert.ErrorContainsf(t, err, `unsupported mode "bogus"`,
+		"NormalizeChargeRequest() error = %v, want unsupported mode error", err) {
+		return
+	}
+
+}
+
+func TestParseChargeRequest_RejectsInvalidChainIDAndModes(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"amount":    "100",
+		"currency":  "0x20c0000000000000000000000000000000000001",
+		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+	}
+
+	tests := []struct {
+		name          string
+		methodDetails map[string]any
+		wantErr       string
+	}{
+		{
+			name:          "fractional chain id",
+			methodDetails: map[string]any{"chainId": float64(42431.5)},
+			wantErr:       "chainId must be an integer",
+		},
+		{
+			name:          "malformed string chain id",
+			methodDetails: map[string]any{"chainId": "42431abc"},
+			wantErr:       `invalid chainId "42431abc"`,
+		},
+		{
+			name:          "unsupported mode",
+			methodDetails: map[string]any{"supportedModes": []any{"push", "bogus"}},
+			wantErr:       `unsupported mode "bogus"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := map[string]any{}
+			for key, value := range base {
+				input[key] = value
+			}
+			input["methodDetails"] = tt.methodDetails
+
+			_, err := ParseChargeRequest(input)
+			if !assert.ErrorContainsf(t, err, tt.wantErr,
+				"ParseChargeRequest() error = %v, want substring %q", err, tt.wantErr) {
+				return
+			}
+
+		})
+	}
+}
+
 func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -234,6 +234,28 @@ func TestEncodeAttribution_VerifiesServerFingerprint(t *testing.T) {
 
 }
 
+func TestChargeRequestRejectsUnsupportedModes(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeChargeRequest(ChargeRequestParams{
+		Amount:         "1",
+		Currency:       "0x20c0000000000000000000000000000000000001",
+		Recipient:      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		SupportedModes: []ChargeMode{"invalid"},
+	})
+	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
+
+	_, err = ParseChargeRequest(map[string]any{
+		"amount":    "1000000",
+		"currency":  "0x20c0000000000000000000000000000000000001",
+		"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		"methodDetails": map[string]any{
+			"supportedModes": []any{"pull", "invalid"},
+		},
+	})
+	assert.EqualError(t, err, `tempo: unsupported charge mode "invalid"`)
+}
+
 func TestMatchTransferCalldata_MemoAndAttributionFallback(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/request.go
+++ b/pkg/tempo/request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,6 +157,9 @@ func NormalizeChargeRequest(params ChargeRequestParams) (ChargeRequest, error) {
 	if err != nil {
 		return ChargeRequest{}, err
 	}
+	if err := validateSupportedModes(params.SupportedModes); err != nil {
+		return ChargeRequest{}, err
+	}
 	splits, err := normalizeSplits(params.Splits, decimals, amount)
 	if err != nil {
 		return ChargeRequest{}, err
@@ -206,7 +210,9 @@ func ParseChargeRequest(input map[string]any) (ChargeRequest, error) {
 		return ChargeRequest{}, err
 	}
 	if raw, ok := input["methodDetails"].(map[string]any); ok {
-		if chainID, ok := asInt64(raw["chainId"]); ok {
+		if chainID, ok, err := asInt64(raw["chainId"]); err != nil {
+			return ChargeRequest{}, err
+		} else if ok {
 			request.MethodDetails.ChainID = &chainID
 		}
 		request.MethodDetails.FeePayer = asBool(raw["feePayer"])
@@ -219,7 +225,10 @@ func ParseChargeRequest(input map[string]any) (ChargeRequest, error) {
 		if err != nil {
 			return ChargeRequest{}, err
 		}
-		request.MethodDetails.SupportedModes = parseModes(raw["supportedModes"])
+		request.MethodDetails.SupportedModes, err = parseModes(raw["supportedModes"])
+		if err != nil {
+			return ChargeRequest{}, err
+		}
 	}
 	if err := validateCanonicalSplits(request.Amount, request.MethodDetails.Splits); err != nil {
 		return ChargeRequest{}, err
@@ -404,45 +413,71 @@ func asBool(value any) bool {
 	}
 }
 
-func asInt64(value any) (int64, bool) {
+func asInt64(value any) (int64, bool, error) {
 	switch typed := value.(type) {
 	case int:
-		return int64(typed), true
+		return int64(typed), true, nil
 	case int64:
-		return typed, true
+		return typed, true, nil
 	case float64:
-		return int64(typed), true
+		if typed != float64(int64(typed)) {
+			return 0, false, fmt.Errorf("tempo: chainId must be an integer")
+		}
+		return int64(typed), true, nil
 	case string:
 		if typed == "" {
-			return 0, false
+			return 0, false, nil
 		}
-		var result int64
-		_, err := fmt.Sscan(typed, &result)
-		return result, err == nil
+		result, err := strconv.ParseInt(typed, 10, 64)
+		if err != nil {
+			return 0, false, fmt.Errorf("tempo: invalid chainId %q", typed)
+		}
+		return result, true, nil
 	default:
-		return 0, false
+		return 0, false, nil
 	}
 }
 
-func parseModes(value any) []ChargeMode {
+func parseModes(value any) ([]ChargeMode, error) {
 	rawModes, ok := value.([]any)
 	if !ok {
-		if strings, ok := value.([]string); ok {
-			modes := make([]ChargeMode, 0, len(strings))
-			for _, mode := range strings {
-				modes = append(modes, ChargeMode(mode))
+		if rawStrings, ok := value.([]string); ok {
+			modes := make([]ChargeMode, 0, len(rawStrings))
+			for _, mode := range rawStrings {
+				parsed := ChargeMode(mode)
+				if !isSupportedMode(parsed) {
+					return nil, fmt.Errorf("tempo: unsupported mode %q", mode)
+				}
+				modes = append(modes, parsed)
 			}
-			return modes
+			return modes, nil
 		}
-		return nil
+		return nil, nil
 	}
 	modes := make([]ChargeMode, 0, len(rawModes))
 	for _, mode := range rawModes {
 		if value := asString(mode); value != "" {
-			modes = append(modes, ChargeMode(value))
+			parsed := ChargeMode(value)
+			if !isSupportedMode(parsed) {
+				return nil, fmt.Errorf("tempo: unsupported mode %q", value)
+			}
+			modes = append(modes, parsed)
 		}
 	}
-	return modes
+	return modes, nil
+}
+
+func isSupportedMode(mode ChargeMode) bool {
+	return mode == ChargeModePull || mode == ChargeModePush
+}
+
+func validateSupportedModes(modes []ChargeMode) error {
+	for _, mode := range modes {
+		if !isSupportedMode(mode) {
+			return fmt.Errorf("tempo: unsupported mode %q", mode)
+		}
+	}
+	return nil
 }
 
 func normalizeSplits(splits []SplitParams, decimals int, totalAmount string) ([]Split, error) {

--- a/pkg/tempo/request.go
+++ b/pkg/tempo/request.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -157,9 +156,6 @@ func NormalizeChargeRequest(params ChargeRequestParams) (ChargeRequest, error) {
 	if err != nil {
 		return ChargeRequest{}, err
 	}
-	if err := validateSupportedModes(params.SupportedModes); err != nil {
-		return ChargeRequest{}, err
-	}
 	splits, err := normalizeSplits(params.Splits, decimals, amount)
 	if err != nil {
 		return ChargeRequest{}, err
@@ -214,9 +210,7 @@ func ParseChargeRequest(input map[string]any) (ChargeRequest, error) {
 		return ChargeRequest{}, err
 	}
 	if raw, ok := input["methodDetails"].(map[string]any); ok {
-		if chainID, ok, err := asInt64(raw["chainId"]); err != nil {
-			return ChargeRequest{}, err
-		} else if ok {
+		if chainID, ok := asInt64(raw["chainId"]); ok {
 			request.MethodDetails.ChainID = &chainID
 		}
 		request.MethodDetails.FeePayer = asBool(raw["feePayer"])
@@ -417,28 +411,23 @@ func asBool(value any) bool {
 	}
 }
 
-func asInt64(value any) (int64, bool, error) {
+func asInt64(value any) (int64, bool) {
 	switch typed := value.(type) {
 	case int:
-		return int64(typed), true, nil
+		return int64(typed), true
 	case int64:
-		return typed, true, nil
+		return typed, true
 	case float64:
-		if typed != float64(int64(typed)) {
-			return 0, false, fmt.Errorf("tempo: chainId must be an integer")
-		}
-		return int64(typed), true, nil
+		return int64(typed), true
 	case string:
 		if typed == "" {
-			return 0, false, nil
+			return 0, false
 		}
-		result, err := strconv.ParseInt(typed, 10, 64)
-		if err != nil {
-			return 0, false, fmt.Errorf("tempo: invalid chainId %q", typed)
-		}
-		return result, true, nil
+		var result int64
+		_, err := fmt.Sscan(typed, &result)
+		return result, err == nil
 	default:
-		return 0, false, nil
+		return 0, false
 	}
 }
 
@@ -454,14 +443,12 @@ func parseModes(value any) ([]ChargeMode, error) {
 		}
 		return nil, nil
 	}
-
 	modes := make([]ChargeMode, 0, len(rawModes))
 	for _, mode := range rawModes {
 		if value := asString(mode); value != "" {
 			modes = append(modes, ChargeMode(value))
 		}
 	}
-
 	return validateChargeModes(modes)
 }
 
@@ -473,21 +460,7 @@ func validateChargeModes(modes []ChargeMode) ([]ChargeMode, error) {
 			return nil, fmt.Errorf("tempo: unsupported charge mode %q", mode)
 		}
 	}
-
 	return append([]ChargeMode(nil), modes...), nil
-}
-
-func isSupportedMode(mode ChargeMode) bool {
-	return mode == ChargeModePull || mode == ChargeModePush
-}
-
-func validateSupportedModes(modes []ChargeMode) error {
-	for _, mode := range modes {
-		if !isSupportedMode(mode) {
-			return fmt.Errorf("tempo: unsupported mode %q", mode)
-		}
-	}
-	return nil
 }
 
 func normalizeSplits(splits []SplitParams, decimals int, totalAmount string) ([]Split, error) {

--- a/pkg/tempo/request.go
+++ b/pkg/tempo/request.go
@@ -164,6 +164,10 @@ func NormalizeChargeRequest(params ChargeRequestParams) (ChargeRequest, error) {
 	if err != nil {
 		return ChargeRequest{}, err
 	}
+	supportedModes, err := validateChargeModes(params.SupportedModes)
+	if err != nil {
+		return ChargeRequest{}, err
+	}
 	request := ChargeRequest{
 		Amount:      amount,
 		Currency:    currency,
@@ -175,7 +179,7 @@ func NormalizeChargeRequest(params ChargeRequestParams) (ChargeRequest, error) {
 			FeePayerURL:    params.FeePayerURL,
 			Memo:           memo,
 			Splits:         splits,
-			SupportedModes: append([]ChargeMode(nil), params.SupportedModes...),
+			SupportedModes: supportedModes,
 		},
 	}
 	if params.ChainID != 0 {
@@ -441,30 +445,36 @@ func asInt64(value any) (int64, bool, error) {
 func parseModes(value any) ([]ChargeMode, error) {
 	rawModes, ok := value.([]any)
 	if !ok {
-		if rawStrings, ok := value.([]string); ok {
-			modes := make([]ChargeMode, 0, len(rawStrings))
-			for _, mode := range rawStrings {
-				parsed := ChargeMode(mode)
-				if !isSupportedMode(parsed) {
-					return nil, fmt.Errorf("tempo: unsupported mode %q", mode)
-				}
-				modes = append(modes, parsed)
+		if strings, ok := value.([]string); ok {
+			modes := make([]ChargeMode, 0, len(strings))
+			for _, mode := range strings {
+				modes = append(modes, ChargeMode(mode))
 			}
-			return modes, nil
+			return validateChargeModes(modes)
 		}
 		return nil, nil
 	}
+
 	modes := make([]ChargeMode, 0, len(rawModes))
 	for _, mode := range rawModes {
 		if value := asString(mode); value != "" {
-			parsed := ChargeMode(value)
-			if !isSupportedMode(parsed) {
-				return nil, fmt.Errorf("tempo: unsupported mode %q", value)
-			}
-			modes = append(modes, parsed)
+			modes = append(modes, ChargeMode(value))
 		}
 	}
-	return modes, nil
+
+	return validateChargeModes(modes)
+}
+
+func validateChargeModes(modes []ChargeMode) ([]ChargeMode, error) {
+	for _, mode := range modes {
+		switch mode {
+		case ChargeModePull, ChargeModePush:
+		default:
+			return nil, fmt.Errorf("tempo: unsupported charge mode %q", mode)
+		}
+	}
+
+	return append([]ChargeMode(nil), modes...), nil
 }
 
 func isSupportedMode(mode ChargeMode) bool {


### PR DESCRIPTION
# Validate Tempo charge request modes

## Summary

- validate supported modes during `NormalizeChargeRequest`
- apply the same validation while parsing generic request maps
- add regression coverage for invalid local and wire-format values

## Why

Unsupported modes previously produced challenges that advertised no usable
credential flow. Rejecting them at request boundaries catches configuration and
wire-format errors before an unsatisfiable challenge is issued.

## Testing

```text
go test ./pkg/tempo
go test ./...
go vet ./...
```
