### PR TITLE
fix(server): reject secret keys shorter than 32 bytes

### DIFF
--- a/.changelog/reject-weak-server-secret.md
+++ b/.changelog/reject-weak-server-secret.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Reject server secret keys shorter than 32 bytes at construction instead of accepting forgeable HMAC-bound challenge IDs. `server.New` now returns `(*Mpp, error)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,14 +76,14 @@ import (
     charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 )
 
-payment := server.New(method, realm, secret)
+payment, err := server.New(method, realm, secret)
 
 // ❌ Bad
 import (
     mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 )
 
-payment := mppserver.New(method, realm, secret)
+payment, err := mppserver.New(method, realm, secret)
 ```
 
 When a local variable would shadow the package name, use a short variable name (`c`, `srv`) instead of aliasing the import.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -62,7 +63,11 @@ func main() {
 		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
 	})
 
-	payment := server.New(method, "api.example.com", "replace-me")
+	// Secret must be at least 32 bytes (generate with: openssl rand -base64 32).
+	payment, err := server.New(method, "api.example.com", "replace-me-with-a-32-byte-min-secret")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:      "0.50",

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -57,12 +57,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	secretKey := "basic-example-secret"
+	secretKey := "basic-example-secret-minimum-32-bytes"
 	if envSecret := getenv("MPP_SECRET_KEY"); envSecret != "" {
 		secretKey = envSecret
 	}
 
-	payment := server.New(method, devnet.Realm, secretKey)
+	payment, err := server.New(method, devnet.Realm, secretKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {

--- a/examples/charge-basic/server.go
+++ b/examples/charge-basic/server.go
@@ -25,7 +25,10 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		return nil, err
+	}
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:      "0.50",

--- a/examples/charge-basic/server/main.go
+++ b/examples/charge-basic/server/main.go
@@ -30,7 +30,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/paid", server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-fee-payer/server.go
+++ b/examples/charge-fee-payer/server.go
@@ -27,7 +27,10 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		return nil, err
+	}
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:      "0.50",

