### PR TITLE
feat: add Tempo relay credential lifecycle

### DIFF
--- a/.changelog/tempo-relay.md
+++ b/.changelog/tempo-relay.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Add split credential validation and broadcast lifecycle hooks, with Tempo API relay configuration for server-side charges.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ func main() {
 | [charge-basic](./examples/charge-basic/) | Generic Tempo charge flow using the high-level MPP client and server helpers, available in both one-command and separate-process layouts |
 | [charge-hash](./examples/charge-hash/) | Push-mode charge flow with a hash credential, available in both one-command and separate-process layouts |
 | [charge-fee-payer](./examples/charge-fee-payer/) | Sponsored Tempo charge flow where the server co-signs as a fee payer, available in both one-command and separate-process layouts |
+| [charge-relay](./examples/charge-relay/) | Moderato charge flow that delegates credential validation and broadcast to Tempo API's MPP relay |
 
 ## Idempotent POST Charges
 
@@ -164,6 +165,25 @@ Use the same `ExternalID` for retries of the same operation. Do not generate a
 new value for each retry, and avoid reusing one value across different paid
 operations. On retry, check the stored idempotency result first and return the
 cached response or receipt instead of executing the POST operation again.
+
+## Split Credential Lifecycle
+
+Server intents may implement `server.SplitIntent` to separate advisory,
+non-mutating validation from settlement:
+
+```go
+validation, err := payment.ValidateCredential(ctx, credential)
+receipt, err := payment.BroadcastCredential(ctx, credential)
+```
+
+`ValidateCredential` requires a split intent and must not consume replay state,
+sign fee-payer transactions, or broadcast. `BroadcastCredential` re-validates
+before settlement. `VerifyCredential` remains an alias for the mutating
+broadcast path, and legacy intents that only implement `Verify` continue to
+work for paid routes and broadcasts.
+
+Tempo relay methods implement the split lifecycle by delegating validation to
+`POST /v1/mpp/validate` and finalization to `POST /v1/mpp/broadcast`.
 
 ## Web Frameworks
 

--- a/README.md
+++ b/README.md
@@ -168,19 +168,29 @@ cached response or receipt instead of executing the POST operation again.
 
 ## Split Credential Lifecycle
 
-Server intents may implement `server.SplitIntent` to separate advisory,
-non-mutating validation from settlement:
+Server intents can register separate advisory validation and settlement hooks:
+
+```go
+intent, err := server.NewIntent("charge", server.IntentHooks{
+	Validate:  validateCredential,
+	Broadcast: broadcastCredential,
+})
+```
+
+The constructed intent still satisfies the existing `server.Intent` interface;
+its `Verify` method calls `Validate` and then `Broadcast`. Servers can also run
+the phases independently:
 
 ```go
 validation, err := payment.ValidateCredential(ctx, credential)
 receipt, err := payment.BroadcastCredential(ctx, credential)
 ```
 
-`ValidateCredential` requires a split intent and must not consume replay state,
-sign fee-payer transactions, or broadcast. `BroadcastCredential` re-validates
-before settlement. `VerifyCredential` remains an alias for the mutating
-broadcast path, and legacy intents that only implement `Verify` continue to
-work for paid routes and broadcasts.
+`ValidateCredential` requires an intent constructed with split hooks and must
+not consume replay state, sign fee-payer transactions, or broadcast.
+`BroadcastCredential` re-validates before settlement. `VerifyCredential`
+remains an alias for the mutating broadcast path, and legacy intents that only
+implement `Verify` continue to work for paid routes and broadcasts.
 
 Tempo relay methods implement the split lifecycle by delegating validation to
 `POST /v1/mpp/validate` and finalization to `POST /v1/mpp/broadcast`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ Run any example directly from the repo root:
 go run ./examples/charge-basic
 go run ./examples/charge-hash
 go run ./examples/charge-fee-payer
+TEMPO_API_KEY=tempo:sk:... go run ./examples/charge-relay
 go run ./examples/basic/server
 go run ./examples/basic/client
 go run ./examples/chi/server
@@ -43,6 +44,9 @@ go run ./examples/charge-fee-payer/client
 
 Set `TEMPO_RPC_URL` to point at a different node if you are not using the
 local dockerized devnet.
+
+`charge-relay` is the exception: it runs against Tempo Moderato by default and
+requires a Tempo API key with the `mpp:write` scope.
 
 `server.ChargeMiddleware` already works with `net/http` and routers built on
 top of it, such as Chi. The Gin and Echo examples use the dedicated adapter

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -46,11 +46,12 @@ method, err := charge.MethodFromConfig(charge.Config{
 })
 ```
 
-The adapter implements `server.SplitIntent`. `payment.ValidateCredential`
-calls only the relay validation endpoint, while `payment.BroadcastCredential`
-re-validates and then calls the broadcast endpoint. Paid HTTP routes use that
-same split lifecycle automatically. `payment.VerifyCredential` remains a
-backwards-compatible alias for the mutating broadcast path.
+The relay registers separate validation and broadcast hooks through
+`server.IntentHooks`. `payment.ValidateCredential` calls only the relay
+validation endpoint, while `payment.BroadcastCredential` re-validates and then
+calls the broadcast endpoint. Paid HTTP routes use that same split lifecycle
+automatically. `payment.VerifyCredential` remains a backwards-compatible alias
+for the mutating broadcast path.
 
 The relay broadcasts pull credentials and recognizes push credentials as
 already broadcast transactions, returning their receipts without sending them

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -1,0 +1,57 @@
+# Charge Relay
+
+A one-command Go API and client that accept pathUSD on Tempo Moderato through
+Tempo API's MPP relay. It mirrors the MPPX relay example: the server issues a
+pull-mode charge for `/api/photo`, the client signs it, and the relay validates
+and broadcasts the credential.
+
+## Setup
+
+Create a Tempo API key with the `mpp:write` scope and provide it only to the
+server process:
+
+```bash
+export TEMPO_API_KEY=tempo:sk:...
+export TEMPO_API_URL=https://api.tempo.xyz
+export MPP_SECRET_KEY=$(openssl rand -base64 32)
+go run ./examples/charge-relay
+```
+
+`TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API.
+`MPP_SECRET_KEY` protects the server-issued challenges; the example has a
+development-only default. The example creates fresh payer and recipient
+accounts, funds the payer through the Moderato faucet, starts an in-process
+HTTP server, validates a credential without broadcasting, submits that same
+credential to `/api/photo`, and prints the relay receipt reference.
+
+## Routes
+
+| Route         | Description             |
+| ------------- | ----------------------- |
+| `/api/photo`  | Payment-gated image URL |
+| `/api/health` | Free health check       |
+
+## Relay configuration
+
+```go
+method, err := charge.MethodFromConfig(charge.Config{
+	ChainID:   tempotx.ChainIdModerato,
+	Currency:  tempo.DefaultCurrencyForChain(tempotx.ChainIdModerato),
+	Recipient: recipient,
+	Relay: &charge.RelayConfig{
+		APIKey:     os.Getenv("TEMPO_API_KEY"),
+		APIBaseURL: os.Getenv("TEMPO_API_URL"),
+	},
+	SupportedModes: []tempo.ChargeMode{tempo.ChargeModePull},
+})
+```
+
+The adapter implements `server.SplitIntent`. `payment.ValidateCredential`
+calls only the relay validation endpoint, while `payment.BroadcastCredential`
+re-validates and then calls the broadcast endpoint. Paid HTTP routes use that
+same split lifecycle automatically. `payment.VerifyCredential` remains a
+backwards-compatible alias for the mutating broadcast path.
+
+The relay broadcasts pull credentials and recognizes push credentials as
+already broadcast transactions, returning their receipts without sending them
+again. Relay failures expose only safe machine-readable codes.

--- a/examples/charge-relay/client.go
+++ b/examples/charge-relay/client.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/server"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+)
+
+type relayClientResult struct {
+	Receipt string
+	URL     string
+}
+
+func runRelayClient(
+	ctx context.Context,
+	apiURL string,
+	rpcURL string,
+	chainID int64,
+	privateKey string,
+	payment *server.Mpp,
+) (*relayClientResult, error) {
+	method, err := charge.New(charge.Config{
+		ChainID:    chainID,
+		PrivateKey: privateKey,
+		RPCURL:     rpcURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure payer: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/api/photo", nil)
+	if err != nil {
+		return nil, err
+	}
+	challengeResponse, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("request photo challenge: %w", err)
+	}
+	challengeResponse.Body.Close()
+	if challengeResponse.StatusCode != http.StatusPaymentRequired {
+		return nil, fmt.Errorf("challenge route returned HTTP %d", challengeResponse.StatusCode)
+	}
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	if err != nil {
+		return nil, fmt.Errorf("parse payment challenge: %w", err)
+	}
+	credential, err := method.CreateCredential(ctx, challenge)
+	if err != nil {
+		return nil, fmt.Errorf("create payment credential: %w", err)
+	}
+	if _, err := payment.ValidateCredential(ctx, credential); err != nil {
+		return nil, fmt.Errorf("validate payment credential: %w", err)
+	}
+
+	request, err = http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/api/photo", nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", credential.ToAuthorization())
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("pay for photo: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("paid route returned HTTP %d", response.StatusCode)
+	}
+
+	receipt, err := mpp.ParseReceipt(response.Header.Get("Payment-Receipt"))
+	if err != nil {
+		return nil, fmt.Errorf("parse payment receipt: %w", err)
+	}
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode paid response: %w", err)
+	}
+	return &relayClientResult{Receipt: receipt.Reference, URL: body.URL}, nil
+}

