### PR TITLE
fix(mpp): preserve method-defined receipt fields across a round trip

### DIFF
--- a/.changelog/preserve-receipt-method-extension-fields.md
+++ b/.changelog/preserve-receipt-method-extension-fields.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Preserve method-defined top-level extension fields (such as `originTxHash`) when parsing and formatting payment receipts. draft-ietf-httpauth-payment §5.3 allows payment methods to define additional receipt fields, and the canonical mppx schema keeps them across a parse/format round trip; previously any top-level field outside the base set was silently dropped. Such fields are now retained on the new `Receipt.Extensions` map and re-emitted at the top level.

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -403,6 +403,60 @@ func TestParsePaymentReceiptRequiresMethodAndTimestamp(t *testing.T) {
 	}
 }
 
+// TestParsePaymentReceiptPreservesMethodExtensionFields asserts that a
+// method-defined top-level receipt field survives a parse -> format round trip.
+// draft-ietf-httpauth-payment §5.3 states "Payment method specifications MAY
+// define additional fields for receipts", and the canonical mppx schema keeps
+// unknown fields rather than dropping them. originTxHash is the extension named
+// in the issue's suggested test. Refs Agricola finding AGR-2026-047.
+func TestParsePaymentReceiptPreservesMethodExtensionFields(t *testing.T) {
+	t.Parallel()
+
+	wire := b64EncodeAny(map[string]any{
+		"status":       "success",
+		"method":       "tempo",
+		"timestamp":    "2026-01-01T00:00:00Z",
+		"reference":    "ref-123",
+		"originTxHash": "0xdeadbeef",
+	})
+
+	parsed, err := ParseReceipt(wire)
+	if !assert.NoErrorf(t, err, "ParseReceipt() error = %v", err) {
+		return
+	}
+	// The extension is accessible on the parsed receipt so consumers can inspect it.
+	if !assert.Equalf(t, "0xdeadbeef", parsed.Extensions["originTxHash"],
+		"parsed.Extensions[originTxHash] = %#v, want 0xdeadbeef", parsed.Extensions["originTxHash"]) {
+		return
+	}
+	// A known base field must never leak into Extensions.
+	if !assert.NotContainsf(t, parsed.Extensions, "reference",
+		"parsed.Extensions must not contain base field reference") {
+		return
+	}
+
+	// The extension is re-emitted at the top level of the wire (not nested
+	// under "extra"), matching the canonical shape.
+	decoded, err := B64Decode(FormatReceipt(parsed))
+	if !assert.NoErrorf(t, err, "B64Decode(FormatReceipt(parsed)) error = %v", err) {
+		return
+	}
+	if !assert.Equalf(t, "0xdeadbeef", decoded["originTxHash"],
+		"formatted receipt originTxHash = %#v, want top-level 0xdeadbeef", decoded["originTxHash"]) {
+		return
+	}
+
+	// And it survives a full parse -> format -> parse round trip unchanged.
+	roundtripped, err := ParseReceipt(FormatReceipt(parsed))
+	if !assert.NoErrorf(t, err, "ParseReceipt(FormatReceipt(parsed)) error = %v", err) {
+		return
+	}
+	if !assert.Equalf(t, "0xdeadbeef", roundtripped.Extensions["originTxHash"],
+		"roundtripped.Extensions[originTxHash] = %#v, want 0xdeadbeef", roundtripped.Extensions["originTxHash"]) {
+		return
+	}
+}
+
 func TestChallengeVerifyAndToEcho(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -563,6 +563,21 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		}
 	}
 
