### PR TITLE
fix(mpp): require receipt method and timestamp

### DIFF
--- a/.changelog/require-receipt-core-fields.md
+++ b/.changelog/require-receipt-core-fields.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject Payment-Receipt headers that omit the required method or timestamp fields.

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -328,11 +328,66 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{
-		"status": "success",
+		"status":    "success",
+		"method":    "tempo",
+		"timestamp": "2026-01-01T00:00:00Z",
 	}))
 	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "receipt missing reference"),
 		"ParseReceipt() error = %v, want missing reference error", err) {
 		return
+	}
+
+	for _, tt := range []struct {
+		name    string
+		receipt map[string]any
+		wantErr string
+	}{
+		{
+			name: "missing timestamp",
+			receipt: map[string]any{
+				"status":    "success",
+				"method":    "tempo",
+				"reference": "ref-123",
+			},
+			wantErr: "receipt missing timestamp",
+		},
+		{
+			name: "empty timestamp",
+			receipt: map[string]any{
+				"status":    "success",
+				"method":    "tempo",
+				"timestamp": "",
+				"reference": "ref-123",
+			},
+			wantErr: "receipt missing timestamp",
+		},
+		{
+			name: "missing method",
+			receipt: map[string]any{
+				"status":    "success",
+				"timestamp": "2026-01-01T00:00:00Z",
+				"reference": "ref-123",
+			},
+			wantErr: "receipt missing method",
+		},
+		{
+			name: "empty method",
+			receipt: map[string]any{
+				"status":    "success",
+				"method":    "",
+				"timestamp": "2026-01-01T00:00:00Z",
+				"reference": "ref-123",
+			},
+			wantErr: "receipt missing method",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseReceipt(b64EncodeAny(tt.receipt))
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
 	}
 
 	_, err = ParseReceipt(b64EncodeAny(map[string]any{

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -491,13 +491,15 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	var ts time.Time
-	if tsRaw := anyStr(data["timestamp"]); tsRaw != "" {
-		ts, err = time.Parse(time.RFC3339Nano, strings.Replace(tsRaw, "Z", "+00:00", 1))
+	tsRaw := anyStr(data["timestamp"])
+	if tsRaw == "" {
+		return nil, fmt.Errorf("mpp: receipt missing timestamp")
+	}
+	ts, err = time.Parse(time.RFC3339Nano, strings.Replace(tsRaw, "Z", "+00:00", 1))
+	if err != nil {
+		ts, err = time.Parse(time.RFC3339, tsRaw)
 		if err != nil {
-			ts, err = time.Parse(time.RFC3339, tsRaw)
-			if err != nil {
-				return nil, fmt.Errorf("mpp: invalid receipt timestamp: %w", err)
-			}
+			return nil, fmt.Errorf("mpp: invalid receipt timestamp: %w", err)
 		}
 	}
 
@@ -507,7 +509,10 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 	}
 
 	method := anyStr(data["method"])
-	if method != "" && !isMethodName(method) {
+	if method == "" {
+		return nil, fmt.Errorf("mpp: receipt missing method")
+	}
+	if !isMethodName(method) {
 		return nil, fmt.Errorf("mpp: invalid receipt method %q", method)
 	}
 


### PR DESCRIPTION
# Require method and timestamp in Payment receipts

## Summary

Reject `Payment-Receipt` headers that omit the required `method` or `timestamp` fields.

Previously, `ParsePaymentReceipt` accepted these malformed receipts and returned an empty method or a zero-value `time.Time`. This makes receipt validation stricter and prevents incomplete receipts from being treated as valid.

## Changes

- Require a non-empty `timestamp` before parsing it.
- Require a non-empty `method` before validating its syntax.
- Preserve the existing timestamp-format and method-name validation.
- Add regression coverage for missing and empty values for both fields.

## Testing

- `go test ./pkg/mpp`
- `go vet ./...`
- `go test -race -count=1 ./...`

