### PR TITLE
fix: reject a bare "." amount instead of parsing it as zero

### DIFF
--- a/.changelog/reject-bare-decimal-amount.md
+++ b/.changelog/reject-bare-decimal-amount.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject a bare `"."` amount instead of parsing it as zero. `ParseUnits(".", d)` returned `0` and `NormalizeChargeRequest` normalized `Amount: "."` to `"0"`, turning a charge into a zero-amount one that a proof credential satisfies without any transfer.

--- a/pkg/mpp/units.go
+++ b/pkg/mpp/units.go
@@ -37,6 +37,13 @@ func ParseUnits(value string, decimals int) (int64, error) {
 		fracPart = value[dot+1:]
 	}
 
+	// A bare "." carries no digits on either side of the separator. Without
+	// this guard both parts pass the digit checks below and the value parses
+	// as 0 instead of being rejected.
+	if intPart == "" && fracPart == "" {
+		return 0, fmt.Errorf("mpp: invalid decimal value: %q", value)
+	}
+
 	if intPart == "" {
 		intPart = "0"
 	}

--- a/pkg/mpp/units_test.go
+++ b/pkg/mpp/units_test.go
@@ -27,6 +27,7 @@ func TestParseUnits(t *testing.T) {
 		{"negative", "-1", 6, 0, true},
 		{"negative decimals", "1", -1, 0, true},
 		{"invalid", "abc", 6, 0, true},
+		{"bare separator", ".", 6, 0, true},
 		{"fractional base units", "1.0000005", 6, 0, true},
 		{"too many decimals", "0.0000001", 6, 0, true},
 		{"negative decimals", "1.5", -1, 0, true},

--- a/pkg/tempo/helpers_test.go
+++ b/pkg/tempo/helpers_test.go
@@ -116,6 +116,24 @@ func TestNormalizeChargeRequest_RejectsNegativeDecimals(t *testing.T) {
 
 }
 
+func TestNormalizeChargeRequest_RejectsBareDecimalSeparator(t *testing.T) {
+	t.Parallel()
+
+	// "." has no digits on either side of the separator. It used to normalize
+	// to "0", which downgrades the charge to a zero-amount one.
+	_, err := NormalizeChargeRequest(ChargeRequestParams{
+		Amount:    ".",
+		Currency:  "0x20c0000000000000000000000000000000000001",
+		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		Decimals:  6,
+	})
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), `invalid amount "."`),
+		"NormalizeChargeRequest() error = %v, want invalid amount error", err) {
+		return
+	}
+
+}
+
 func TestNormalizeChargeRequest_RejectsInvalidSplits(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tempo/request.go
+++ b/pkg/tempo/request.go
@@ -363,6 +363,12 @@ func parseUnitsString(value string, decimals int) (string, error) {
 		intPart = value[:dot]
 		fracPart = value[dot+1:]
 	}
+	// A bare "." carries no digits on either side of the separator. Without
+	// this guard it normalizes to "0", which silently turns a charge into a
+	// zero-amount one that a proof credential can satisfy for free.
+	if intPart == "" && fracPart == "" {
+		return "", fmt.Errorf("tempo: invalid amount %q", value)
+	}
 	if intPart == "" {
 		intPart = "0"
 	}


### PR DESCRIPTION
## Problem

`ParseUnits` (`pkg/mpp/units.go`) and `parseUnitsString` (`pkg/tempo/request.go`) split an amount on the first `.` and then substitute `"0"` for an empty integer part. A bare `"."` leaves **both** the integer and the fractional part empty, so it slips past the digit validation and parses as zero instead of being rejected:

```go
mpp.ParseUnits(".", 6)   // => (0, <nil>)   — want an error
```

For the Tempo method this is more than a lax parser. `NormalizeChargeRequest` uses the same helper, so a `"."` price normalizes to a zero-amount charge:

```go
tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
    Amount:    ".",
    Currency:  "0x20c0000000000000000000000000000000000001",
    Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
    Decimals:  6,
})
// => ChargeRequest{Amount: "0", ...}, <nil>
```

`amount: "0"` is exactly the string the charge verifier gates its zero-amount paths on — `verifyProof` in `pkg/tempo/server/charge.go` rejects anything where `request.Amount != "0"`, and `ChargeRequest.Allows` admits proof credentials unconditionally. The issued challenge is therefore satisfiable by a proof signature with no transfer at all.

So a typo in a configured price silently downgrades a paid route to a free one, instead of failing when the challenge is built. It needs a server-side misconfiguration to trigger — it is not client-controlled — but the failure mode is silent and points the wrong way.

The other SDKs already reject this input:

- `mpp-rs` — `parse_dollar_amount(".", _)` returns `AmountError::InvalidFormat` (both parts empty).
- `pympp` — `parse_units(".")` raises `ValueError`, since `Decimal(".")` is an `InvalidOperation`.

## Fix

Reject values that carry no digits on either side of the separator, in both helpers.

`".5"`, `"1."`, `"0."` and every existing case keep working — only a value with no digits at all changes behaviour. Split amounts were already covered, since `validateCanonicalSplits` rejects non-positive entries; only the primary amount was affected.

## Tests

- `pkg/mpp/units_test.go` — `"."` added to the error table.
- `pkg/tempo/helpers_test.go` — `TestNormalizeChargeRequest_RejectsBareDecimalSeparator`.

Both fail on `main` and pass with the change. `go vet`, `gofmt`, `go test -race ./...` and the integration job are green.
