### PR TITLE
fix(mpp): stop BodyDigest panicking on JSON-marshallable body types

### DIFF
--- a/pkg/mpp/digest.go
+++ b/pkg/mpp/digest.go
@@ -36,13 +36,23 @@ func toBytes(body any) []byte {
 		return v
 	case string:
 		return []byte(v)
-	case map[string]any:
+	case json.RawMessage:
+		return v
+	default:
+		// Any other value that came out of ordinary JSON decoding — a
+		// map, a slice, a typed struct, a scalar — is JSON-marshallable.
+		// Route it through the same canonical JSON path used for
+		// map[string]any rather than rejecting it outright; this is
+		// what BodyDigest's `body any` signature already promises.
 		b, err := json.Marshal(v)
 		if err != nil {
-			panic(fmt.Sprintf("mpp: failed to marshal body: %v", err))
+			// Only genuinely non-JSON-serializable Go values reach
+			// here (chan, func, unsupported cyclic structures) —
+			// values no ordinary decoded HTTP body can produce. This
+			// remains a programmer error, not an operational input a
+			// server should ever receive from request handling.
+			panic(fmt.Sprintf("mpp: unsupported body type %T: %v", body, err))
 		}
 		return b
-	default:
-		panic(fmt.Sprintf("mpp: unsupported body type %T", body))
 	}
 }

--- a/pkg/mpp/digest_test.go
+++ b/pkg/mpp/digest_test.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -78,4 +79,54 @@ func TestBodyDigest_Prefix(t *testing.T) {
 	assert.Falsef(t, len(digest) < 8 || digest[:8] != "sha-256=",
 		"digest should start with 'sha-256=', got %q", digest)
 
+}
+
+// Reproduces #95: JSON-compatible body types outside the old narrow
+// allow-list ([]byte, string, map[string]any) must not panic.
+
+func TestBodyDigest_Compute_Slice(t *testing.T) {
+	assert.NotPanics(t, func() {
+		digest := BodyDigest.Compute([]int{1, 2, 3})
+		assert.Equal(t, "sha-256="+shaB64(t, "[1,2,3]"), digest)
+	})
+}
+
+func TestBodyDigest_Compute_Struct(t *testing.T) {
+	type payload struct {
+		Amount int    `json:"amount"`
+		Symbol string `json:"symbol"`
+	}
+	assert.NotPanics(t, func() {
+		digest := BodyDigest.Compute(payload{Amount: 5, Symbol: "USDC"})
+		assert.Equal(t, "sha-256="+shaB64(t, `{"amount":5,"symbol":"USDC"}`), digest)
+	})
+}
+
+func TestBodyDigest_Compute_RawMessage(t *testing.T) {
+	raw := json.RawMessage(`{"items":[1,2,3]}`)
+	assert.NotPanics(t, func() {
+		digest := BodyDigest.Compute(raw)
+		assert.Equal(t, "sha-256="+shaB64(t, `{"items":[1,2,3]}`), digest)
+	})
+}
+
+func TestBodyDigest_Compute_Int(t *testing.T) {
+	assert.NotPanics(t, func() {
+		digest := BodyDigest.Compute(42)
+		assert.Equal(t, "sha-256="+shaB64(t, "42"), digest)
+	})
+}
+
+func TestBodyDigest_Compute_UnsupportedStillPanics(t *testing.T) {
+	// A genuinely non-JSON-serializable Go value should still panic —
+	// this isn't something ordinary request-body decoding can produce.
+	assert.Panics(t, func() {
+		BodyDigest.Compute(make(chan int))
+	})
+}
+
+func shaB64(t *testing.T, s string) string {
+	t.Helper()
+	digest := BodyDigest.Compute(s)
+	return digest[len("sha-256="):]
 }


### PR DESCRIPTION
## What

`toBytes` in `pkg/mpp/digest.go` only recognized `[]byte`, `string`, and the exact type `map[string]any`. Every other value — a decoded slice, a typed struct, `json.RawMessage`, a bare scalar — fell into the `default` case and panicked. `server.VerifyOrChallenge` calls `BodyDigest.Compute` on whatever the application passes as the request body, so a handler that decoded JSON into anything other than `map[string]any` could crash the process while setting up a payment challenge.

Reproduces on main:
```go
mpp.BodyDigest.Compute([]int{1, 2, 3})              // panics
mpp.BodyDigest.Compute(json.RawMessage(`{"items":[1,2,3]}`)) // panics
```

## Fix

`BodyDigest`'s exported signature (`body any`) already promises to accept arbitrary bodies, so this routes the `default` case through `json.Marshal` instead of rejecting it — the same path `map[string]any` already used. Added an explicit `json.RawMessage` case so raw pre-encoded JSON round-trips without a redundant marshal.

The remaining panic path is narrowed to genuinely non-JSON-serializable Go values (`chan`, `func`, unsupported cyclic structures) — values no ordinary request-body decoding can produce, so it stays a programmer-error signal rather than something reachable from request handling.

**No exported signature change** — `BodyDigest.Compute`/`Verify` keep the same `func(body any) string` / `func(digest string, body any) bool` shape, so this doesn't affect existing callers. This answers the issue's option 1 (accept JSON-marshallable values through the existing digest path) without the breaking API change option 2 would need.

## Testing

Added regression coverage in `digest_test.go` for slice, struct, `json.RawMessage`, and bare `int` bodies (all previously panicking), plus a test confirming a truly unsupported type (`chan`) still panics as expected.

```
go test ./pkg/mpp/... -run TestBodyDigest -v
```
All pass, including the pre-existing map/string/bytes cases (no regression). Also ran the full `./pkg/mpp/...` suite and `go vet ./pkg/mpp/...` clean.

Note: the module's `go.mod` currently requires Go >= 1.26, which wasn't available in my build environment (newest apt package was 1.23), so I temporarily lowered the local `go` directive plus a `gopkg.in/yaml.v3` replace to fetch test-only deps, verified everything, then reverted both before this commit — neither shows up in the diff. Happy to re-verify against 1.26 if there's a way to point me at it, or if CI just confirms directly.

Fixes #95