### PR TITLE
fix(client): retry across multiple 402 challenges up to a default limit

### DIFF
--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -36,74 +36,94 @@ func NewTransport(methods []Method, inner http.RoundTripper) *Transport {
 	}
 }
 
+// defaultMaxPaymentRetries matches mppx's defaultMaxPaymentRetries: a server
+// may respond to a submitted credential with a *fresh* 402 challenge (an
+// expired challenge racing a slow client, a rejected credential offering a
+// new one, etc.) rather than success or a final failure. Retrying up to this
+// many times lets the client recover from that instead of giving up after a
+// single credential.
+const defaultMaxPaymentRetries = 3
+
 // RoundTrip implements http.RoundTripper with automatic 402 handling.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.inner.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != http.StatusPaymentRequired {
-		return resp, nil
-	}
 
-	// Parse all WWW-Authenticate headers looking for Payment challenges (RFC 9110).
-	challenges, errs := t.parseChallenges(resp.Header)
-	_ = errs // Non-Payment or malformed headers are silently skipped.
+	for attempt := 0; attempt < defaultMaxPaymentRetries; attempt++ {
+		if resp.StatusCode != http.StatusPaymentRequired {
+			return resp, nil
+		}
 
-	// Find first challenge with a matching method that hasn't expired.
-	var matched *mpp.Challenge
-	var method Method
-	now := time.Now().UTC()
-	for i := range challenges {
-		ch := &challenges[i]
-		if ch.Expires != "" {
-			expiry, err := parseChallengeExpiry(ch.Expires)
-			if err != nil {
-				// Unparseable expiry: the issuing server rejects such a
-				// credential (server.VerifyOrChallenge returns "invalid expires
-				// format"), so don't waste a payment on a challenge it would
-				// refuse. Skip it.
-				continue
+		// Parse all WWW-Authenticate headers looking for Payment challenges (RFC 9110).
+		challenges, errs := t.parseChallenges(resp.Header)
+		_ = errs // Non-Payment or malformed headers are silently skipped.
+
+		// Find first challenge with a matching method that hasn't expired.
+		var matched *mpp.Challenge
+		var method Method
+		now := time.Now().UTC()
+		for i := range challenges {
+			ch := &challenges[i]
+			if ch.Expires != "" {
+				expiry, err := parseChallengeExpiry(ch.Expires)
+				if err != nil {
+					// Unparseable expiry: the issuing server rejects such a
+					// credential (server.VerifyOrChallenge returns "invalid expires
+					// format"), so don't waste a payment on a challenge it would
+					// refuse. Skip it.
+					continue
+				}
+				if expiry.Before(now) {
+					continue
+				}
 			}
-			if expiry.Before(now) {
-				continue
+			if m, ok := t.methods[ch.Method]; ok {
+				matched = ch
+				method = m
+				break
 			}
 		}
-		if m, ok := t.methods[ch.Method]; ok {
-			matched = ch
-			method = m
-			break
-		}
-	}
 
-	if matched == nil {
-		// No matching method found — return original 402 response as-is.
-		return resp, nil
-	}
-	if err := validatePaymentOrigin(req, matched); err != nil {
+		if matched == nil {
+			// No matching method found — return this 402 response as-is.
+			return resp, nil
+		}
+		if err := validatePaymentOrigin(req, matched); err != nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			return nil, err
+		}
+
+		// Drain and close the 402 response body so the connection can be reused.
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
-		return nil, err
+
+		// Create payment credential.
+		cred, err := method.CreateCredential(req.Context(), matched)
+		if err != nil {
+			return nil, fmt.Errorf("mpp: creating credential for method %q: %w", matched.Method, err)
+		}
+
+		// Clone the original request for retry. Always cloned from the original
+		// req (not the previous retry) so a request body backed by GetBody is
+		// re-read fresh each attempt rather than chaining clones of clones.
+		retry, err := t.cloneRequest(req)
+		if err != nil {
+			return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
+		}
+		retry.Header.Set("Authorization", cred.ToAuthorization())
+
+		resp, err = t.inner.RoundTrip(retry)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Drain and close the 402 response body so the connection can be reused.
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	// Create payment credential.
-	cred, err := method.CreateCredential(req.Context(), matched)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", matched.Method, err)
-	}
-
-	// Clone the original request for retry.
-	retry, err := t.cloneRequest(req)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
-	}
-	retry.Header.Set("Authorization", cred.ToAuthorization())
-
-	return t.inner.RoundTrip(retry)
+	// Exhausted retries — return whatever the last attempt produced (still a
+	// 402 at this point, since a non-402 response returns immediately above).
+	return resp, nil
 }
 
 // parseChallengeExpiry parses a challenge expiry using RFC 3339 and the

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -126,6 +126,107 @@ func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
 
 }
 
