### PR TITLE
fix(tempo): use the canonical idempotency key namespace in the relay

### DIFF
--- a/.changelog/relay-canonical-idempotency-namespace.md
+++ b/.changelog/relay-canonical-idempotency-namespace.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Send relay broadcast `Idempotency-Key` headers under the canonical `mpp_` namespace instead of `mppx_`. The key is otherwise byte-identical (Keccak-256 of the signed transaction, or SHA-256 of the canonical relay input), so the previous prefix prevented the relay from deduplicating equivalent canonical and Go submissions of the same transaction or credential retry. Matches `src/tempo/server/Relay.ts` in the canonical mppx implementation.

--- a/pkg/tempo/server/relay.go
+++ b/pkg/tempo/server/relay.go
@@ -255,12 +255,12 @@ func relayIdempotencyKey(credential *mpp.Credential, input []byte) string {
 	if credential.Payload["type"] == string(tempo.CredentialTypeTransaction) {
 		if signature, ok := credential.Payload["signature"].(string); ok {
 			if raw, err := hexutil.Decode(signature); err == nil {
-				return "mppx_" + crypto.Keccak256Hash(raw).Hex()
+				return "mpp_" + crypto.Keccak256Hash(raw).Hex()
 			}
 		}
 	}
 	digest := sha256.Sum256(input)
-	return "mppx_0x" + hex.EncodeToString(digest[:])
+	return "mpp_0x" + hex.EncodeToString(digest[:])
 }
 
 func parseRelayReceipt(receipt *relayReceipt) (*mpp.Receipt, error) {

--- a/pkg/tempo/server/relay_test.go
+++ b/pkg/tempo/server/relay_test.go
@@ -120,7 +120,30 @@ func TestRelayVerifyValidatesAndBroadcastsCredential(t *testing.T) {
 	assert.Equal(t, "/mpp/v1/mpp/broadcast", broadcastCall.Path)
 	raw, err := hexutil.Decode("0x1234")
 	require.NoError(t, err)
-	assert.Equal(t, "mppx_"+crypto.Keccak256Hash(raw).Hex(), broadcastCall.IdempotencyKey)
+	assert.Equal(t, "mpp_"+crypto.Keccak256Hash(raw).Hex(), broadcastCall.IdempotencyKey)
+}
+
+func TestRelayIdempotencyKeyUsesCanonicalNamespace(t *testing.T) {
+	t.Parallel()
+	// Canonical mppx namespaces relay broadcast idempotency keys with `mpp_`
+	// (src/tempo/server/Relay.ts:235,239). The key must match byte-for-byte so
+	// the relay can deduplicate equivalent canonical and Go submissions.
+	transaction := relayTestCredential(map[string]any{"type": "transaction", "signature": "0x1234"})
+	raw, err := hexutil.Decode("0x1234")
+	require.NoError(t, err)
+	txInput, err := marshalRelayInput(transaction)
+	require.NoError(t, err)
+	txKey := relayIdempotencyKey(transaction, txInput)
+	assert.Equal(t, "mpp_"+crypto.Keccak256Hash(raw).Hex(), txKey)
+	assert.NotContains(t, txKey, "mppx_")
+
+	fallback := relayTestCredential(map[string]any{"type": "hash", "hash": "0xabc"})
+	input, err := marshalRelayInput(fallback)
+	require.NoError(t, err)
+	digest := sha256.Sum256(input)
+	key := relayIdempotencyKey(fallback, input)
+	assert.Equal(t, "mpp_0x"+hex.EncodeToString(digest[:]), key)
+	assert.NotContains(t, key, "mppx_")
 }
 
 func TestRelayFinalizesPushCredential(t *testing.T) {
@@ -153,7 +176,7 @@ func TestRelayFinalizesPushCredential(t *testing.T) {
 	input, err := marshalRelayInput(credential)
 	require.NoError(t, err)
 	digest := sha256.Sum256(input)
-	assert.Equal(t, "mppx_0x"+hex.EncodeToString(digest[:]), broadcastCall.IdempotencyKey)
+	assert.Equal(t, "mpp_0x"+hex.EncodeToString(digest[:]), broadcastCall.IdempotencyKey)
 }
 
 func TestRelayIntentExposesCredentialHooks(t *testing.T) {


### PR DESCRIPTION
## Problem

The Tempo relay builds its idempotency key under a different namespace prefix than the canonical reference uses. The value is observable on the wire, so two implementations of the same protocol derive different keys for the same submission.

Fixes the Go side of tempoxyz/mpp-tools#147 (AGR-2026-051).

## Fix

Use the canonical namespace when deriving the relay idempotency key, in `pkg/tempo/server/relay.go`.

Unlike #112 and #113, there is no conformance vector covering this one — the case rests on divergence from the canonical reference rather than on a rule the harness already encodes. Worth saying plainly, since that makes it a weaker paper trail than the other two.

## Transition note

This changes the key value on the wire. A submission already in flight and deduped under an old-prefix key will, on retry after deploy, hash under the new prefix and not correlate with the pre-deploy attempt.

That's a one-time transition effect rather than an ongoing problem, and the new value is the correct end state — but it's a real consequence and worth deciding on deliberately rather than discovering later.

## Tests

`pkg/tempo/server/relay_test.go` asserts the derived key uses the canonical namespace. Verified failing-first.

`go build ./...`, `go vet ./...`, and `go test -race ./...` clean.

## Overlap with my other open PRs

- **#113** (`pkg/mpp/parse.go`, receipt parsing) — no overlap, different package
- **#112** (server secret guard) — file overlap only: it also edits `pkg/tempo/server/relay_test.go`, for unrelated server-secret assertions. It does not touch the idempotency key derivation or these assertions, so expect a trivial textual conflict in that file if both land, with no logical conflict. The changelog fragments are distinct.

All three branch from current `main` independently.

## Changeset

`patch`. No API change, matching comparable relay-side behavioural fixes — transport-redirect-guard, validate-transfer-memo-hex, fresh-challenge-on-verification-failure.
