### PR TITLE
fix(mpp): require method and timestamp when parsing receipts

### DIFF
--- a/.changelog/require-receipt-method-timestamp.md
+++ b/.changelog/require-receipt-method-timestamp.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject payment receipts that omit the `method` or `timestamp` field when parsing. Both are required base receipt fields per draft-ietf-httpauth-payment §5.3 and the canonical mppx schema; previously an incomplete receipt parsed successfully with an empty method and zero timestamp.

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -376,6 +376,33 @@ func TestParsePaymentReceiptValidation(t *testing.T) {
 
 }
 
+// TestParsePaymentReceiptRequiresMethodAndTimestamp asserts that method and
+// timestamp are required receipt fields, matching draft-ietf-httpauth-payment
+// §5.3 and the canonical mppx Receipt schema. The wire values are the exact
+// error_missing_method and error_missing_timestamp scenarios from the shared
+// conformance suite (conformance/vectors/receipt.json), both of which require
+// parse rejection. Refs Agricola finding AGR-2026-048.
+func TestParsePaymentReceiptRequiresMethodAndTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// conformance error_missing_method: valid receipt with "method" omitted.
+	const missingMethodWire = "eyJyZWZlcmVuY2UiOiIweGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWYxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYiIsInN0YXR1cyI6InN1Y2Nlc3MiLCJ0aW1lc3RhbXAiOiIyMDI2LTAxLTI5VDEyOjAwOjMwWiJ9"
+	// conformance error_missing_timestamp: valid receipt with "timestamp" omitted.
+	const missingTimestampWire = "eyJtZXRob2QiOiJ0ZW1wbyIsInJlZmVyZW5jZSI6IjB4YWJjZGVmMTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWYxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MGFiIiwic3RhdHVzIjoic3VjY2VzcyJ9"
+
+	_, err := ParseReceipt(missingMethodWire)
+	if assert.Errorf(t, err, "ParseReceipt(missing method) error = nil, want rejection") {
+		assert.Containsf(t, err.Error(), "receipt missing method",
+			"ParseReceipt(missing method) error = %v, want missing method error", err)
+	}
+
+	_, err = ParseReceipt(missingTimestampWire)
+	if assert.Errorf(t, err, "ParseReceipt(missing timestamp) error = nil, want rejection") {
+		assert.Containsf(t, err.Error(), "receipt missing timestamp",
+			"ParseReceipt(missing timestamp) error = %v, want missing timestamp error", err)
+	}
+}
+
 func TestChallengeVerifyAndToEcho(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -490,25 +490,31 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		return nil, fmt.Errorf("mpp: invalid receipt status: %q", status)
 	}
 
-	var ts time.Time
-	if tsRaw := anyStr(data["timestamp"]); tsRaw != "" {
-		ts, err = time.Parse(time.RFC3339Nano, strings.Replace(tsRaw, "Z", "+00:00", 1))
-		if err != nil {
-			ts, err = time.Parse(time.RFC3339, tsRaw)
-			if err != nil {
-				return nil, fmt.Errorf("mpp: invalid receipt timestamp: %w", err)
-			}
-		}
-	}
-
 	reference := anyStr(data["reference"])
 	if reference == "" {
 		return nil, fmt.Errorf("mpp: receipt missing reference")
 	}
 
+	// method and timestamp are required base receipt fields per
+	// draft-ietf-httpauth-payment §5.3 and the canonical mppx Receipt schema.
 	method := anyStr(data["method"])
-	if method != "" && !isMethodName(method) {
+	if method == "" {
+		return nil, fmt.Errorf("mpp: receipt missing method")
+	}
+	if !isMethodName(method) {
 		return nil, fmt.Errorf("mpp: invalid receipt method %q", method)
+	}
+
+	tsRaw := anyStr(data["timestamp"])
+	if tsRaw == "" {
+		return nil, fmt.Errorf("mpp: receipt missing timestamp")
+	}
+	ts, err := time.Parse(time.RFC3339Nano, strings.Replace(tsRaw, "Z", "+00:00", 1))
+	if err != nil {
+		ts, err = time.Parse(time.RFC3339, tsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("mpp: invalid receipt timestamp: %w", err)
+		}
 	}
 
 	var externalID string


### PR DESCRIPTION
## Problem

`ParsePaymentReceipt` accepts a receipt that omits `method` or `timestamp`, even though the canonical reference treats both as required. A receipt missing either field parses successfully and flows on as if it were well-formed.

The conformance suite already encodes this as normative — the vector rejecting an under-specified receipt is there, and the Go adapter carries a shim to compensate for the library not enforcing it.

Fixes the Go side of tempoxyz/mpp-tools#144 (AGR-2026-048).

## Fix

Reject a receipt missing `method` or `timestamp` at parse time, in `pkg/mpp/parse.go`.

The reference check is ordered before the method/timestamp checks deliberately, so the existing "missing reference" case keeps its original error rather than being shadowed by the new ones.

Same shape as #112 (AGR-2026-033) — canonical requires rejecting an under-specified input, the conformance suite encodes it, and the library was silently accepting it. That one needed a signature change; this is contained.

## Tests

A new case in `pkg/mpp/errors_receipt_test.go` covering both omissions. Verified failing-first: before the guard, both receipts parse with `error = nil`.

`TestParsePaymentReceiptValidation` (including the missing-reference case) and `TestReceiptRoundTrip` still pass unchanged.

`go build ./...`, `go vet ./...`, and `go test -race ./...` all clean.

## Blast radius

Contained to `ParsePaymentReceipt`. Every internal emit path already sets both fields — `charge.go` in three places via `WithReceiptMethod`, and `relay.go` on the struct directly — so no round-trip breaks.

No overlap with #112's files.

## Changeset

`patch`. No public signature change, matching the bump comparable parser-tightening fixes used: #81 (preserve subscriptionId), #39 (reject missing expires), #66 (reject multiple credentials).
