### PR TITLE
fix(mpp): reject non-string opaque values

### DIFF
--- a/.changelog/validate-opaque-string-values.md
+++ b/.changelog/validate-opaque-string-values.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject Payment challenges and credentials whose opaque metadata contains non-string values.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@924710544d534332220d164bfa5747340bb85f93
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@6667d4c0c94c9d4637774ebce10d436e3368a9e2
     with:
       protocol-paths: |
         pkg/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@924710544d534332220d164bfa5747340bb85f93
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@6667d4c0c94c9d4637774ebce10d436e3368a9e2
     with:
       adapter: go
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -229,9 +229,9 @@ func ParseChallenge(header string) (*Challenge, error) {
 		if err != nil {
 			return nil, fmt.Errorf("mpp: invalid opaque field: %w", err)
 		}
-		opaque = make(map[string]string, len(opaqueMap))
-		for k, v := range opaqueMap {
-			opaque[k] = anyStr(v)
+		opaque, err = toStringMap(opaqueMap)
+		if err != nil {
+			return nil, fmt.Errorf("mpp: invalid opaque field: %w", err)
 		}
 	}
 
@@ -411,15 +411,18 @@ func ParseCredential(header string) (*Credential, error) {
 			if err != nil {
 				return nil, fmt.Errorf("mpp: invalid credential opaque field: %w", err)
 			}
-			echo.Opaque = make(map[string]string, len(decoded))
-			for key, value := range decoded {
-				echo.Opaque[key] = anyStr(value)
+			echo.Opaque, err = toStringMap(decoded)
+			if err != nil {
+				return nil, fmt.Errorf("mpp: invalid credential opaque field: %w", err)
 			}
 		case map[string]any:
-			echo.Opaque = make(map[string]string, len(opaque))
-			for key, value := range opaque {
-				echo.Opaque[key] = anyStr(value)
+			var err error
+			echo.Opaque, err = toStringMap(opaque)
+			if err != nil {
+				return nil, fmt.Errorf("mpp: invalid credential opaque field: %w", err)
 			}
+		default:
+			return nil, fmt.Errorf("mpp: invalid credential opaque field: must be an encoded string or object")
 		}
 	}
 
@@ -601,4 +604,19 @@ func anyStr(v any) string {
 		return s
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+func toStringMap(data map[string]any) (map[string]string, error) {
+	if data == nil {
+		return nil, fmt.Errorf("must be an object")
+	}
+	result := make(map[string]string, len(data))
+	for key, value := range data {
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("value for %q must be a string", key)
+		}
+		result[key] = stringValue
+	}
+	return result, nil
 }

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -382,6 +382,12 @@ func TestParseChallenge(t *testing.T) {
 			wantErr: `invalid request field`,
 		},
 		{
+			name: "opaque value must be string",
+			header: `Payment id="abc", realm="api.example.com", method="tempo", intent="charge", request="e30", opaque="` +
+				b64EncodeAny(map[string]any{"trace": 123}) + `"`,
+			wantErr: `invalid opaque field: value for "trace" must be a string`,
+		},
+		{
 			name:    "header too large",
 			header:  "Payment " + strings.Repeat("a", maxHeaderPayload),
 			wantErr: `WWW-Authenticate header exceeds maximum size`,
@@ -506,6 +512,27 @@ func TestParseCredential(t *testing.T) {
 			name:    "invalid opaque encoding",
 			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo", "intent": "charge", "request": "e30", "opaque": "not-base64"}, "payload": map[string]any{}}),
 			wantErr: `invalid credential opaque field`,
+		},
+		{
+			name: "encoded opaque value must be string",
+			header: "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{
+				"id": "abc", "method": "tempo", "intent": "charge", "request": "e30",
+				"opaque": b64EncodeAny(map[string]any{"trace": true}),
+			}, "payload": map[string]any{}}),
+			wantErr: `invalid credential opaque field: value for "trace" must be a string`,
+		},
+		{
+			name: "object opaque value must be string",
+			header: "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{
+				"id": "abc", "method": "tempo", "intent": "charge", "request": "e30",
+				"opaque": map[string]any{"route": []any{"paid"}},
+			}, "payload": map[string]any{}}),
+			wantErr: `invalid credential opaque field: value for "route" must be a string`,
+		},
+		{
+			name:    "opaque must use supported representation",
+			header:  "Payment " + b64EncodeAny(map[string]any{"challenge": map[string]any{"id": "abc", "method": "tempo", "intent": "charge", "request": "e30", "opaque": true}, "payload": map[string]any{}}),
+			wantErr: `invalid credential opaque field: must be an encoded string or object`,
 		},
 		{
 			name:    "authorization header too large",


### PR DESCRIPTION
# Reject non-string opaque metadata values

## Summary

Validate that every value in challenge and credential `opaque` metadata is a string.

The MPP opaque field is a flat string-to-string object. Previously, non-string values such as numbers, booleans, arrays, and nested objects were passed through `anyStr`, which could silently coerce them or turn them into empty strings.

## Changes

- Add a shared conversion helper that rejects non-string map values.
- Apply strict validation when parsing challenge opaque metadata.
- Apply the same validation to encoded-string and object credential representations.
- Reject unsupported credential opaque representations.
- Add public parser regression tests for each affected representation.

## Testing

- `go test ./pkg/mpp`
- `go vet ./...`
- `go test -race -count=1 ./...`