--- a/examples/charge-relay/main.go
+++ b/examples/charge-relay/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/tempoxyz/mpp-go/examples/internal/devnet"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+const relayRealm = "mpp-go-relay.example.com"
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	apiKey := os.Getenv("TEMPO_API_KEY")
+	if apiKey == "" {
+		return fmt.Errorf("set TEMPO_API_KEY to a Tempo API key with the mpp:write scope")
+	}
+	apiURL := os.Getenv("TEMPO_API_URL")
+	if apiURL == "" {
+		apiURL = "https://api.tempo.xyz"
+	}
+	rpcURL := os.Getenv("TEMPO_RPC_URL")
+	if rpcURL == "" {
+		rpcURL = tempotx.RpcUrlModerato
+	}
+	secretKey := os.Getenv("MPP_SECRET_KEY")
+	if secretKey == "" {
+		secretKey = "mpp-go-demo-tempo-api-relay-secret-key"
+	}
+
+	rpc := tempo.NewRPCClient(rpcURL)
+	chainID, err := rpc.GetChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("get Moderato chain ID: %w", err)
+	}
+	if int64(chainID) != tempotx.ChainIdModerato {
+		return fmt.Errorf("relay example requires Moderato chain ID %d, got %d", tempotx.ChainIdModerato, chainID)
+	}
+
+	api, err := startRelayServer(apiKey, apiURL, secretKey, int64(chainID))
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	payerKey, err := crypto.GenerateKey()
+	if err != nil {
+		return fmt.Errorf("generate payer: %w", err)
+	}
+	payerPrivateKey := hexutil.Encode(crypto.FromECDSA(payerKey))
+	payer := crypto.PubkeyToAddress(payerKey.PublicKey)
+	if err := devnet.FundAddress(ctx, rpc, payer); err != nil {
+		return fmt.Errorf("fund Moderato payer: %w", err)
+	}
+	result, err := runRelayClient(ctx, api.URL, rpcURL, int64(chainID), payerPrivateKey, api.payment)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("validated and paid %s through the Tempo relay from %s; receipt %s\n", result.URL, payer.Hex(), result.Receipt)
+	return nil
+}

--- a/examples/charge-relay/server.go
+++ b/examples/charge-relay/server.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+type relayServer struct {
+	*httptest.Server
+	payment *server.Mpp
+}
+
+func startRelayServer(apiKey, apiURL, secretKey string, chainID int64) (*relayServer, error) {
+	recipientKey, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate recipient: %w", err)
+	}
+	recipient := crypto.PubkeyToAddress(recipientKey.PublicKey)
+	method, err := charge.MethodFromConfig(charge.Config{
+		ChainID:   chainID,
+		Currency:  tempo.DefaultCurrencyForChain(chainID),
+		Recipient: recipient.Hex(),
+		Relay: &charge.RelayConfig{
+			APIKey:     apiKey,
+			APIBaseURL: apiURL,
+		},
+		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePull},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure relay server: %w", err)
+	}
+	payment := server.New(method, relayRealm, secretKey)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	mux.Handle("GET /api/photo", server.ChargeMiddleware(payment, server.ChargeParams{
+		Amount:      "0.01",
+		Description: "Random stock photo",
+	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"url": "https://picsum.photos/1024/1024",
+		})
+	})))
+	return &relayServer{Server: httptest.NewServer(mux), payment: payment}, nil
+}

--- a/pkg/mpp/errors.go
+++ b/pkg/mpp/errors.go
@@ -74,6 +74,8 @@ type PaymentError struct {
 	Status int       `json:"status"`
 	Detail string    `json:"detail"`
 	Hint   string    `json:"hint,omitempty"`
+	// Details contains safe machine-readable error metadata.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 func (e *PaymentError) Error() string {
@@ -111,6 +113,9 @@ func (e *PaymentError) ProblemDetails(challengeID string) map[string]any {
 	}
 	if e.Hint != "" {
 		m["hint"] = e.Hint
+	}
+	if len(e.Details) > 0 {
+		m["details"] = e.Details
 	}
 	return m
 }

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -158,6 +158,12 @@ func TestPaymentErrorHelpers(t *testing.T) {
 		"problem[challengeId] = %#v, want %q", problem["challengeId"], "challenge-1") {
 		return
 	}
