### PR TITLE
fix(mpp): reject empty required auth-params when formatting challenges

### DIFF
--- a/.changelog/reject-empty-required-auth-params.md
+++ b/.changelog/reject-empty-required-auth-params.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject empty required auth-params (`id`, `realm`, `method`, `intent`, `request`) in `FormatAuthenticateStrict`; an empty value was previously omitted from the header, producing a `WWW-Authenticate` challenge that `ParseChallenge` itself rejects. The lenient `FormatAuthenticate` path is unchanged.

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -257,19 +257,24 @@ func FormatAuthenticate(c *Challenge, realm string) string {
 	return header
 }
 
-// FormatAuthenticateStrict formats a Challenge as an authentication header value
-// and rejects values that cannot be safely represented in quoted auth-params.
+// FormatAuthenticateStrict formats a Challenge as an authentication header value.
+// It rejects values that cannot be safely represented in quoted auth-params, and
+// empty required auth-params (id, realm, method, intent, request), which would
+// otherwise be omitted and yield a challenge ParseChallenge rejects.
 func FormatAuthenticateStrict(c *Challenge, realm string) (string, error) {
 	return formatAuthenticate(c, realm, true)
 }
 
-func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, error) {
+func formatAuthenticate(c *Challenge, realm string, strict bool) (string, error) {
 	var parts []string
-	add := func(k, v string) error {
+	add := func(k, v string, required bool) error {
 		if v == "" {
+			if strict && required {
+				return fmt.Errorf("mpp: missing required %s auth-param", k)
+			}
 			return nil
 		}
-		if rejectCRLF && strings.ContainsAny(v, "\r\n") {
+		if strict && strings.ContainsAny(v, "\r\n") {
 			return fmt.Errorf("mpp: invalid %s auth-param: contains CR or LF", k)
 		}
 		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, escapeQuoted(v)))
@@ -277,15 +282,16 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 	}
 
 	for _, param := range []struct {
-		key   string
-		value string
+		key      string
+		value    string
+		required bool
 	}{
-		{key: "id", value: c.ID},
-		{key: "realm", value: realm},
-		{key: "method", value: c.Method},
-		{key: "intent", value: c.Intent},
+		{key: "id", value: c.ID, required: true},
+		{key: "realm", value: realm, required: true},
+		{key: "method", value: c.Method, required: true},
+		{key: "intent", value: c.Intent, required: true},
 	} {
-		if err := add(param.key, param.value); err != nil {
+		if err := add(param.key, param.value, param.required); err != nil {
 			return "", err
 		}
 	}
@@ -295,21 +301,22 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 		reqB64 = b64EncodeRequest(c.Request)
 	}
 	for _, param := range []struct {
-		key   string
-		value string
+		key      string
+		value    string
+		required bool
 	}{
-		{key: "request", value: reqB64},
+		{key: "request", value: reqB64, required: true},
 		{key: "digest", value: c.Digest},
 		{key: "expires", value: c.Expires},
 		{key: "description", value: c.Description},
 	} {
-		if err := add(param.key, param.value); err != nil {
+		if err := add(param.key, param.value, param.required); err != nil {
 			return "", err
 		}
 	}
 
 	if c.Opaque != nil {
-		if err := add("opaque", b64EncodeSortedStringMap(c.Opaque)); err != nil {
+		if err := add("opaque", b64EncodeSortedStringMap(c.Opaque), false); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -258,6 +258,140 @@ func TestFormatAuthenticateStrictRejectsCRLF(t *testing.T) {
 	}
 }
 
+func TestFormatAuthenticateStrictRejectsEmptyRequiredAuthParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*Challenge)
+		wantErr string
+	}{
+		{
+			name:    "empty id",
+			mutate:  func(c *Challenge) { c.ID = "" },
+			wantErr: "mpp: missing required id auth-param",
+		},
+		{
+			name:    "empty realm",
+			wantErr: "mpp: missing required realm auth-param",
+		},
+		{
+			name:    "empty method",
+			mutate:  func(c *Challenge) { c.Method = "" },
+			wantErr: "mpp: missing required method auth-param",
+		},
+		{
+			name:    "empty intent",
+			mutate:  func(c *Challenge) { c.Intent = "" },
+			wantErr: "mpp: missing required intent auth-param",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			challenge := NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{"amount": "100"})
+			realm := "api.example.com"
+			if tt.mutate != nil {
+				tt.mutate(challenge)
+			} else {
+				realm = ""
+			}
+
+			got, err := challenge.ToAuthenticateStrict(realm)
+			require.Error(t, err, "ToAuthenticateStrict() = %q", got)
+			assert.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestFormatAuthenticateAlwaysEncodesRequest(t *testing.T) {
+	t.Parallel()
+
+	// request is a required auth-param, but it can never be empty: an absent
+	// request object encodes to the empty JSON object. Assert that invariant so
+	// the required-field guard on "request" cannot be reached by accident.
+	challenge := &Challenge{ID: "ch_1", Method: "tempo", Intent: "charge"}
+
+	got, err := challenge.ToAuthenticateStrict("api.example.com")
+	require.NoError(t, err)
+	assert.Contains(t, got, `request="e30"`)
+}
+
+func TestFormatAuthenticateStrictDropsEmptyOptionalAuthParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Challenge)
+		absent string
+	}{
+		{
+			name:   "empty digest",
+			mutate: func(c *Challenge) { c.Digest = "" },
+			absent: "digest=",
+		},
+		{
+			name:   "empty expires",
+			mutate: func(c *Challenge) { c.Expires = "" },
+			absent: "expires=",
+		},
+		{
+			name:   "empty description",
+			mutate: func(c *Challenge) { c.Description = "" },
+			absent: "description=",
+		},
+		{
+			name:   "nil opaque",
+			mutate: func(c *Challenge) { c.Opaque = nil },
+			absent: "opaque=",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			challenge := NewChallenge("secret", "api.example.com", "tempo", "charge",
+				map[string]any{"amount": "100"},
+				WithDigest("sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="),
+				WithExpires("2026-01-29T12:05:00Z"),
+				WithDescription("API access payment required"),
+				WithMeta(map[string]string{"trace": "123"}),
+			)
+			tt.mutate(challenge)
+
+			got, err := challenge.ToAuthenticateStrict("api.example.com")
+			require.NoError(t, err)
+			assert.NotContains(t, got, tt.absent)
+
+			// The remaining challenge is still complete and parseable.
+			parsed, err := ParseChallenge(got)
+			require.NoError(t, err)
+			assert.Equal(t, challenge.ID, parsed.ID)
+		})
+	}
+}
+
+func TestFormatAuthenticateLenientKeepsDroppingEmptyAuthParams(t *testing.T) {
+	t.Parallel()
+
+	// The lenient formatter returns only a string, so callers cannot observe an
+	// error. Its behavior must stay unchanged: empty auth-params are dropped.
+	challenge := NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{"amount": "100"})
+	challenge.ID = ""
+
+	got := challenge.ToAuthenticate("")
+
+	assert.Equal(t, `Payment method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAifQ"`, got)
+	assert.NotContains(t, got, "id=")
+	assert.NotContains(t, got, "realm=")
+}
+
 func TestFormatAuthenticateStripsCRLF(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`formatAuthenticate` omits any auth-param whose value is empty. That includes the required `id`, `realm`, `method` and `intent` fields, so `FormatAuthenticateStrict` returns no error while emitting a `WWW-Authenticate` value that this SDK's own `ParseChallenge` rejects with `missing required challenge fields`.

The conformance suite already expects this to fail:

    // mpp-tools conformance/vectors/www-authenticate.json
    "name": "error_empty_id_format",
    "object": { "id": "", ... },
    "tests": { "format": { "success": false, "error_type": "format_error" } }

and the Go adapter passes that vector only because it carries a manual guard immediately before calling into the SDK:

    // mpp-tools conformance/adapters/go/main.go:158
    if challenge.ID == "" {
        printJSON(commandResponse{Success: false, Error: "id must not be empty", ErrorType: "format_error"})
        return
    }
    header, err := challenge.ToAuthenticateStrict(challenge.Realm)

That guard becomes unnecessary once the SDK enforces it.

`FormatAuthenticate` returns only a string, so its callers cannot observe an error; the lenient path is deliberately unchanged. Optional params (`digest`, `expires`, `description`, `opaque`) keep being dropped when empty.

One caveat worth naming: `protocol.schema.json` sets `minLength: 1` on `id`, `method` and `intent` but not on `realm`, so an empty realm is not a schema violation. It is still treated as required here because `ParseChallenge` rejects a challenge without one. `server.New` accepts an empty realm today, and such a server previously emitted 402s this SDK could not parse; it now surfaces the misconfiguration as a 400 problem document.

Reverting the check fails the four new `TestFormatAuthenticateStrictRejectsEmptyRequiredAuthParams` subtests; the "behaviour unchanged" tests pass either way.
