### PR TITLE
chore: batch Dependabot updates

### DIFF
--- a/.changelog/dependabot-batching.md
+++ b/.changelog/dependabot-batching.md
@@ -1,0 +1,6 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Batch routine dependency updates weekly and automatically merge patch and minor
+updates after all pull request checks pass.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,20 @@
 version: 2
+
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+
 updates:
   - package-ecosystem: gomod
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-    groups:
-      go-deps:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies
 
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      actions:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,13 @@ updates:
     directory: /
     patterns: ["*"]
     multi-ecosystem-group: weekly-dependencies
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     patterns: ["*"]
     multi-ecosystem-group: weekly-dependencies
+    cooldown:
+      default-days: 7

--- a/.github/workflows/changelog-release.yml
+++ b/.github/workflows/changelog-release.yml
@@ -20,6 +20,6 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: tempoxyz/changelogs@74f07b39c7c85773575e32472dfd5298ec6baaf4 # master
+      - uses: tempoxyz/changelogs@bd50cca508d81505924dfa3997b1696ac2b7b1aa # v0.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+name: Dependabot
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@1d20c6f032568c0aea39c0e7e57e4ba350516281

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,14 +1,61 @@
 name: Dependabot
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Dependabot-only API automation; never executes PR code.
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions: {}
 
 jobs:
+  changelog:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      updated: ${{ steps.changelog.outputs.updated }}
+    steps:
+      - name: Add changelog for Go updates
+        id: changelog
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+          files=$(gh api --paginate \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename')
+
+          if ! grep -Eq '^go\.(mod|sum)$' <<< "$files"; then
+            exit 0
+          fi
+
+          if grep -E '^\.changelog/[^/]+\.md$' <<< "$files" \
+            | grep -qv '^\.changelog/README\.md$'; then
+            exit 0
+          fi
+
+          changelog=$(printf '%s\n' \
+            '---' \
+            'github.com/tempoxyz/mpp-go: patch' \
+            '---' \
+            '' \
+            'Update Go dependencies in the weekly Dependabot batch.')
+          content=$(printf '%s\n' "$changelog" | base64 | tr -d '\n')
+
+          gh api --method PUT \
+            "/repos/${GITHUB_REPOSITORY}/contents/.changelog/dependabot-${PR_NUMBER}.md" \
+            -f message='chore: add dependency changelog' \
+            -f content="$content" \
+            -f branch="$HEAD_REF"
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
   merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: changelog
+    if: needs.changelog.outputs.updated != 'true'
     permissions:
       checks: read
       contents: write


### PR DESCRIPTION
## Motivation

Routine Go module and GitHub Actions updates currently arrive as separate pull requests and require repetitive merge handling.

## Summary

- Batch routine Go module and GitHub Actions updates into one weekly pull request
- Call the reusable Dependabot workflow from tempoxyz/mpp-tools#67 at an exact commit
- Automatically squash-merge patch and minor updates after every pull request check passes
- Keep major updates manual and security updates independent of the weekly version-update schedule

## Key design considerations

- Pin the shared workflow to commit `1d20c6f032568c0aea39c0e7e57e4ba350516281`
- Keep merge policy centralized in `mpp-tools`
- Include the repository-required changelog entry
- Depend on tempoxyz/mpp-tools#67