+// Regression test for AGR-2026-052 / tempoxyz/mpp-tools#148: a server that
+// rejects the first credential with a *fresh* 402 challenge (rather than
+// succeeding or failing outright) must still be recoverable — the client
+// should retry up to defaultMaxPaymentRetries times, not give up after one.
+func TestTransport_RoundTrip_RetriesAcrossMultiple402s(t *testing.T) {
+	callCount := 0
+	var challengeA, challengeB *mpp.Challenge
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch callCount {
+		case 1:
+			// First request: no credential yet, issue challenge A.
+			w.Header().Set("WWW-Authenticate", challengeA.ToAuthenticate(challengeA.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			w.Write([]byte("pay me (A)"))
+		case 2:
+			// Second request: credential for A submitted, but the server
+			// rejects it and issues a *different* fresh challenge B instead
+			// of failing outright (e.g. the A credential expired mid-flight).
+			assert.Truef(t, strings.HasPrefix(r.Header.Get("Authorization"), "Payment "),
+				"expected a Payment credential on attempt 2, got %q", r.Header.Get("Authorization"))
+			w.Header().Set("WWW-Authenticate", challengeB.ToAuthenticate(challengeB.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			w.Write([]byte("pay me (B)"))
+		default:
+			// Third request: credential for B submitted, accept it.
+			assert.Truef(t, strings.HasPrefix(r.Header.Get("Authorization"), "Payment "),
+				"expected a Payment credential on attempt 3, got %q", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("paid"))
+		}
+	}))
+	defer srv.Close()
+	challengeA = challengeForURL(t, srv.URL, "tempo", nil)
+	challengeB = challengeForURL(t, srv.URL, "tempo", nil)
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !assert.Equalf(t, "paid", string(body),
+		"expected body 'paid', got %q", string(body)) {
+		return
+	}
+	if !assert.EqualValuesf(t, 3, callCount,
+		"expected 3 calls to server (initial + 2 retries), got %d", callCount) {
+		return
+	}
+	if !assert.EqualValuesf(t, 2, method.calls,
+		"expected CreateCredential to be called twice (once per challenge), got %d", method.calls) {
+		return
+	}
+}
+
+// A server that keeps issuing fresh 402 challenges past the retry budget
+// must not loop forever — the client gives up and returns the last 402.
+func TestTransport_RoundTrip_GivesUpAfterMaxRetries(t *testing.T) {
+	callCount := 0
+	challenge := mpp.NewChallenge("secret", "127.0.0.1", "tempo", "payment", nil)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("127.0.0.1"))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("pay me"))
+	}))
+	defer srv.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected final response to still be 402, got %d", resp.StatusCode) {
+		return
+	}
+	// 1 initial request + defaultMaxPaymentRetries (3) retries = 4 total calls.
+	if !assert.EqualValuesf(t, 1+defaultMaxPaymentRetries, callCount,
+		"expected %d calls to server, got %d", 1+defaultMaxPaymentRetries, callCount) {
+		return
+	}
+}
+
 func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {
 	challenge := mpp.NewChallenge("secret", "realm", "stripe", "payment", nil)
 


### PR DESCRIPTION
## What

`Transport.RoundTrip` handled exactly one 402 response: it created a credential, retried once, and returned that retry's response directly regardless of what it was. Canonical mppx (`src/client/internal/Fetch.ts`) loops up to `maxPaymentRetries` (default 3) successive actionable challenges, since a server can legitimately respond to a submitted credential with a **fresh** 402 — a different challenge, not success or a final failure (e.g. the original challenge expired mid-flight, or the credential was rejected but the server is willing to reissue). Against such a server, the Go transport recovered from zero of those retries and returned the second 402 to the caller unpaid, even though canonical mppx would have paid successfully.

Flagged by the cross-SDK audit as [AGR-2026-052](https://github.com/tempoxyz/mpp-tools/issues/148).

## Fix

Wraps the existing single-attempt logic in a loop bounded by a new `defaultMaxPaymentRetries = 3` constant (matching mppx's default). Each iteration re-parses `WWW-Authenticate` challenges from the latest response, so a fresh challenge on retry N is picked up on iteration N. The retry request is always cloned from the *original* `req` (not the previous retry), so a `GetBody`-backed request body is re-read fresh each attempt instead of chaining clones of clones.

Behavior for a single 402 (the common case) is unchanged. A server that never accepts still gets bounded by the retry limit rather than looping forever, and a non-actionable 402 (no matching method) still returns immediately as before.

## Testing

- `TestTransport_RoundTrip_RetriesAcrossMultiple402s`: a server that rejects the first credential with a second, different challenge succeeds on the third request, and `CreateCredential` is called once per distinct challenge.
- `TestTransport_RoundTrip_GivesUpAfterMaxRetries`: a server that always returns 402 is called exactly `1+defaultMaxPaymentRetries` times, then the transport returns that last 402 rather than looping forever.

Ran `go test ./pkg/client/... -v` and `go vet ./pkg/client/...` locally — all pass, including the full existing suite (no regressions). Unlike the mpp-java PRs I opened today, `pkg/client` only depends on stdlib + `pkg/mpp`, so I could actually compile and run this one end-to-end.

Fixes tempoxyz/mpp-tools#148