+	// Preserve method-defined top-level extension fields. Payment method
+	// specifications MAY define additional receipt fields (draft-ietf-httpauth-payment
+	// §5.3); the canonical mppx schema keeps them across a parse/format round trip
+	// rather than dropping them. Everything outside the known base keys is retained.
+	var extensions map[string]any
+	for k, v := range data {
+		if _, known := receiptBaseFields[k]; known {
+			continue
+		}
+		if extensions == nil {
+			extensions = make(map[string]any)
+		}
+		extensions[k] = v
+	}
+
 	return &Receipt{
 		Status:         status,
 		Timestamp:      ts,
@@ -571,7 +586,21 @@ func ParsePaymentReceipt(header string) (*Receipt, error) {
 		ExternalID:     externalID,
 		SubscriptionID: subscriptionID,
 		Extra:          extra,
+		Extensions:     extensions,
 	}, nil
+}
+
+// receiptBaseFields is the set of top-level Payment-Receipt keys the parser
+// maps onto named Receipt fields. Any other top-level key is a method-defined
+// extension and is preserved via Receipt.Extensions.
+var receiptBaseFields = map[string]struct{}{
+	"status":         {},
+	"timestamp":      {},
+	"reference":      {},
+	"method":         {},
+	"externalId":     {},
+	"subscriptionId": {},
+	"extra":          {},
 }
 
 // FormatPaymentReceipt formats a Receipt as a Payment-Receipt header value.
@@ -594,6 +623,15 @@ func FormatPaymentReceipt(r *Receipt) string {
 	}
 	if len(r.Extra) > 0 {
 		data["extra"] = r.Extra
+	}
+	// Re-emit method-defined extension fields at the top level, matching the
+	// canonical wire shape. Base fields always win, so reserved keys are never
+	// overwritten by an Extensions entry.
+	for k, v := range r.Extensions {
+		if _, reserved := receiptBaseFields[k]; reserved {
+			continue
+		}
+		data[k] = v
 	}
 	return b64EncodeAny(data)
 }

--- a/pkg/mpp/receipt.go
+++ b/pkg/mpp/receipt.go
@@ -12,6 +12,16 @@ type Receipt struct {
 	ExternalID     string         `json:"externalId,omitempty"`
 	SubscriptionID string         `json:"subscriptionId,omitempty"`
 	Extra          map[string]any `json:"extra,omitempty"`
+
+	// Extensions holds method-defined top-level receipt fields beyond the
+	// base set. draft-ietf-httpauth-payment §5.3 states "Payment method
+	// specifications MAY define additional fields for receipts", and the
+	// canonical mppx schema preserves such unknown fields across
+	// parse/serialize round trips rather than discarding them. These are
+	// flattened to the top level of the Payment-Receipt JSON (not nested
+	// under "extra"). The tag is "-" because serialization is handled
+	// explicitly by FormatPaymentReceipt, not via struct marshaling.
+	Extensions map[string]any `json:"-"`
 }
 
 // ReceiptOption configures optional fields when creating a Receipt.


### PR DESCRIPTION
## Problem

Method-defined top-level fields on a `Payment-Receipt` — `originTxHash` and the like — are silently dropped on a parse → format round trip. Only the base field set survives; anything else disappears.

Fixes the Go side of tempoxyz/mpp-tools#143 (AGR-2026-047).

## Why these fields should survive

draft-ietf-httpauth-payment §5.3 states that payment method specifications MAY define additional fields for receipts. The canonical mppx implementation honours that by parsing receipts with `z.looseObject` (`src/Receipt.ts:38`), so unrecognised top-level fields pass through untouched.

mpp-go kept only a nested `extra` object, so a method-defined field at the top level had nowhere to go.

## Fix

- New `Receipt.Extensions map[string]any` for unrecognised top-level fields
- `ParsePaymentReceipt` captures every non-base key
- `FormatPaymentReceipt` re-emits them at the top level, with base fields always winning on collision

Additive: a new exported field, no change to how existing fields behave. Hence `minor` rather than `patch` — the bump reflects the API addition, not a behaviour break.

## Tests

Round-trip regression test from the issue's suggestion: parse a receipt carrying `originTxHash`, format it, assert the field is still present. Verified failing-first — before the change the field is gone after formatting.

`go build ./...`, `go vet ./...`, `go test -race ./...` all clean.

## A gap worth flagging separately

This isn't backed by a failing conformance vector. `receipt.json` is scoped to §5.3 but has no extension-preservation scenario, which is exactly why Go reads "Conformance: Complete" despite dropping the fields.

So the argument here rests on the spec text and the canonical implementation rather than on a red vector. The missing vector looks like a real gap in the shared suite — happy to open that separately against mpp-tools if it'd be useful.