+	if !assert.Nil(t, problem["details"], "problem[details] = %#v, want nil", problem["details"]) {
+		return
+	}
+
+	err.Details = map[string]any{"code": "temporarily_unavailable", "retry": "same_credential"}
+	assert.Equal(t, err.Details, err.ProblemDetails("")["details"])
 
 	nonVerification := ErrBadRequest("invalid")
 	if !assert.False(t, errors.Is(nonVerification, ErrVerification),

--- a/pkg/server/lifecycle.go
+++ b/pkg/server/lifecycle.go
@@ -17,7 +17,7 @@ func validateCredential(
 	request map[string]any,
 	method string,
 ) (*Validation, error) {
-	split, ok := intent.(SplitIntent)
+	split, ok := intent.(*splitHookIntent)
 	if !ok {
 		err := mpp.ErrVerificationFailed(fmt.Sprintf(
 			"%s/%s does not support non-mutating credential validation",
@@ -27,24 +27,7 @@ func validateCredential(
 		err.Details = map[string]any{"intent": intent.Name(), "method": method}
 		return nil, err
 	}
-	return split.Validate(ctx, credential, request)
-}
-
-// validateAndBroadcastCredential preserves the legacy Verify path while
-// ensuring split intents pass validation immediately before settlement.
-func validateAndBroadcastCredential(
-	ctx context.Context,
-	intent Intent,
-	credential *mpp.Credential,
-	request map[string]any,
-) (*mpp.Receipt, error) {
-	if split, ok := intent.(SplitIntent); ok {
-		if _, err := split.Validate(ctx, credential, request); err != nil {
-			return nil, err
-		}
-		return split.Broadcast(ctx, credential, request)
-	}
-	return intent.Verify(ctx, credential, request)
+	return split.validate(ctx, credential, request)
 }
 
 // prepareCredential authenticates the echoed stateless challenge, enforces its

--- a/pkg/server/lifecycle.go
+++ b/pkg/server/lifecycle.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+// validateCredential dispatches the advisory validation phase and rejects
+// legacy intents rather than invoking their potentially mutating Verify hook.
+func validateCredential(
+	ctx context.Context,
+	intent Intent,
+	credential *mpp.Credential,
+	request map[string]any,
+	method string,
+) (*Validation, error) {
+	split, ok := intent.(SplitIntent)
+	if !ok {
+		err := mpp.ErrVerificationFailed(fmt.Sprintf(
+			"%s/%s does not support non-mutating credential validation",
+			method,
+			intent.Name(),
+		))
+		err.Details = map[string]any{"intent": intent.Name(), "method": method}
+		return nil, err
+	}
+	return split.Validate(ctx, credential, request)
+}
+
+// validateAndBroadcastCredential preserves the legacy Verify path while
+// ensuring split intents pass validation immediately before settlement.
+func validateAndBroadcastCredential(
+	ctx context.Context,
+	intent Intent,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if split, ok := intent.(SplitIntent); ok {
+		if _, err := split.Validate(ctx, credential, request); err != nil {
+			return nil, err
+		}
+		return split.Broadcast(ctx, credential, request)
+	}
+	return intent.Verify(ctx, credential, request)
+}
+
+// prepareCredential authenticates the echoed stateless challenge, enforces its
+// server bindings and expiry, and resolves the intent request for dispatch.
+func (m *Mpp) prepareCredential(credential *mpp.Credential) (Intent, map[string]any, error) {
+	if credential == nil {
+		return nil, nil, mpp.ErrMalformedCredential("credential is required")
+	}
+	echoedRequest, err := echoedRequestMap(credential)
+	if err != nil {
+		return nil, nil, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
+	}
+	echoed := &credential.Challenge
+	echoedChallenge := mpp.NewChallenge(
+		m.secretKey,
+		echoed.Realm,
+		echoed.Method,
+		echoed.Intent,
+		echoedRequest,
+		echoedChallengeOpts(credential)...,
+	)
+	if !mpp.ConstantTimeEqual(echoed.ID, echoedChallenge.ID) {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "challenge was not issued by this server")
+	}
+	if echoed.Realm != m.realm {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "realm mismatch")
+	}
+	if echoed.Method != m.method.Name() {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "method mismatch")
+	}
+	intent, ok := m.method.Intents()[echoed.Intent]
+	if !ok || intent.Name() != echoed.Intent {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "intent mismatch")
+	}
+	if echoed.Expires == "" {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "missing required expires")
+	}
+	expires, err := parseChallengeExpiry(echoed.Expires)
+	if err != nil {
+		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "invalid expires format")
+	}
+	if time.Now().UTC().After(expires) {
+		return nil, nil, mpp.ErrPaymentExpired(echoed.Expires)
+	}
+	return intent, echoedRequest, nil
+}
+
+// parseChallengeExpiry accepts the protocol's RFC 3339 timestamp format,
+// including fractional seconds supported by time.Parse.
+func parseChallengeExpiry(value string) (time.Time, error) {
+	return time.Parse(time.RFC3339, value)
+}

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+type splitTestIntent struct {
+	validateCalls  int
+	broadcastCalls int
+	verifyCalls    int
+	validateErr    error
+	broadcastErr   error
+}
+
+func (i *splitTestIntent) Name() string { return "charge" }
+
+func (i *splitTestIntent) Validate(
+	_ context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*Validation, error) {
+	i.validateCalls++
+	if i.validateErr != nil {
+		return nil, i.validateErr
+	}
+	return &Validation{
+		Challenge:  credential.Challenge,
+		Credential: credential,
+		Details:    map[string]any{},
+		Intent:     i.Name(),
+		Method:     "tempo",
+		Request:    request,
+		Source:     credential.Source,
+	}, nil
+}
+
+func (i *splitTestIntent) Broadcast(
+	_ context.Context,
+	_ *mpp.Credential,
+	_ map[string]any,
+) (*mpp.Receipt, error) {
+	i.broadcastCalls++
+	if i.broadcastErr != nil {
+		return nil, i.broadcastErr
+	}
+	return mpp.Success("0xsplit", mpp.WithReceiptMethod("tempo")), nil
+}
+
+func (i *splitTestIntent) Verify(
+	_ context.Context,
+	_ *mpp.Credential,
+	_ map[string]any,
+) (*mpp.Receipt, error) {
+	i.verifyCalls++
+	return mpp.Success("0xlegacy", mpp.WithReceiptMethod("tempo")), nil
+}
+
+func splitCredential(secretKey string, request map[string]any) *mpp.Credential {
+	challenge := mpp.NewChallenge(
+		secretKey,
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	return challenge.NewCredential(map[string]any{"type": "transaction", "signature": "0x1234"})
+}
+
+func TestVerifyOrChallengeUsesSplitLifecycle(t *testing.T) {
+	t.Parallel()
+	intent := &splitTestIntent{}
+	request := map[string]any{"amount": "1", "currency": "0x123"}
+	credential := splitCredential("secret-key", request)
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        intent,
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       credential.Challenge.Expires,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0xsplit", result.Receipt.Reference)
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+}
+
+func TestMppCredentialLifecycle(t *testing.T) {
+	t.Parallel()
+	intent := &splitTestIntent{}
+	method := chargeTestMethod{intents: map[string]Intent{"charge": intent}}
+	payment := New(method, "api.example.com", "secret-key")
+	request := map[string]any{"amount": "1", "currency": "0x123"}
+	credential := splitCredential("secret-key", request)
+
+	validation, err := payment.ValidateCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, credential, validation.Credential)
+	assert.Equal(t, request, validation.Request)
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Zero(t, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+
+	receipt, err := payment.BroadcastCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, "0xsplit", receipt.Reference)
+	assert.Equal(t, 2, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+
+	receipt, err = payment.VerifyCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, "0xsplit", receipt.Reference)
+	assert.Equal(t, 3, intent.validateCalls)
+	assert.Equal(t, 2, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+}
+
+func TestMppValidateCredentialRequiresSplitIntent(t *testing.T) {
+	t.Parallel()
+	payment := New(
+		chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}},
+		"api.example.com",
+		"secret-key",
+	)
+	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+
+	_, err := payment.ValidateCredential(context.Background(), credential)
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, mpp.ErrorTypeVerificationFailed, paymentErr.Type)
+	assert.Equal(t, map[string]any{"intent": "charge", "method": "tempo"}, paymentErr.Details)
+}
+
+func TestMppBroadcastCredentialSupportsLegacyIntent(t *testing.T) {
+	t.Parallel()
+	payment := New(
+		chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}},
+		"api.example.com",
+		"secret-key",
+	)
+	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+
+	receipt, err := payment.BroadcastCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, "0xreceipt", receipt.Reference)
+}
+
+func TestMppBroadcastCredentialStopsAfterValidationFailure(t *testing.T) {
+	t.Parallel()
+	intent := &splitTestIntent{validateErr: errors.New("invalid")}
+	payment := New(
+		chargeTestMethod{intents: map[string]Intent{"charge": intent}},
+		"api.example.com",
+		"secret-key",
+	)
+	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+
+	_, err := payment.BroadcastCredential(context.Background(), credential)
+	require.Error(t, err)
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Zero(t, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+}
+
+func TestMppCredentialLifecycleRejectsForeignChallenge(t *testing.T) {
+	t.Parallel()
+	intent := &splitTestIntent{}
+	payment := New(
+		chargeTestMethod{intents: map[string]Intent{"charge": intent}},
+		"api.example.com",
+		"secret-key",
+	)
+	credential := splitCredential("foreign-secret", map[string]any{"amount": "1"})
+
+	_, err := payment.ValidateCredential(context.Background(), credential)
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, mpp.ErrorTypeInvalidChallenge, paymentErr.Type)
+	assert.Zero(t, intent.validateCalls)
+}

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -13,7 +13,6 @@ import (
 type splitTestIntent struct {
 	validateCalls  int
 	broadcastCalls int
-	verifyCalls    int
 	validateErr    error
 	broadcastErr   error
 }
@@ -52,13 +51,14 @@ func (i *splitTestIntent) Broadcast(
 	return mpp.Success("0xsplit", mpp.WithReceiptMethod("tempo")), nil
 }
 
-func (i *splitTestIntent) Verify(
-	_ context.Context,
-	_ *mpp.Credential,
-	_ map[string]any,
-) (*mpp.Receipt, error) {
-	i.verifyCalls++
-	return mpp.Success("0xlegacy", mpp.WithReceiptMethod("tempo")), nil
+func newSplitTestServerIntent(t *testing.T, hooks *splitTestIntent) Intent {
+	t.Helper()
+	intent, err := NewIntent(hooks.Name(), IntentHooks{
+		Validate:  hooks.Validate,
+		Broadcast: hooks.Broadcast,
+	})
+	require.NoError(t, err)
+	return intent
 }
 
 func splitCredential(secretKey string, request map[string]any) *mpp.Credential {
@@ -81,7 +81,7 @@ func TestVerifyOrChallengeUsesSplitLifecycle(t *testing.T) {
 
 	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
 		Authorization: credential.ToAuthorization(),
-		Intent:        intent,
+		Intent:        newSplitTestServerIntent(t, intent),
 		Request:       request,
 		Realm:         "api.example.com",
 		SecretKey:     "secret-key",
@@ -92,13 +92,12 @@ func TestVerifyOrChallengeUsesSplitLifecycle(t *testing.T) {
 	assert.Equal(t, "0xsplit", result.Receipt.Reference)
 	assert.Equal(t, 1, intent.validateCalls)
 	assert.Equal(t, 1, intent.broadcastCalls)
-	assert.Zero(t, intent.verifyCalls)
 }
 
 func TestMppCredentialLifecycle(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
-	method := chargeTestMethod{intents: map[string]Intent{"charge": intent}}
+	method := chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}}
 	payment := New(method, "api.example.com", "secret-key")
 	request := map[string]any{"amount": "1", "currency": "0x123"}
 	credential := splitCredential("secret-key", request)
@@ -109,24 +108,88 @@ func TestMppCredentialLifecycle(t *testing.T) {
 	assert.Equal(t, request, validation.Request)
 	assert.Equal(t, 1, intent.validateCalls)
 	assert.Zero(t, intent.broadcastCalls)
-	assert.Zero(t, intent.verifyCalls)
 
 	receipt, err := payment.BroadcastCredential(context.Background(), credential)
 	require.NoError(t, err)
 	assert.Equal(t, "0xsplit", receipt.Reference)
 	assert.Equal(t, 2, intent.validateCalls)
 	assert.Equal(t, 1, intent.broadcastCalls)
-	assert.Zero(t, intent.verifyCalls)
 
 	receipt, err = payment.VerifyCredential(context.Background(), credential)
 	require.NoError(t, err)
 	assert.Equal(t, "0xsplit", receipt.Reference)
 	assert.Equal(t, 3, intent.validateCalls)
 	assert.Equal(t, 2, intent.broadcastCalls)
-	assert.Zero(t, intent.verifyCalls)
 }
 
-func TestMppValidateCredentialRequiresSplitIntent(t *testing.T) {
+func TestNewIntentSynthesizesVerify(t *testing.T) {
+	t.Parallel()
+	intent := &splitTestIntent{}
+	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+	configured := newSplitTestServerIntent(t, intent)
+
+	receipt, err := configured.Verify(
+		context.Background(),
+		credential,
+		map[string]any{"amount": "1"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "0xsplit", receipt.Reference)
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+
+	intent.validateErr = errors.New("invalid")
+	_, err = configured.Verify(
+		context.Background(),
+		credential,
+		map[string]any{"amount": "1"},
+	)
+	require.Error(t, err)
+	assert.Equal(t, 2, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+}
+
+func TestNewIntentValidatesHookShape(t *testing.T) {
+	t.Parallel()
+	verify := func(context.Context, *mpp.Credential, map[string]any) (*mpp.Receipt, error) {
+		return mpp.Success("0xlegacy"), nil
+	}
+	validate := func(context.Context, *mpp.Credential, map[string]any) (*Validation, error) {
+		return &Validation{}, nil
+	}
+	broadcast := func(context.Context, *mpp.Credential, map[string]any) (*mpp.Receipt, error) {
+		return mpp.Success("0xsplit"), nil
+	}
+	tests := []struct {
+		name      string
+		intent    string
+		hooks     IntentHooks
+		wantError bool
+	}{
+		{name: "verify", intent: "charge", hooks: IntentHooks{Verify: verify}},
+		{name: "split", intent: "charge", hooks: IntentHooks{Validate: validate, Broadcast: broadcast}},
+		{name: "missing name", hooks: IntentHooks{Verify: verify}, wantError: true},
+		{name: "missing hooks", intent: "charge", wantError: true},
+		{name: "validate only", intent: "charge", hooks: IntentHooks{Validate: validate}, wantError: true},
+		{name: "broadcast only", intent: "charge", hooks: IntentHooks{Broadcast: broadcast}, wantError: true},
+		{name: "mixed", intent: "charge", hooks: IntentHooks{Verify: verify, Validate: validate, Broadcast: broadcast}, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			intent, err := NewIntent(tt.intent, tt.hooks)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Nil(t, intent)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.intent, intent.Name())
+		})
+	}
+}
+
+func TestMppValidateCredentialRequiresSplitHooks(t *testing.T) {
 	t.Parallel()
 	payment := New(
 		chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}},
@@ -160,7 +223,7 @@ func TestMppBroadcastCredentialStopsAfterValidationFailure(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{validateErr: errors.New("invalid")}
 	payment := New(
-		chargeTestMethod{intents: map[string]Intent{"charge": intent}},
+		chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}},
 		"api.example.com",
 		"secret-key",
 	)
@@ -170,14 +233,13 @@ func TestMppBroadcastCredentialStopsAfterValidationFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, 1, intent.validateCalls)
 	assert.Zero(t, intent.broadcastCalls)
-	assert.Zero(t, intent.verifyCalls)
 }
 
 func TestMppCredentialLifecycleRejectsForeignChallenge(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
 	payment := New(
-		chargeTestMethod{intents: map[string]Intent{"charge": intent}},
+		chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}},
 		"api.example.com",
 		"secret-key",
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,14 +38,83 @@ type Validation struct {
 	Source string
 }
 
-// SplitIntent separates non-mutating credential validation from settlement.
-// Verify remains the backwards-compatible combined path.
-type SplitIntent interface {
-	Intent
-	// Validate performs an advisory check without mutating payment state.
-	Validate(ctx context.Context, credential *mpp.Credential, request map[string]any) (*Validation, error)
-	// Broadcast finalizes a credential after validation and may mutate payment state.
-	Broadcast(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error)
+// VerifyFunc is the legacy combined credential verification hook.
+type VerifyFunc func(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error)
+
+// ValidateFunc performs an advisory credential check without mutating payment state.
+type ValidateFunc func(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*Validation, error)
+
+// BroadcastFunc finalizes a validated credential and may mutate payment state.
+type BroadcastFunc func(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error)
+
+// IntentHooks configures either a legacy Verify hook or split Validate and Broadcast hooks.
+type IntentHooks struct {
+	// Verify configures the legacy combined verification path.
+	Verify VerifyFunc
+	// Validate configures the advisory phase of a split verification path.
+	Validate ValidateFunc
+	// Broadcast configures the settlement phase of a split verification path.
+	Broadcast BroadcastFunc
+}
+
+type verifyHookIntent struct {
+	name   string
+	verify VerifyFunc
+}
+
+type splitHookIntent struct {
+	name      string
+	validate  ValidateFunc
+	broadcast BroadcastFunc
+}
+
+// NewIntent builds an Intent from either Verify or Validate and Broadcast hooks.
+func NewIntent(name string, hooks IntentHooks) (Intent, error) {
+	if name == "" {
+		return nil, fmt.Errorf("server: intent name is required")
+	}
+	if hooks.Verify != nil && hooks.Validate == nil && hooks.Broadcast == nil {
+		return &verifyHookIntent{name: name, verify: hooks.Verify}, nil
+	}
+	if hooks.Verify == nil && hooks.Validate != nil && hooks.Broadcast != nil {
+		return &splitHookIntent{name: name, validate: hooks.Validate, broadcast: hooks.Broadcast}, nil
+	}
+	return nil, fmt.Errorf("server: intent hooks require either Verify or both Validate and Broadcast")
+}
+
+func (i *verifyHookIntent) Name() string { return i.name }
+
+func (i *verifyHookIntent) Verify(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	return i.verify(ctx, credential, request)
+}
+
+func (i *splitHookIntent) Name() string { return i.name }
+
+func (i *splitHookIntent) Verify(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if _, err := i.validate(ctx, credential, request); err != nil {
+		return nil, err
+	}
+	return i.broadcast(ctx, credential, request)
 }
 
 // Method is the interface for server-side payment methods.
@@ -97,7 +166,7 @@ func (m *Mpp) BroadcastCredential(ctx context.Context, credential *mpp.Credentia
 	if err != nil {
 		return nil, err
 	}
-	return validateAndBroadcastCredential(ctx, intent, credential, request)
+	return intent.Verify(ctx, credential, request)
 }
 
 // VerifyCredential is a backwards-compatible alias for BroadcastCredential.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,34 @@ type Intent interface {
 	Verify(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error)
 }
 
+// Validation describes a credential accepted without consuming or broadcasting it.
+type Validation struct {
+	// Challenge is the server-issued challenge echoed by the credential.
+	Challenge mpp.ChallengeEcho
+	// Credential is the accepted credential.
+	Credential *mpp.Credential
+	// Details contains method-specific validation metadata.
+	Details map[string]any
+	// Intent is the validated payment intent.
+	Intent string
+	// Method is the validated payment method.
+	Method string
+	// Request is the challenge request bound to the credential.
+	Request map[string]any
+	// Source is the optional payer identity.
+	Source string
+}
+
+// SplitIntent separates non-mutating credential validation from settlement.
+// Verify remains the backwards-compatible combined path.
+type SplitIntent interface {
+	Intent
+	// Validate performs an advisory check without mutating payment state.
+	Validate(ctx context.Context, credential *mpp.Credential, request map[string]any) (*Validation, error)
+	// Broadcast finalizes a credential after validation and may mutate payment state.
+	Broadcast(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error)
+}
+
 // Method is the interface for server-side payment methods.
 type Method interface {
 	Name() string
@@ -52,6 +80,29 @@ func New(method Method, realm, secretKey string) *Mpp {
 // Realm returns the WWW-Authenticate realm used by this payment handler.
 func (m *Mpp) Realm() string {
 	return m.realm
+}
+
+// ValidateCredential validates an issued credential without consuming or broadcasting it.
+func (m *Mpp) ValidateCredential(ctx context.Context, credential *mpp.Credential) (*Validation, error) {
+	intent, request, err := m.prepareCredential(credential)
+	if err != nil {
+		return nil, err
+	}
+	return validateCredential(ctx, intent, credential, request, m.method.Name())
+}
+
+// BroadcastCredential validates and settles an issued credential.
+func (m *Mpp) BroadcastCredential(ctx context.Context, credential *mpp.Credential) (*mpp.Receipt, error) {
+	intent, request, err := m.prepareCredential(credential)
+	if err != nil {
+		return nil, err
+	}
+	return validateAndBroadcastCredential(ctx, intent, credential, request)
+}
+
+// VerifyCredential is a backwards-compatible alias for BroadcastCredential.
+func (m *Mpp) VerifyCredential(ctx context.Context, credential *mpp.Credential) (*mpp.Receipt, error) {
+	return m.BroadcastCredential(ctx, credential)
 }
 
 // ChargeParams contains the parameters for a charge operation.

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -58,7 +58,7 @@ type VerifyResult struct {
 //  6. Verify echoed fields match (realm, method, intent name, request)
 //  7. Check expiry
 //  8. Verify body digest, if present
-//  9. Call intent.Verify
+//  9. Validate then broadcast split intents, or call legacy intent.Verify
 //  10. Return result
 func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult, error) {
 	expires := params.Expires
@@ -164,16 +164,12 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	// 7. Check expiry before body-digest validation so expired credentials
 	// consistently return the payment-expired 402 path.
 	if echoed.Expires != "" {
-		expiresTime, err := time.Parse(time.RFC3339, echoed.Expires)
+		expiresTime, err := parseChallengeExpiry(echoed.Expires)
 		if err != nil {
-			// Try the millisecond format used by mpp.Expires helpers.
-			expiresTime, err = time.Parse("2006-01-02T15:04:05.000Z", echoed.Expires)
-			if err != nil {
-				return challengeResultError(
-					challenge,
-					mpp.ErrInvalidChallenge(echoed.ID, "invalid expires format"),
-				)
-			}
+			return challengeResultError(
+				challenge,
+				mpp.ErrInvalidChallenge(echoed.ID, "invalid expires format"),
+			)
 		}
 		if time.Now().UTC().After(expiresTime) {
 			return challengeResultError(challenge, mpp.ErrPaymentExpired(echoed.Expires))
@@ -192,8 +188,8 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		return challengeResultError(challenge, err)
 	}
 
-	// 9. Call intent.Verify.
-	receipt, err := params.Intent.Verify(ctx, credential, params.Request)
+	// 9. Validate and broadcast split intents; fall back to legacy Verify.
+	receipt, err := validateAndBroadcastCredential(ctx, params.Intent, credential, params.Request)
 	if err != nil {
 		if pe, ok := err.(*mpp.PaymentError); ok {
 			if pe.Status != http.StatusPaymentRequired {

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -188,8 +188,8 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		return challengeResultError(challenge, err)
 	}
 
-	// 9. Validate and broadcast split intents; fall back to legacy Verify.
-	receipt, err := validateAndBroadcastCredential(ctx, params.Intent, credential, params.Request)
+	// 9. Hook-built intents synthesize Verify from validation and broadcast.
+	receipt, err := params.Intent.Verify(ctx, credential, params.Request)
 	if err != nil {
 		if pe, ok := err.(*mpp.PaymentError); ok {
 			if pe.Status != http.StatusPaymentRequired {

--- a/pkg/tempo/server/config.go
+++ b/pkg/tempo/server/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	FeePayerPolicies map[string]FeePayerPolicy
 	// Store persists replay-protection keys for hash and proof credentials.
 	Store tempo.Store
+	// Relay delegates credential validation and finalization to Tempo API or a compatible MPP relay.
+	Relay *RelayConfig
 }
 
 // MethodFromConfig constructs a Tempo charge method from one config struct.
@@ -69,6 +71,15 @@ func MethodFromConfig(config Config) (*Method, error) {
 			return nil, err
 		}
 		methodConfig.Intent = intent
+	}
+	if config.Relay != nil {
+		relay, err := newRelayClient(config.Relay)
+		if err != nil {
+			return nil, err
+		}
+		method := NewMethod(methodConfig)
+		method.intent = &relayIntent{base: method.intent, relay: relay}
+		return method, nil
 	}
 	return NewMethod(methodConfig), nil
 }

--- a/pkg/tempo/server/config.go
+++ b/pkg/tempo/server/config.go
@@ -78,7 +78,12 @@ func MethodFromConfig(config Config) (*Method, error) {
 			return nil, err
 		}
 		method := NewMethod(methodConfig)
-		method.intent = &relayIntent{base: method.intent, relay: relay}
+		intent, err := relay.intent(method.intent.Name())
+		if err != nil {
+			return nil, err
+		}
+		method.intent = intent
+		method.supportsUnknownChain = true
 		return method, nil
 	}
 	return NewMethod(methodConfig), nil

--- a/pkg/tempo/server/method.go
+++ b/pkg/tempo/server/method.go
@@ -33,15 +33,16 @@ type MethodConfig struct {
 
 // Method adapts Tempo charge configuration to the generic server interfaces.
 type Method struct {
-	intent         mppserver.Intent
-	currency       string
-	recipient      string
-	decimals       int
-	chainID        int64
-	feePayer       bool
-	feePayerURL    string
-	memo           string
-	supportedModes []tempo.ChargeMode
+	intent               mppserver.Intent
+	currency             string
+	recipient            string
+	decimals             int
+	chainID              int64
+	feePayer             bool
+	feePayerURL          string
+	memo                 string
+	supportedModes       []tempo.ChargeMode
+	supportsUnknownChain bool
 }
 
 var _ mppserver.Method = (*Method)(nil)
@@ -59,22 +60,23 @@ func NewMethod(config MethodConfig) *Method {
 	}
 	chainID := config.ChainID
 	if chainID == 0 {
-		chainID = tempo.InferChainIDFromRPCURL(intentRPCURL(intent))
+		chainID = tempo.InferChainIDFromRPCURL(intent.rpcURL)
 	}
 	currency := config.Currency
 	if currency == "" {
 		currency = tempo.DefaultCurrencyForChain(chainID)
 	}
 	return &Method{
-		intent:         intent,
-		currency:       currency,
-		recipient:      config.Recipient,
-		decimals:       decimals,
-		chainID:        chainID,
-		feePayer:       config.FeePayer,
-		feePayerURL:    config.FeePayerURL,
-		memo:           config.Memo,
-		supportedModes: append([]tempo.ChargeMode(nil), config.SupportedModes...),
+		intent:               intent,
+		currency:             currency,
+		recipient:            config.Recipient,
+		decimals:             decimals,
+		chainID:              chainID,
+		feePayer:             config.FeePayer,
+		feePayerURL:          config.FeePayerURL,
+		memo:                 config.Memo,
+		supportedModes:       append([]tempo.ChargeMode(nil), config.SupportedModes...),
+		supportsUnknownChain: intent.rpc != nil || intent.rpcURL != "",
 	}
 }
 
@@ -108,7 +110,7 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 	if chainID == 0 {
 		chainID = m.chainID
 	}
-	if chainID != 0 && !intentSupportsChain(m.intent, chainID) {
+	if chainID != 0 && !tempo.IsKnownChainID(chainID) && !m.supportsUnknownChain {
 		return nil, fmt.Errorf("tempo server: unknown chain id %d; configure Intent.RPC or Intent.RPCURL explicitly", chainID)
 	}
 	memo := params.Memo
@@ -137,31 +139,6 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 		return nil, err
 	}
 	return request.Map(), nil
-}
-
-func intentRPCURL(intent mppserver.Intent) string {
-	switch intent := intent.(type) {
-	case *Intent:
-		return intent.rpcURL
-	case *relayIntent:
-		return intentRPCURL(intent.base)
-	default:
-		return ""
-	}
-}
-
-func intentSupportsChain(intent mppserver.Intent, chainID int64) bool {
-	if tempo.IsKnownChainID(chainID) {
-		return true
-	}
-	switch intent := intent.(type) {
-	case *Intent:
-		return intent.rpc != nil || intent.rpcURL != ""
-	case *relayIntent:
-		return true
-	default:
-		return false
-	}
 }
 
 func resolvedModes(memo string, requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {

--- a/pkg/tempo/server/method.go
+++ b/pkg/tempo/server/method.go
@@ -33,7 +33,7 @@ type MethodConfig struct {
 
 // Method adapts Tempo charge configuration to the generic server interfaces.
 type Method struct {
-	intent         *Intent
+	intent         mppserver.Intent
 	currency       string
 	recipient      string
 	decimals       int
@@ -59,7 +59,7 @@ func NewMethod(config MethodConfig) *Method {
 	}
 	chainID := config.ChainID
 	if chainID == 0 {
-		chainID = tempo.InferChainIDFromRPCURL(intent.rpcURL)
+		chainID = tempo.InferChainIDFromRPCURL(intentRPCURL(intent))
 	}
 	currency := config.Currency
 	if currency == "" {
@@ -108,7 +108,7 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 	if chainID == 0 {
 		chainID = m.chainID
 	}
-	if chainID != 0 && m.intent.rpc == nil && m.intent.rpcURL == "" && !tempo.IsKnownChainID(chainID) {
+	if chainID != 0 && !intentSupportsChain(m.intent, chainID) {
 		return nil, fmt.Errorf("tempo server: unknown chain id %d; configure Intent.RPC or Intent.RPCURL explicitly", chainID)
 	}
 	memo := params.Memo
@@ -137,6 +137,31 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 		return nil, err
 	}
 	return request.Map(), nil
+}
+
+func intentRPCURL(intent mppserver.Intent) string {
+	switch intent := intent.(type) {
+	case *Intent:
+		return intent.rpcURL
+	case *relayIntent:
+		return intentRPCURL(intent.base)
+	default:
+		return ""
+	}
+}
+
+func intentSupportsChain(intent mppserver.Intent, chainID int64) bool {
+	if tempo.IsKnownChainID(chainID) {
+		return true
+	}
+	switch intent := intent.(type) {
+	case *Intent:
+		return intent.rpc != nil || intent.rpcURL != ""
+	case *relayIntent:
+		return true
+	default:
+		return false
+	}
 }
 
 func resolvedModes(memo string, requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {

--- a/pkg/tempo/server/relay.go
+++ b/pkg/tempo/server/relay.go
@@ -1,0 +1,320 @@
+package chargeserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+)
+
+const defaultRelayAPIBaseURL = "https://api.tempo.xyz"
+
+const maxRelayResponseSize = 1 << 20
+
+// RelayErrorCode is a stable machine-readable relay failure code.
+type RelayErrorCode string
+
+const (
+	// RelayErrorAlreadyUsed means the credential or transaction was already used.
+	RelayErrorAlreadyUsed RelayErrorCode = "already_used"
+	// RelayErrorBroadcastFailed means transaction broadcast or confirmation failed.
+	RelayErrorBroadcastFailed RelayErrorCode = "broadcast_failed"
+	// RelayErrorExpired means the challenge or payment authorization expired.
+	RelayErrorExpired RelayErrorCode = "expired"
+	// RelayErrorInvalidPayment means the payment payload or requirements are invalid.
+	RelayErrorInvalidPayment RelayErrorCode = "invalid_payment"
+	// RelayErrorInsufficientFunds means the sender lacks funds.
+	RelayErrorInsufficientFunds RelayErrorCode = "insufficient_funds"
+	// RelayErrorPolicyDenied means the payment violates relay or account policy.
+	RelayErrorPolicyDenied RelayErrorCode = "policy_denied"
+	// RelayErrorScreenRejected means an originator or recipient failed screening.
+	RelayErrorScreenRejected RelayErrorCode = "screen_rejected"
+	// RelayErrorSimulationFailed means transaction simulation failed.
+	RelayErrorSimulationFailed RelayErrorCode = "simulation_failed"
+	// RelayErrorTemporarilyUnavailable means retrying may succeed.
+	RelayErrorTemporarilyUnavailable RelayErrorCode = "temporarily_unavailable"
+	// RelayErrorUnsupported means the method, intent, network, or asset is unsupported.
+	RelayErrorUnsupported RelayErrorCode = "unsupported"
+	// RelayErrorUnknown means the relay encountered an unexpected failure.
+	RelayErrorUnknown RelayErrorCode = "unknown"
+)
+
+// RelayConfig configures Tempo API or a compatible MPP relay.
+type RelayConfig struct {
+	// APIKey is a Tempo API key with the mpp:write scope.
+	APIKey string
+	// APIBaseURL is the relay base URL, including an optional path prefix.
+	// It defaults to https://api.tempo.xyz.
+	APIBaseURL string
+	// HTTPClient overrides the client used for relay calls.
+	HTTPClient *http.Client
+}
+
+type relayClient struct {
+	apiKey       string
+	httpClient   *http.Client
+	validateURL  string
+	broadcastURL string
+}
+
+type relayIntent struct {
+	base  mppserver.Intent
+	relay *relayClient
+}
+
+var _ mppserver.SplitIntent = (*relayIntent)(nil)
+
+func (i *relayIntent) Name() string {
+	return i.base.Name()
+}
+
+func (i *relayIntent) Validate(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mppserver.Validation, error) {
+	return i.relay.validate(ctx, credential, request, tempo.MethodName, i.Name())
+}
+
+func (i *relayIntent) Broadcast(
+	ctx context.Context,
+	credential *mpp.Credential,
+	_ map[string]any,
+) (*mpp.Receipt, error) {
+	return i.relay.broadcast(ctx, credential)
+}
+
+func (i *relayIntent) Verify(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if _, err := i.Validate(ctx, credential, request); err != nil {
+		return nil, err
+	}
+	return i.Broadcast(ctx, credential, request)
+}
+
+type relayError struct {
+	Code    RelayErrorCode `json:"code"`
+	Message string         `json:"message,omitempty"`
+}
+
+type relayReceipt struct {
+	ExternalID string `json:"externalId,omitempty"`
+	Method     string `json:"method"`
+	Reference  string `json:"reference"`
+	Timestamp  string `json:"timestamp"`
+}
+
+type relayResponse struct {
+	Success bool          `json:"success"`
+	Error   *relayError   `json:"error,omitempty"`
+	Receipt *relayReceipt `json:"receipt,omitempty"`
+}
+
+func newRelayClient(config *RelayConfig) (*relayClient, error) {
+	if config == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(config.APIKey) == "" {
+		return nil, fmt.Errorf("tempo server: relay API key is required")
+	}
+	baseURL := config.APIBaseURL
+	if baseURL == "" {
+		baseURL = defaultRelayAPIBaseURL
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("tempo server: invalid relay API base URL %q", baseURL)
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	client := *http.DefaultClient
+	if config.HTTPClient != nil {
+		client = *config.HTTPClient
+	}
+	// Relay endpoints should not redirect. Besides making endpoint selection
+	// explicit, this prevents the custom API-key header from reaching another
+	// origin through net/http's default redirect handling.
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &relayClient{
+		apiKey:       config.APIKey,
+		httpClient:   &client,
+		validateURL:  parsed.ResolveReference(&url.URL{Path: "v1/mpp/validate"}).String(),
+		broadcastURL: parsed.ResolveReference(&url.URL{Path: "v1/mpp/broadcast"}).String(),
+	}, nil
+}
+
+func (r *relayClient) verify(ctx context.Context, credential *mpp.Credential) (*mpp.Receipt, error) {
+	if _, err := r.validate(ctx, credential, nil, tempo.MethodName, tempo.IntentCharge); err != nil {
+		return nil, err
+	}
+	return r.broadcast(ctx, credential)
+}
+
+func (r *relayClient) validate(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+	method string,
+	intent string,
+) (*mppserver.Validation, error) {
+	input, err := marshalRelayInput(credential)
+	if err != nil {
+		return nil, relayFailure(credential, nil)
+	}
+	validation, err := r.post(ctx, r.validateURL, input, "")
+	if err != nil || !validation.Success {
+		return nil, relayFailure(credential, validation.Error)
+	}
+	return &mppserver.Validation{
+		Challenge:  credential.Challenge,
+		Credential: credential,
+		Details:    map[string]any{},
+		Intent:     intent,
+		Method:     method,
+		Request:    request,
+		Source:     credential.Source,
+	}, nil
+}
+
+func (r *relayClient) broadcast(ctx context.Context, credential *mpp.Credential) (*mpp.Receipt, error) {
+	input, err := marshalRelayInput(credential)
+	if err != nil {
+		return nil, relayFailure(credential, nil)
+	}
+	broadcast, err := r.post(ctx, r.broadcastURL, input, relayIdempotencyKey(credential, input))
+	if err != nil || !broadcast.Success || broadcast.Receipt == nil {
+		return nil, relayFailure(credential, broadcast.Error)
+	}
+	return parseRelayReceipt(broadcast.Receipt)
+}
+
+func marshalRelayInput(credential *mpp.Credential) ([]byte, error) {
+	raw, err := json.Marshal(credential)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var input any
+	if err := decoder.Decode(&input); err != nil {
+		return nil, err
+	}
+	var canonical bytes.Buffer
+	encoder := json.NewEncoder(&canonical)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(input); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(canonical.Bytes(), []byte("\n")), nil
+}
+
+func (r *relayClient) post(
+	ctx context.Context,
+	endpoint string,
+	input []byte,
+	idempotencyKey string,
+) (relayResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(input))
+	if err != nil {
+		return relayResponse{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Tempo-API-Key", r.apiKey)
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+
+	response, err := r.httpClient.Do(req)
+	if err != nil {
+		return relayResponse{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return relayResponse{}, fmt.Errorf("relay returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxRelayResponseSize+1))
+	if err != nil || len(body) > maxRelayResponseSize {
+		return relayResponse{}, fmt.Errorf("invalid relay response")
+	}
+	var result relayResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return relayResponse{}, err
+	}
+	return result, nil
+}
+
+func relayIdempotencyKey(credential *mpp.Credential, input []byte) string {
+	if credential.Payload["type"] == string(tempo.CredentialTypeTransaction) {
+		if signature, ok := credential.Payload["signature"].(string); ok {
+			if raw, err := hexutil.Decode(signature); err == nil {
+				return "mppx_" + crypto.Keccak256Hash(raw).Hex()
+			}
+		}
+	}
+	digest := sha256.Sum256(input)
+	return "mppx_0x" + hex.EncodeToString(digest[:])
+}
+
+func parseRelayReceipt(receipt *relayReceipt) (*mpp.Receipt, error) {
+	if receipt.Method != tempo.MethodName || receipt.Reference == "" {
+		return nil, mpp.ErrVerificationFailed("payment verification failed")
+	}
+	timestamp, err := time.Parse(time.RFC3339, receipt.Timestamp)
+	if err != nil {
+		return nil, mpp.ErrVerificationFailed("payment verification failed")
+	}
+	return &mpp.Receipt{
+		Status:     "success",
+		Timestamp:  timestamp.UTC(),
+		Reference:  receipt.Reference,
+		Method:     receipt.Method,
+		ExternalID: receipt.ExternalID,
+	}, nil
+}
+
+func relayFailure(credential *mpp.Credential, relayErr *relayError) error {
+	if relayErr != nil && relayErr.Code == RelayErrorExpired {
+		return mpp.ErrPaymentExpired(credential.Challenge.Expires)
+	}
+	err := mpp.ErrVerificationFailed("payment verification failed")
+	if relayErr != nil {
+		err.Details = safeRelayErrorDetails(relayErr.Code)
+	}
+	return err
+}
+
+func safeRelayErrorDetails(code RelayErrorCode) map[string]any {
+	switch code {
+	case RelayErrorAlreadyUsed,
+		RelayErrorBroadcastFailed,
+		RelayErrorInsufficientFunds,
+		RelayErrorInvalidPayment,
+		RelayErrorSimulationFailed,
+		RelayErrorUnsupported:
+		return map[string]any{"code": string(code)}
+	case RelayErrorTemporarilyUnavailable:
+		return map[string]any{"code": string(code), "retry": "same_credential"}
+	default:
+		return nil
+	}
+}

--- a/pkg/tempo/server/relay.go
+++ b/pkg/tempo/server/relay.go
@@ -70,42 +70,30 @@ type relayClient struct {
 	broadcastURL string
 }
 
-type relayIntent struct {
-	base  mppserver.Intent
-	relay *relayClient
-}
-
-var _ mppserver.SplitIntent = (*relayIntent)(nil)
-
-func (i *relayIntent) Name() string {
-	return i.base.Name()
-}
-
-func (i *relayIntent) Validate(
-	ctx context.Context,
-	credential *mpp.Credential,
-	request map[string]any,
-) (*mppserver.Validation, error) {
-	return i.relay.validate(ctx, credential, request, tempo.MethodName, i.Name())
-}
-
-func (i *relayIntent) Broadcast(
-	ctx context.Context,
-	credential *mpp.Credential,
-	_ map[string]any,
-) (*mpp.Receipt, error) {
-	return i.relay.broadcast(ctx, credential)
-}
-
-func (i *relayIntent) Verify(
-	ctx context.Context,
-	credential *mpp.Credential,
-	request map[string]any,
-) (*mpp.Receipt, error) {
-	if _, err := i.Validate(ctx, credential, request); err != nil {
-		return nil, err
-	}
-	return i.Broadcast(ctx, credential, request)
+func (r *relayClient) intent(name string) (mppserver.Intent, error) {
+	return mppserver.NewIntent(name, mppserver.IntentHooks{
+		Validate: func(
+			ctx context.Context,
+			credential *mpp.Credential,
+			_ map[string]any,
+		) (*mppserver.Validation, error) {
+			if credential == nil {
+				return nil, mpp.ErrMalformedCredential("credential is required")
+			}
+			request, err := relayCredentialRequest(credential)
+			if err != nil {
+				return nil, mpp.ErrMalformedCredential("invalid echoed request")
+			}
+			return r.validate(ctx, credential, request, tempo.MethodName, name)
+		},
+		Broadcast: func(
+			ctx context.Context,
+			credential *mpp.Credential,
+			_ map[string]any,
+		) (*mpp.Receipt, error) {
+			return r.broadcast(ctx, credential)
+		},
+	})
 }
 
 type relayError struct {
@@ -160,13 +148,6 @@ func newRelayClient(config *RelayConfig) (*relayClient, error) {
 		validateURL:  parsed.ResolveReference(&url.URL{Path: "v1/mpp/validate"}).String(),
 		broadcastURL: parsed.ResolveReference(&url.URL{Path: "v1/mpp/broadcast"}).String(),
 	}, nil
-}
-
-func (r *relayClient) verify(ctx context.Context, credential *mpp.Credential) (*mpp.Receipt, error) {
-	if _, err := r.validate(ctx, credential, nil, tempo.MethodName, tempo.IntentCharge); err != nil {
-		return nil, err
-	}
-	return r.broadcast(ctx, credential)
 }
 
 func (r *relayClient) validate(
@@ -225,6 +206,13 @@ func marshalRelayInput(credential *mpp.Credential) ([]byte, error) {
 		return nil, err
 	}
 	return bytes.TrimSuffix(canonical.Bytes(), []byte("\n")), nil
+}
+
+func relayCredentialRequest(credential *mpp.Credential) (map[string]any, error) {
+	if credential.Challenge.Request == "" {
+		return nil, nil
+	}
+	return mpp.B64Decode(credential.Challenge.Request)
 }
 
 func (r *relayClient) post(

--- a/pkg/tempo/server/relay_test.go
+++ b/pkg/tempo/server/relay_test.go
@@ -1,0 +1,360 @@
+package chargeserver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+)
+
+const relayTestAPIKey = "tempo_api_key"
+
+type relayCall struct {
+	Body           map[string]any
+	IdempotencyKey string
+	Path           string
+	APIKey         string
+}
+
+func relayTestCredential(payload map[string]any) *mpp.Credential {
+	challenge := mpp.NewChallenge(
+		"test-secret-key",
+		"api.example.com",
+		tempo.MethodName,
+		tempo.IntentCharge,
+		map[string]any{
+			"amount":    "1",
+			"currency":  "0x20c0000000000000000000000000000000000001",
+			"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		},
+		mpp.WithExpires("2026-08-03T12:00:00.000Z"),
+	)
+	return challenge.NewCredential(payload, mpp.WithCredentialSource(
+		"did:pkh:eip155:42431:0x1234567890123456789012345678901234567890",
+	))
+}
+
+func relayTestServer(t *testing.T, respond func(string) any) (*httptest.Server, <-chan relayCall) {
+	t.Helper()
+	calls := make(chan relayCall, 10)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		calls <- relayCall{
+			Body:           body,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+			Path:           r.URL.Path,
+			APIKey:         r.Header.Get("Tempo-API-Key"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(respond(r.URL.Path))
+	}))
+	t.Cleanup(server.Close)
+	return server, calls
+}
+
+func newRelayForTest(t *testing.T, apiBaseURL string) *relayClient {
+	t.Helper()
+	relay, err := newRelayClient(&RelayConfig{APIKey: relayTestAPIKey, APIBaseURL: apiBaseURL})
+	require.NoError(t, err)
+	return relay
+}
+
+func TestRelayVerifyValidatesAndBroadcastsCredential(t *testing.T) {
+	t.Parallel()
+	server, calls := relayTestServer(t, func(path string) any {
+		if path == "/mpp/v1/mpp/validate" {
+			return map[string]any{"success": true}
+		}
+		return map[string]any{
+			"success": true,
+			"receipt": map[string]any{
+				"externalId": "order_123",
+				"method":     "tempo",
+				"reference":  "0xabc",
+				"timestamp":  "2026-07-22T00:00:00.000Z",
+			},
+		}
+	})
+	credential := relayTestCredential(map[string]any{
+		"type":      "transaction",
+		"signature": "0x1234",
+	})
+
+	receipt, err := newRelayForTest(t, server.URL+"/mpp").verify(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, &mpp.Receipt{
+		Status:     "success",
+		Timestamp:  time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC),
+		Reference:  "0xabc",
+		Method:     "tempo",
+		ExternalID: "order_123",
+	}, receipt)
+
+	validateCall := <-calls
+	broadcastCall := <-calls
+	assert.Equal(t, "/mpp/v1/mpp/validate", validateCall.Path)
+	assert.Equal(t, "", validateCall.IdempotencyKey)
+	assert.Equal(t, relayTestAPIKey, validateCall.APIKey)
+	assert.Equal(t, credential.Source, validateCall.Body["source"])
+	assert.Equal(t, validateCall.Body, broadcastCall.Body)
+	assert.Equal(t, "/mpp/v1/mpp/broadcast", broadcastCall.Path)
+	raw, err := hexutil.Decode("0x1234")
+	require.NoError(t, err)
+	assert.Equal(t, "mppx_"+crypto.Keccak256Hash(raw).Hex(), broadcastCall.IdempotencyKey)
+}
+
+func TestRelayFinalizesPushCredential(t *testing.T) {
+	t.Parallel()
+	server, calls := relayTestServer(t, func(path string) any {
+		if path == "/v1/mpp/validate" {
+			return map[string]any{"success": true}
+		}
+		return map[string]any{
+			"success": true,
+			"receipt": map[string]any{
+				"method":    "tempo",
+				"reference": "0xabc",
+				"timestamp": "2026-07-22T00:00:00Z",
+			},
+		}
+	})
+	credential := relayTestCredential(map[string]any{
+		"type": "hash",
+		"hash": "0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890",
+	})
+
+	_, err := newRelayForTest(t, server.URL).verify(context.Background(), credential)
+	require.NoError(t, err)
+	validateCall := <-calls
+	broadcastCall := <-calls
+	assert.Equal(t, "/v1/mpp/validate", validateCall.Path)
+	assert.Equal(t, "/v1/mpp/broadcast", broadcastCall.Path)
+
+	input, err := marshalRelayInput(credential)
+	require.NoError(t, err)
+	digest := sha256.Sum256(input)
+	assert.Equal(t, "mppx_0x"+hex.EncodeToString(digest[:]), broadcastCall.IdempotencyKey)
+}
+
+func TestRelayIntentExposesSplitLifecycle(t *testing.T) {
+	t.Parallel()
+	server, calls := relayTestServer(t, func(path string) any {
+		if path == "/v1/mpp/validate" {
+			return map[string]any{"success": true}
+		}
+		return map[string]any{
+			"success": true,
+			"receipt": map[string]any{
+				"method":    "tempo",
+				"reference": "0xabc",
+				"timestamp": "2026-07-22T00:00:00Z",
+			},
+		}
+	})
+	base, err := NewIntent(IntentConfig{})
+	require.NoError(t, err)
+	intent := &relayIntent{base: base, relay: newRelayForTest(t, server.URL)}
+	credential := relayTestCredential(map[string]any{"type": "transaction", "signature": "0x1234"})
+	request := map[string]any{"amount": "1"}
+
+	validation, err := intent.Validate(context.Background(), credential, request)
+	require.NoError(t, err)
+	assert.Equal(t, request, validation.Request)
+	assert.Equal(t, credential, validation.Credential)
+	assert.Equal(t, "/v1/mpp/validate", (<-calls).Path)
+	select {
+	case call := <-calls:
+		t.Fatalf("Validate() unexpectedly called %s", call.Path)
+	default:
+	}
+
+	receipt, err := intent.Broadcast(context.Background(), credential, request)
+	require.NoError(t, err)
+	assert.Equal(t, "0xabc", receipt.Reference)
+	assert.Equal(t, "/v1/mpp/broadcast", (<-calls).Path)
+}
+
+func TestRelayErrorMapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		code    RelayErrorCode
+		details map[string]any
+		typeURI mpp.ErrorType
+	}{
+		{name: "already used", code: RelayErrorAlreadyUsed, details: map[string]any{"code": string(RelayErrorAlreadyUsed)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "broadcast failed", code: RelayErrorBroadcastFailed, details: map[string]any{"code": string(RelayErrorBroadcastFailed)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "invalid payment", code: RelayErrorInvalidPayment, details: map[string]any{"code": string(RelayErrorInvalidPayment)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "insufficient funds", code: RelayErrorInsufficientFunds, details: map[string]any{"code": string(RelayErrorInsufficientFunds)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "simulation failed", code: RelayErrorSimulationFailed, details: map[string]any{"code": string(RelayErrorSimulationFailed)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "unsupported", code: RelayErrorUnsupported, details: map[string]any{"code": string(RelayErrorUnsupported)}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "temporarily unavailable", code: RelayErrorTemporarilyUnavailable, details: map[string]any{"code": string(RelayErrorTemporarilyUnavailable), "retry": "same_credential"}, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "expired", code: RelayErrorExpired, typeURI: mpp.ErrorTypePaymentExpired},
+		{name: "policy denied", code: RelayErrorPolicyDenied, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "screen rejected", code: RelayErrorScreenRejected, typeURI: mpp.ErrorTypeVerificationFailed},
+		{name: "unknown", code: RelayErrorUnknown, typeURI: mpp.ErrorTypeVerificationFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server, _ := relayTestServer(t, func(string) any {
+				return map[string]any{
+					"success": false,
+					"error": map[string]any{
+						"code":    tt.code,
+						"message": "private relay detail",
+					},
+				}
+			})
+			credential := relayTestCredential(map[string]any{"type": "proof", "signature": "0x1234"})
+
+			_, err := newRelayForTest(t, server.URL).verify(context.Background(), credential)
+			var paymentErr *mpp.PaymentError
+			require.ErrorAs(t, err, &paymentErr)
+			assert.Equal(t, tt.typeURI, paymentErr.Type)
+			assert.Equal(t, tt.details, paymentErr.Details)
+			assert.NotContains(t, paymentErr.Error(), "private relay detail")
+		})
+	}
+}
+
+func TestRelayBoundaryFailuresAreGeneric(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		validate  any
+		broadcast any
+	}{
+		{name: "validation malformed", validate: "not a relay response"},
+		{name: "validation missing success", validate: map[string]any{}},
+		{name: "broadcast malformed", validate: map[string]any{"success": true}, broadcast: "not a relay response"},
+		{name: "broadcast missing receipt", validate: map[string]any{"success": true}, broadcast: map[string]any{"success": true}},
+		{name: "receipt wrong method", validate: map[string]any{"success": true}, broadcast: map[string]any{"success": true, "receipt": map[string]any{"method": "stripe", "reference": "0xabc", "timestamp": "2026-07-22T00:00:00Z"}}},
+		{name: "receipt invalid timestamp", validate: map[string]any{"success": true}, broadcast: map[string]any{"success": true, "receipt": map[string]any{"method": "tempo", "reference": "0xabc", "timestamp": "invalid"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server, _ := relayTestServer(t, func(path string) any {
+				if path == "/v1/mpp/validate" {
+					return tt.validate
+				}
+				return tt.broadcast
+			})
+
+			_, err := newRelayForTest(t, server.URL).verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}))
+			var paymentErr *mpp.PaymentError
+			require.ErrorAs(t, err, &paymentErr)
+			assert.Equal(t, mpp.ErrorTypeVerificationFailed, paymentErr.Type)
+			assert.Empty(t, paymentErr.Details)
+		})
+	}
+}
+
+func TestRelayHTTPFailureIsGeneric(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"code":"unsupported","message":"private relay detail"}}`, http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := newRelayForTest(t, server.URL).verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}))
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, mpp.ErrorTypeVerificationFailed, paymentErr.Type)
+	assert.Empty(t, paymentErr.Details)
+	assert.NotContains(t, paymentErr.Error(), "private relay detail")
+}
+
+func TestRelayDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+	targetCalled := make(chan struct{}, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetCalled <- struct{}{}
+	}))
+	t.Cleanup(target.Close)
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(redirect.Close)
+
+	_, err := newRelayForTest(t, redirect.URL).verify(
+		context.Background(),
+		relayTestCredential(map[string]any{"type": "proof"}),
+	)
+	require.Error(t, err)
+	select {
+	case <-targetCalled:
+		t.Fatal("relay followed redirect and exposed request headers")
+	default:
+	}
+}
+
+func TestNewRelayClientValidationAndDefaults(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config *RelayConfig
+		err    string
+	}{
+		{name: "disabled"},
+		{name: "missing API key", config: &RelayConfig{}, err: "tempo server: relay API key is required"},
+		{name: "invalid base URL", config: &RelayConfig{APIKey: relayTestAPIKey, APIBaseURL: "://bad"}, err: "tempo server: invalid relay API base URL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			relay, err := newRelayClient(tt.config)
+			if tt.err == "" {
+				require.NoError(t, err)
+				assert.Nil(t, relay)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		})
+	}
+
+	relay, err := newRelayClient(&RelayConfig{APIKey: relayTestAPIKey})
+	require.NoError(t, err)
+	assert.Equal(t, defaultRelayAPIBaseURL+"/v1/mpp/validate", relay.validateURL)
+	assert.Equal(t, defaultRelayAPIBaseURL+"/v1/mpp/broadcast", relay.broadcastURL)
+}
+
+func TestMethodFromConfigAppliesRelayToCustomIntent(t *testing.T) {
+	t.Parallel()
+	server, _ := relayTestServer(t, func(string) any {
+		return map[string]any{"success": false, "error": map[string]any{"code": RelayErrorUnsupported}}
+	})
+	localIntent, err := NewIntent(IntentConfig{})
+	require.NoError(t, err)
+	method, err := MethodFromConfig(Config{
+		Intent:    localIntent,
+		Recipient: testRecipient,
+		ChainID:   42431,
+		Relay:     &RelayConfig{APIKey: relayTestAPIKey, APIBaseURL: server.URL},
+	})
+	require.NoError(t, err)
+
+	configured := method.Intents()[tempo.IntentCharge]
+	_, err = configured.Verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}), nil)
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, map[string]any{"code": string(RelayErrorUnsupported)}, paymentErr.Details)
+	configuredRelay, ok := configured.(*relayIntent)
+	require.True(t, ok)
+	assert.Same(t, localIntent, configuredRelay.base)
+}

--- a/pkg/tempo/server/relay_test.go
+++ b/pkg/tempo/server/relay_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 )
 
@@ -38,7 +39,7 @@ func relayTestCredential(payload map[string]any) *mpp.Credential {
 			"currency":  "0x20c0000000000000000000000000000000000001",
 			"recipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 		},
-		mpp.WithExpires("2026-08-03T12:00:00.000Z"),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
 	)
 	return challenge.NewCredential(payload, mpp.WithCredentialSource(
 		"did:pkh:eip155:42431:0x1234567890123456789012345678901234567890",
@@ -71,6 +72,13 @@ func newRelayForTest(t *testing.T, apiBaseURL string) *relayClient {
 	return relay
 }
 
+func newRelayIntentForTest(t *testing.T, apiBaseURL string) mppserver.Intent {
+	t.Helper()
+	intent, err := newRelayForTest(t, apiBaseURL).intent(tempo.IntentCharge)
+	require.NoError(t, err)
+	return intent
+}
+
 func TestRelayVerifyValidatesAndBroadcastsCredential(t *testing.T) {
 	t.Parallel()
 	server, calls := relayTestServer(t, func(path string) any {
@@ -92,7 +100,7 @@ func TestRelayVerifyValidatesAndBroadcastsCredential(t *testing.T) {
 		"signature": "0x1234",
 	})
 
-	receipt, err := newRelayForTest(t, server.URL+"/mpp").verify(context.Background(), credential)
+	receipt, err := newRelayIntentForTest(t, server.URL+"/mpp").Verify(context.Background(), credential, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &mpp.Receipt{
 		Status:     "success",
@@ -135,7 +143,7 @@ func TestRelayFinalizesPushCredential(t *testing.T) {
 		"hash": "0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890",
 	})
 
-	_, err := newRelayForTest(t, server.URL).verify(context.Background(), credential)
+	_, err := newRelayIntentForTest(t, server.URL).Verify(context.Background(), credential, nil)
 	require.NoError(t, err)
 	validateCall := <-calls
 	broadcastCall := <-calls
@@ -148,7 +156,7 @@ func TestRelayFinalizesPushCredential(t *testing.T) {
 	assert.Equal(t, "mppx_0x"+hex.EncodeToString(digest[:]), broadcastCall.IdempotencyKey)
 }
 
-func TestRelayIntentExposesSplitLifecycle(t *testing.T) {
+func TestRelayIntentExposesCredentialHooks(t *testing.T) {
 	t.Parallel()
 	server, calls := relayTestServer(t, func(path string) any {
 		if path == "/v1/mpp/validate" {
@@ -163,26 +171,33 @@ func TestRelayIntentExposesSplitLifecycle(t *testing.T) {
 			},
 		}
 	})
-	base, err := NewIntent(IntentConfig{})
+	method, err := MethodFromConfig(Config{
+		ChainID:   42431,
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Relay:     &RelayConfig{APIKey: relayTestAPIKey, APIBaseURL: server.URL},
+	})
 	require.NoError(t, err)
-	intent := &relayIntent{base: base, relay: newRelayForTest(t, server.URL)}
+	payment := mppserver.New(method, "api.example.com", "test-secret-key")
 	credential := relayTestCredential(map[string]any{"type": "transaction", "signature": "0x1234"})
-	request := map[string]any{"amount": "1"}
 
-	validation, err := intent.Validate(context.Background(), credential, request)
+	validation, err := payment.ValidateCredential(context.Background(), credential)
 	require.NoError(t, err)
-	assert.Equal(t, request, validation.Request)
+	boundRequest, err := relayCredentialRequest(credential)
+	require.NoError(t, err)
+	assert.Equal(t, boundRequest, validation.Request)
 	assert.Equal(t, credential, validation.Credential)
 	assert.Equal(t, "/v1/mpp/validate", (<-calls).Path)
 	select {
 	case call := <-calls:
-		t.Fatalf("Validate() unexpectedly called %s", call.Path)
+		t.Fatalf("ValidateCredential() unexpectedly called %s", call.Path)
 	default:
 	}
 
-	receipt, err := intent.Broadcast(context.Background(), credential, request)
+	receipt, err := payment.BroadcastCredential(context.Background(), credential)
 	require.NoError(t, err)
 	assert.Equal(t, "0xabc", receipt.Reference)
+	assert.Equal(t, "/v1/mpp/validate", (<-calls).Path)
 	assert.Equal(t, "/v1/mpp/broadcast", (<-calls).Path)
 }
 
@@ -220,7 +235,7 @@ func TestRelayErrorMapping(t *testing.T) {
 			})
 			credential := relayTestCredential(map[string]any{"type": "proof", "signature": "0x1234"})
 
-			_, err := newRelayForTest(t, server.URL).verify(context.Background(), credential)
+			_, err := newRelayIntentForTest(t, server.URL).Verify(context.Background(), credential, nil)
 			var paymentErr *mpp.PaymentError
 			require.ErrorAs(t, err, &paymentErr)
 			assert.Equal(t, tt.typeURI, paymentErr.Type)
@@ -254,7 +269,7 @@ func TestRelayBoundaryFailuresAreGeneric(t *testing.T) {
 				return tt.broadcast
 			})
 
-			_, err := newRelayForTest(t, server.URL).verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}))
+			_, err := newRelayIntentForTest(t, server.URL).Verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}), nil)
 			var paymentErr *mpp.PaymentError
 			require.ErrorAs(t, err, &paymentErr)
 			assert.Equal(t, mpp.ErrorTypeVerificationFailed, paymentErr.Type)
@@ -270,7 +285,7 @@ func TestRelayHTTPFailureIsGeneric(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := newRelayForTest(t, server.URL).verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}))
+	_, err := newRelayIntentForTest(t, server.URL).Verify(context.Background(), relayTestCredential(map[string]any{"type": "proof"}), nil)
 	var paymentErr *mpp.PaymentError
 	require.ErrorAs(t, err, &paymentErr)
 	assert.Equal(t, mpp.ErrorTypeVerificationFailed, paymentErr.Type)
@@ -291,9 +306,10 @@ func TestRelayDoesNotFollowRedirects(t *testing.T) {
 	}))
 	t.Cleanup(redirect.Close)
 
-	_, err := newRelayForTest(t, redirect.URL).verify(
+	_, err := newRelayIntentForTest(t, redirect.URL).Verify(
 		context.Background(),
 		relayTestCredential(map[string]any{"type": "proof"}),
+		nil,
 	)
 	require.Error(t, err)
 	select {
@@ -354,7 +370,18 @@ func TestMethodFromConfigAppliesRelayToCustomIntent(t *testing.T) {
 	var paymentErr *mpp.PaymentError
 	require.ErrorAs(t, err, &paymentErr)
 	assert.Equal(t, map[string]any{"code": string(RelayErrorUnsupported)}, paymentErr.Details)
-	configuredRelay, ok := configured.(*relayIntent)
-	require.True(t, ok)
-	assert.Same(t, localIntent, configuredRelay.base)
+}
+
+func TestRelayMethodAllowsRelayResolvedChain(t *testing.T) {
+	t.Parallel()
+	method, err := MethodFromConfig(Config{
+		ChainID:   999999,
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Relay:     &RelayConfig{APIKey: relayTestAPIKey},
+	})
+	require.NoError(t, err)
+
+	_, err = method.BuildChargeRequest(mppserver.ChargeParams{Amount: "1"})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Motivation

Allow Tempo payment servers to delegate credential validation and settlement to Tempo API while exposing a non-mutating validation phase.

## Summary

- Add split validate and broadcast lifecycle hooks with legacy Verify compatibility
- Add Tempo relay configuration, safe error mapping, and idempotent broadcast requests
- Add a Moderato relay example and release documentation

## Key design considerations

- Broadcast re-validates credentials immediately before settlement
- Relay API keys are server-only and never forwarded through redirects
- Existing local Tempo intents and paid routes retain their combined verification behavior