--- a/examples/charge-fee-payer/server/main.go
+++ b/examples/charge-fee-payer/server/main.go
@@ -41,7 +41,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/paid", server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-hash/server.go
+++ b/examples/charge-hash/server.go
@@ -27,7 +27,10 @@ func startServer(rpcURL string, chainID int64) (*exampleServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		return nil, err
+	}
 
 	handler := server.ChargeMiddleware(payment, server.ChargeParams{
 		Amount:         "0.50",

--- a/examples/charge-hash/server/main.go
+++ b/examples/charge-hash/server/main.go
@@ -31,7 +31,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	payment := server.New(method, devnet.Realm, "example-secret")
+	payment, err := server.New(method, devnet.Realm, "example-secret-minimum-32-byte-secret")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/paid", server.ChargeMiddleware(payment, server.ChargeParams{

--- a/examples/charge-relay/server.go
+++ b/examples/charge-relay/server.go
@@ -36,7 +36,10 @@ func startRelayServer(apiKey, apiURL, secretKey string, chainID int64) (*relaySe
 	if err != nil {
 		return nil, fmt.Errorf("configure relay server: %w", err)
 	}
-	payment := server.New(method, relayRealm, secretKey)
+	payment, err := server.New(method, relayRealm, secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("configure payment server: %w", err)
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, _ *http.Request) {

--- a/examples/chi/server/main.go
+++ b/examples/chi/server/main.go
@@ -44,12 +44,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	secretKey := "chi-example-secret"
+	secretKey := "chi-example-secret-minimum-32-bytes"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {
 		secretKey = envSecret
 	}
 
-	payment := server.New(method, devnet.Realm, secretKey)
+	payment, err := server.New(method, devnet.Realm, secretKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	router := chi.NewRouter()
 
 	router.Get("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/examples/echo/server/main.go
+++ b/examples/echo/server/main.go
@@ -44,12 +44,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	secretKey := "echo-example-secret"
+	secretKey := "echo-example-secret-minimum-32-bytes"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {
 		secretKey = envSecret
 	}
 
-	payment := server.New(method, devnet.Realm, secretKey)
+	payment, err := server.New(method, devnet.Realm, secretKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	e := echofw.New()
 
 	e.GET("/health", func(c echofw.Context) error {

--- a/examples/fiber/server/main.go
+++ b/examples/fiber/server/main.go
@@ -44,12 +44,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	secretKey := "fiber-example-secret"
+	secretKey := "fiber-example-secret-minimum-32-bytes"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {
 		secretKey = envSecret
 	}
 
-	payment := server.New(method, devnet.Realm, secretKey)
+	payment, err := server.New(method, devnet.Realm, secretKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	app := fiberfw.New()
 
 	app.Get("/health", func(c *fiberfw.Ctx) error {

--- a/examples/gin/server/main.go
+++ b/examples/gin/server/main.go
@@ -44,12 +44,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	secretKey := "gin-example-secret"
+	secretKey := "gin-example-secret-minimum-32-bytes"
 	if envSecret := os.Getenv("MPP_SECRET_KEY"); envSecret != "" {
 		secretKey = envSecret
 	}
 
-	payment := server.New(method, devnet.Realm, secretKey)
+	payment, err := server.New(method, devnet.Realm, secretKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	router := ginfw.Default()
 
 	router.GET("/health", func(c *ginfw.Context) {

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -38,7 +38,7 @@ func (i composeTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[st
 
 const (
 	composeRealm  = "api.example.com"
-	composeSecret = "secret-key"
+	composeSecret = "test-secret-key-minimum-32-byte-secret"
 )
 
 func composeTestServer(t *testing.T, configs ...ComposeConfig) *httptest.Server {
@@ -137,8 +137,8 @@ func payWithBody(t *testing.T, url string, challenge *mpp.Challenge, body string
 // --- tests ---
 
 func TestComposeMiddleware_FansOutChallenges(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -165,8 +165,8 @@ func TestComposeMiddleware_FansOutChallenges(t *testing.T) {
 }
 
 func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -206,7 +206,7 @@ func TestComposeMiddleware_DispatchesToCorrectMethod(t *testing.T) {
 }
 
 func TestComposeMiddlewareAutoScopesResourceAndQuery(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -228,8 +228,8 @@ func TestComposeMiddlewareAutoScopesResourceAndQuery(t *testing.T) {
 }
 
 func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -254,7 +254,7 @@ func TestComposeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 }
 
 func TestComposeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 	handler := ComposeMiddleware(ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}})(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
@@ -286,8 +286,8 @@ func TestComposeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
 	// Two entries with the same method+intent but different amounts.
 	// The credential should dispatch to the correct entry based on request matching.
-	methodCheap := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
-	methodExpensive := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodCheap := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodExpensive := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodCheap, Params: ChargeParams{Amount: "0.01"}},
@@ -335,8 +335,8 @@ func TestComposeMiddleware_SameMethodDifferentAmounts(t *testing.T) {
 }
 
 func TestComposeMiddleware_SameRequestDifferentMetaSelectsMatchingConfig(t *testing.T) {
-	methodBasic := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
-	methodPro := New(composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodBasic := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodPro := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodBasic, Params: ChargeParams{Amount: "1.00", Meta: map[string]string{"plan": "basic"}}},
@@ -376,7 +376,7 @@ func TestComposeMiddleware_SameRequestDifferentMetaSelectsMatchingConfig(t *test
 }
 
 func TestComposeMiddleware_RejectsUnknownMethod(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -394,8 +394,8 @@ func TestComposeMiddleware_RejectsUnknownMethod(t *testing.T) {
 }
 
 func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -433,8 +433,8 @@ func TestComposeMiddleware_CrossMethodCredentialRejected(t *testing.T) {
 }
 
 func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -475,8 +475,8 @@ func TestComposeMiddleware_AcceptsPaymentFromMixedAuthorizationHeader(t *testing
 }
 
 func TestComposeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
-	methodB := New(composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -511,7 +511,7 @@ func TestComposeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
 }
 
 func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -565,7 +565,7 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 }
 
 func TestComposeMiddleware_SingleMethod(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
@@ -599,7 +599,7 @@ func TestComposeMiddleware_SingleMethod(t *testing.T) {
 }
 
 func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
-	methodA := New(composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
 
 	srv := composeTestServer(t,
 		ComposeConfig{
@@ -659,8 +659,8 @@ func TestComposeMiddleware_PanicsOnNilMpp(t *testing.T) {
 }
 
 func TestComposeMiddleware_PanicsOnMixedRealms(t *testing.T) {
-	a := New(composeTestMethod{name: "alpha"}, "realm-a.example.com", composeSecret)
-	b := New(composeTestMethod{name: "beta"}, "realm-b.example.com", composeSecret)
+	a := newTestServer(t, composeTestMethod{name: "alpha"}, "realm-a.example.com", composeSecret)
+	b := newTestServer(t, composeTestMethod{name: "beta"}, "realm-b.example.com", composeSecret)
 
 	defer func() {
 		{

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -47,7 +47,7 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 			return err
 		}
 	})
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	e.GET("/paid", func(c echofw.Context) error {
 		credential := Credential(c)
 		receipt := Receipt(c)
@@ -123,7 +123,7 @@ func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 
 	e := echofw.New()
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	e.GET("/paid/:id", func(c echofw.Context) error {
 		return c.String(http.StatusOK, "paid")
 	}, ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}))
@@ -159,7 +159,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 
 	e := echofw.New()
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	e.POST("/paid", func(c echofw.Context) error {
 		_, _ = io.ReadAll(c.Request().Body)
 		return c.String(http.StatusOK, "paid")
@@ -192,7 +192,7 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	t.Parallel()
 
 	e := echofw.New()
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	e.POST("/paid", func(c echofw.Context) error {
 		body, _ := io.ReadAll(c.Request().Body)
 		return c.String(http.StatusOK, string(body))
@@ -218,4 +218,11 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, paidResponse.Code)
 	assert.Equal(t, originalBody, paidResponse.Body.String())
+}
+
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+	t.Helper()
+	payment, err := server.New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
 }

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -35,7 +35,7 @@ func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[strin
 func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	t.Parallel()
 
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	app := fiberfw.New()
 
 	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
@@ -120,7 +120,7 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	app := fiberfw.New()
 	app.Get("/paid/:id", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
 		return c.SendString("paid")
@@ -158,7 +158,7 @@ func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	app := fiberfw.New()
 
 	app.Post("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
@@ -193,7 +193,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	t.Parallel()
 
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	app := fiberfw.New()
 
 	app.Post("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *fiberfw.Ctx) error {
@@ -229,7 +229,7 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	t.Parallel()
 
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	app := fiberfw.New()
 
 	app.Get("/paid", ChargeMiddleware(payment, server.ChargeParams{
@@ -257,4 +257,11 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	}
 	require.NoError(t, json.NewDecoder(challengeResponse.Body).Decode(&problem))
 	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
+}
+
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+	t.Helper()
+	payment, err := server.New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
 }

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -35,7 +35,7 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	t.Parallel()
 
 	ginfw.SetMode(ginfw.TestMode)
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	router := ginfw.New()
 	router.GET("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
 		credential := Credential(c)
@@ -104,7 +104,7 @@ func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 
 	ginfw.SetMode(ginfw.TestMode)
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	router := ginfw.New()
 	router.GET("/paid/:id", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
 		c.String(http.StatusOK, "paid")
@@ -141,7 +141,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 	t.Parallel()
 
 	ginfw.SetMode(ginfw.TestMode)
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	router := ginfw.New()
 	router.POST("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
 		_, _ = io.ReadAll(c.Request.Body)
@@ -175,7 +175,7 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	t.Parallel()
 
 	ginfw.SetMode(ginfw.TestMode)
-	payment := server.New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	router := ginfw.New()
 	router.POST("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
 		body, _ := io.ReadAll(c.Request.Body)
@@ -202,4 +202,11 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, paidResponse.Code)
 	assert.Equal(t, originalBody, paidResponse.Body.String())
+}
+
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+	t.Helper()
+	payment, err := server.New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
 }

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -77,14 +77,14 @@ func TestVerifyOrChallengeUsesSplitLifecycle(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
 	request := map[string]any{"amount": "1", "currency": "0x123"}
-	credential := splitCredential("secret-key", request)
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", request)
 
 	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
 		Authorization: credential.ToAuthorization(),
 		Intent:        newSplitTestServerIntent(t, intent),
 		Request:       request,
 		Realm:         "api.example.com",
-		SecretKey:     "secret-key",
+		SecretKey:     "test-secret-key-minimum-32-byte-secret",
 		Method:        "tempo",
 		Expires:       credential.Challenge.Expires,
 	})
@@ -98,9 +98,9 @@ func TestMppCredentialLifecycle(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
 	method := chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}}
-	payment := New(method, "api.example.com", "secret-key")
+	payment := newTestServer(t, method, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	request := map[string]any{"amount": "1", "currency": "0x123"}
-	credential := splitCredential("secret-key", request)
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", request)
 
 	validation, err := payment.ValidateCredential(context.Background(), credential)
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestMppCredentialLifecycle(t *testing.T) {
 func TestNewIntentSynthesizesVerify(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
-	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", map[string]any{"amount": "1"})
 	configured := newSplitTestServerIntent(t, intent)
 
 	receipt, err := configured.Verify(
@@ -191,12 +191,12 @@ func TestNewIntentValidatesHookShape(t *testing.T) {
 
 func TestMppValidateCredentialRequiresSplitHooks(t *testing.T) {
 	t.Parallel()
-	payment := New(
+	payment := newTestServer(t,
 		chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}},
 		"api.example.com",
-		"secret-key",
+		"test-secret-key-minimum-32-byte-secret",
 	)
-	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", map[string]any{"amount": "1"})
 
 	_, err := payment.ValidateCredential(context.Background(), credential)
 	var paymentErr *mpp.PaymentError
@@ -207,12 +207,12 @@ func TestMppValidateCredentialRequiresSplitHooks(t *testing.T) {
 
 func TestMppBroadcastCredentialSupportsLegacyIntent(t *testing.T) {
 	t.Parallel()
-	payment := New(
+	payment := newTestServer(t,
 		chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}},
 		"api.example.com",
-		"secret-key",
+		"test-secret-key-minimum-32-byte-secret",
 	)
-	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", map[string]any{"amount": "1"})
 
 	receipt, err := payment.BroadcastCredential(context.Background(), credential)
 	require.NoError(t, err)
@@ -222,12 +222,12 @@ func TestMppBroadcastCredentialSupportsLegacyIntent(t *testing.T) {
 func TestMppBroadcastCredentialStopsAfterValidationFailure(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{validateErr: errors.New("invalid")}
-	payment := New(
+	payment := newTestServer(t,
 		chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}},
 		"api.example.com",
-		"secret-key",
+		"test-secret-key-minimum-32-byte-secret",
 	)
-	credential := splitCredential("secret-key", map[string]any{"amount": "1"})
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", map[string]any{"amount": "1"})
 
 	_, err := payment.BroadcastCredential(context.Background(), credential)
 	require.Error(t, err)
@@ -238,10 +238,10 @@ func TestMppBroadcastCredentialStopsAfterValidationFailure(t *testing.T) {
 func TestMppCredentialLifecycleRejectsForeignChallenge(t *testing.T) {
 	t.Parallel()
 	intent := &splitTestIntent{}
-	payment := New(
+	payment := newTestServer(t,
 		chargeTestMethod{intents: map[string]Intent{"charge": newSplitTestServerIntent(t, intent)}},
 		"api.example.com",
-		"secret-key",
+		"test-secret-key-minimum-32-byte-secret",
 	)
 	credential := splitCredential("foreign-secret", map[string]any{"amount": "1"})
 

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -42,7 +42,7 @@ func (verificationFailedIntent) Verify(_ context.Context, _ *mpp.Credential, _ m
 }
 
 func TestChargeMiddleware_EndToEnd(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, CredentialFromContext(r.Context()).Source+":"+ReceiptFromContext(r.Context()).Reference)
 	}))
@@ -119,7 +119,7 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 }
 
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, "paid")
 	}))
@@ -158,7 +158,7 @@ func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 }
 
 func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.ReadAll(r.Body)
 		_, _ = io.WriteString(w, "paid")
@@ -195,7 +195,7 @@ func TestChargeMiddlewareRejectsTamperedRequestBodyDigest(t *testing.T) {
 }
 
 func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_, _ = io.WriteString(w, string(body))
@@ -233,7 +233,7 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 }
 
 func TestChargeMiddlewareReturnsFreshChallengeOnVerificationFailure(t *testing.T) {
-	payment := New(verificationFailedMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, verificationFailedMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Fail(t, "handler should not be called")
 	}))
@@ -271,7 +271,7 @@ func TestChargeMiddlewareReturnsFreshChallengeOnVerificationFailure(t *testing.T
 }
 
 func TestChargeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handlerCalled := false
 	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handlerCalled = true
@@ -311,7 +311,7 @@ func TestChargeMiddlewareRejectsMultiplePaymentCredentials(t *testing.T) {
 }
 
 func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
-	payment := New(middlewareTestMethod{}, "api.example.com", "secret-key")
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	handler := ChargeMiddleware(payment, ChargeParams{
 		Amount:      "0.50",
 		Description: "Line one\r\nLine two",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,10 @@ type ChargeRequestBuilder interface {
 	BuildChargeRequest(params ChargeParams) (map[string]any, error)
 }
 
+// minimumSecretKeyBytes is the shortest secret key accepted for HMAC-bound
+// challenge IDs. It matches the canonical mppx reference (assertSecretKey).
+const minimumSecretKeyBytes = 32
+
 // Mpp is the server-side payment handler.
 type Mpp struct {
 	method    Method
@@ -137,13 +141,18 @@ type Mpp struct {
 	secretKey string
 }
 
-// New creates an Mpp instance.
-func New(method Method, realm, secretKey string) *Mpp {
+// New creates an Mpp instance. It returns an error when secretKey is shorter
+// than minimumSecretKeyBytes, since a weak secret yields forgeable,
+// HMAC-bound challenge IDs.
+func New(method Method, realm, secretKey string) (*Mpp, error) {
+	if len(secretKey) < minimumSecretKeyBytes {
+		return nil, fmt.Errorf("server: secret key must be at least %d bytes", minimumSecretKeyBytes)
+	}
 	return &Mpp{
 		method:    method,
 		realm:     realm,
 		secretKey: secretKey,
-	}
+	}, nil
 }
 
 // Realm returns the WWW-Authenticate realm used by this payment handler.

--- a/pkg/server/server_charge_test.go
+++ b/pkg/server/server_charge_test.go
@@ -18,7 +18,7 @@ func (m chargeTestMethod) Intents() map[string]Intent { return m.intents }
 func TestMppCharge_UsesMetaAsChallengeMeta(t *testing.T) {
 	t.Parallel()
 
-	mppServer := New(chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}, "api.example.com", "secret-key")
+	mppServer := newTestServer(t, chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	result, err := mppServer.Charge(context.Background(), ChargeParams{
 		Amount:     "0.50",
 		Currency:   "0x20c0000000000000000000000000000000000001",
@@ -71,7 +71,7 @@ func TestMppCharge_UsesMetaAsChallengeMeta(t *testing.T) {
 func TestMppCharge_RequiresChargeIntent(t *testing.T) {
 	t.Parallel()
 
-	mppServer := New(chargeTestMethod{intents: map[string]Intent{}}, "api.example.com", "secret-key")
+	mppServer := newTestServer(t, chargeTestMethod{intents: map[string]Intent{}}, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	_, err := mppServer.Charge(context.Background(), ChargeParams{Amount: "0.50"})
 	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), `does not support charge intent`),
 		"Charge() error = %v, want missing charge intent error", err) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRejectsWeakSecret(t *testing.T) {
+	t.Parallel()
+
+	method := chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}
+	for _, tc := range []struct {
+		name   string
+		secret string
+	}{
+		{"empty", ""},
+		{"thirtyOneBytes", strings.Repeat("a", 31)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(method, "api.example.com", tc.secret)
+			assert.EqualError(t, err, "server: secret key must be at least 32 bytes")
+		})
+	}
+}
+
+func TestNewAcceptsMinimumLengthSecret(t *testing.T) {
+	t.Parallel()
+
+	method := chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}
+	payment, err := New(method, "api.example.com", strings.Repeat("a", 32))
+	require.NoError(t, err)
+	require.NotNil(t, payment)
+}
+
+// newTestServer constructs an Mpp for tests and fails the test if New rejects
+// the secret. Callers must pass a secret of at least minimumSecretKeyBytes.
+func newTestServer(t *testing.T, method Method, realm, secretKey string) *Mpp {
+	t.Helper()
+	payment, err := New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
+}

--- a/pkg/tempo/server/relay_test.go
+++ b/pkg/tempo/server/relay_test.go
@@ -30,7 +30,7 @@ type relayCall struct {
 
 func relayTestCredential(payload map[string]any) *mpp.Credential {
 	challenge := mpp.NewChallenge(
-		"test-secret-key",
+		"test-secret-key-minimum-32-byte-secret",
 		"api.example.com",
 		tempo.MethodName,
 		tempo.IntentCharge,
@@ -178,7 +178,7 @@ func TestRelayIntentExposesCredentialHooks(t *testing.T) {
 		Relay:     &RelayConfig{APIKey: relayTestAPIKey, APIBaseURL: server.URL},
 	})
 	require.NoError(t, err)
-	payment := mppserver.New(method, "api.example.com", "test-secret-key")
+	payment := newTestServer(t, method, "api.example.com", "test-secret-key-minimum-32-byte-secret")
 	credential := relayTestCredential(map[string]any{"type": "transaction", "signature": "0x1234"})
 
 	validation, err := payment.ValidateCredential(context.Background(), credential)
@@ -384,4 +384,11 @@ func TestRelayMethodAllowsRelayResolvedChain(t *testing.T) {
 
 	_, err = method.BuildChargeRequest(mppserver.ChargeParams{Amount: "1"})
 	require.NoError(t, err)
+}
+
+func newTestServer(t *testing.T, method mppserver.Method, realm, secretKey string) *mppserver.Mpp {
+	t.Helper()
+	payment, err := mppserver.New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -36,7 +36,7 @@ const (
 	defaultIntegrationRPCURL = "http://localhost:8545"
 
 	integrationRealm     = "mpp-go.local"
-	integrationSecretKey = "integration-secret"
+	integrationSecretKey = "integration-secret-minimum-32-byte-secret"
 	// integrationCurrency is the fixed TIP-20 token used in the local devnet tests.
 	integrationCurrency = "0x20c0000000000000000000000000000000000000"
 	// integrationRecipient is the account that receives paid transfers during tests.
@@ -957,9 +957,9 @@ func newPaidServer(t *testing.T, rpcURL string, chainID uint64, feePayerSigner *
 		ChainID:        int64(chainID),
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
-	basic := mppserver.New(basicMethod, integrationRealm, integrationSecretKey)
-	feePayer := mppserver.New(feePayerMethod, integrationRealm, integrationSecretKey)
-	hash := mppserver.New(hashMethod, integrationRealm, integrationSecretKey)
+	basic := newTestServer(t, basicMethod, integrationRealm, integrationSecretKey)
+	feePayer := newTestServer(t, feePayerMethod, integrationRealm, integrationSecretKey)
+	hash := newTestServer(t, hashMethod, integrationRealm, integrationSecretKey)
 
 	proofMethod := chargeserver.NewMethod(chargeserver.MethodConfig{
 		Intent:    intent,
@@ -973,8 +973,8 @@ func newPaidServer(t *testing.T, rpcURL string, chainID uint64, feePayerSigner *
 		Recipient: integrationRecipient,
 		ChainID:   int64(chainID),
 	})
-	proof := mppserver.New(proofMethod, integrationRealm, integrationSecretKey)
-	splits := mppserver.New(splitsMethod, integrationRealm, integrationSecretKey)
+	proof := newTestServer(t, proofMethod, integrationRealm, integrationSecretKey)
+	splits := newTestServer(t, splitsMethod, integrationRealm, integrationSecretKey)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/paid", paidHandler(t, basic, false))
@@ -1123,4 +1123,11 @@ func writeIntegrationPaymentError(w http.ResponseWriter, err error) {
 
 	w.WriteHeader(http.StatusInternalServerError)
 	_ = json.NewEncoder(w).Encode(map[string]any{"detail": err.Error()})
+}
+
+func newTestServer(t *testing.T, method mppserver.Method, realm, secretKey string) *mppserver.Mpp {
+	t.Helper()
+	payment, err := mppserver.New(method, realm, secretKey)
+	require.NoError(t, err)
+	return payment
 }


### PR DESCRIPTION
## Problem

`server.New` stores `secretKey` verbatim with no validation (`pkg/server/server.go:141`), and it flows into the HMAC challenge binding at `server.go:286`. A short or empty secret yields forgeable, HMAC-bound challenge IDs.

The canonical mppx reference guards this in two places — `Mppx.ts:511` rejects a missing secret, and `assertSecretKey` (`Mppx.ts:941`) enforces a 32-byte minimum via `minimumSecretKeyBytes`. mpp-go had neither.

Fixes the Go side of tempoxyz/mpp-tools#109 (AGR-2026-033).

## Fix

A single `len(secretKey) < 32` guard in `New`, which subsumes the empty case and covers both canonical conditions. `len()` on a Go string counts UTF-8 bytes, matching the reference's `TextEncoder().encode(secretKey).byteLength` — not rune count.

`New` now returns `(*Mpp, error)`. This mirrors `charge.New(charge.Config{...})`, which already returns `(_, error)` in this repo, so the constructor shape stays consistent rather than introducing a new pattern.

Worth noting: the conformance suite already treats this as normative — `challenge-id.json` carries a negative vector ("Rejects HMAC secret keys shorter than 32 bytes", `"secretKey": "short"`), and the Go adapter enforces `len < 32` in `generateConformanceChallengeID`. This brings the library in line with a rule the harness already assumes.

## Scope

The signature change ripples through call sites, but only test and example code — there is no production caller of `server.New` in this repo:

- `pkg/server/*_test.go` — routed through a `newTestServer(t, ...)` helper
- `pkg/server/{echo,fiber,gin}/middleware_test.go`, `pkg/tempo/server/relay_test.go`, `tests/integration_test.go` — inline error handling
- `examples/**` — error handling added
- Every documented/test secret grown to >=32 bytes. Paired `New`/`splitCredential` literals were updated together so signing stays in sync; the deliberately-mismatched `"foreign-secret"` is left alone
- `README.md` and `AGENTS.md` updated to the new form

## Tests

`TestNewRejectsWeakSecret` (empty, 31 bytes -> error) and `TestNewAcceptsMinimumLengthSecret` (32 bytes -> ok), asserting the exact error message.

`go build ./...`, `go vet ./...`, and `go test -race ./...` pass. The integration suite compiles (`go test -tags=integration -c`); running it needs a live devnet RPC.

One pre-existing note: `go vet -tags=integration ./tests/...` reports `unreachable code` at `tests/integration_test.go:914`. I verified against an untouched checkout that this predates the change and sits outside the diff, so I left it alone.
