### PR TITLE
fix: accept unescaped description quotes

### DIFF
--- a/.changelog/parse-unescaped-description-quotes.md
+++ b/.changelog/parse-unescaped-description-quotes.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Accept legacy challenge descriptions containing unescaped quotes.

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -58,6 +58,12 @@ func parseAuthParams(s string) (map[string]string, error) {
 			i++
 		}
 		if i < len(s) && s[i] != ',' {
+			// Legacy challenges may contain unescaped quotes in the optional
+			// description. Keep the value up to the quote and ignore the
+			// malformed, non-semantic suffix.
+			if key == "description" {
+				break
+			}
 			return nil, fmt.Errorf("mpp: malformed auth-param separator")
 		}
 	}

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -313,6 +313,20 @@ func TestParseChallenge(t *testing.T) {
 			want:   optional,
 		},
 		{
+			name: "unescaped quotes in description",
+			header: `Payment id="ch_special", realm="api.example.com", method="tempo", intent="charge", ` +
+				`request="eyJhbW91bnQiOiIxMDAifQ", description="Payment for "Premium" service — 50% off!"`,
+			want: &Challenge{
+				ID:          "ch_special",
+				Method:      "tempo",
+				Intent:      "charge",
+				Request:     map[string]any{"amount": "100"},
+				Realm:       "api.example.com",
+				RequestB64:  "eyJhbW91bnQiOiIxMDAifQ",
+				Description: "Payment for ",
+			},
+		},
+		{
 			name:    "invalid scheme",
 			header:  `Bearer realm="api.example.com"`,
 			wantErr: `expected Payment scheme`,


### PR DESCRIPTION
## Motivation

The Go SDK rejects the permissive conformance vector for legacy challenge descriptions containing unescaped quotes.

## Summary

- Truncate legacy description values at the first unescaped quote
- Ignore the malformed, non-semantic description suffix
- Add regression coverage and a patch changelog entry

## Key design considerations

- Keep escaped quote handling unchanged
- Preserve strict separator validation for semantic auth parameters
- Limit permissive behavior to the optional description field