### PR TITLE
fix: check SetString ok before using parsed amount in MatchTransferCalldata

### DIFF
--- a/.changelog/match-transfer-calldata-amount-parse.md
+++ b/.changelog/match-transfer-calldata-amount-parse.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject calldata with a non-hex amount field in `MatchTransferCalldata` instead of silently treating it as a zero amount. The `big.Int.SetString` success flag was previously ignored, so malformed calldata that passed the selector and length checks could be parsed as `amount = 0` and spuriously match a zero-amount `ChargeRequest`.

--- a/pkg/tempo/abi.go
+++ b/pkg/tempo/abi.go
@@ -49,8 +49,10 @@ func MatchTransferCalldata(dataHex string, request ChargeRequest, realm, challen
 		return false
 	}
 	toAddress := "0x" + dataHex[8+24:8+64]
-	amount := new(big.Int)
-	amount.SetString(dataHex[72:136], 16)
+	amount, ok := new(big.Int).SetString(dataHex[72:136], 16)
+	if !ok {
+		return false
+	}
 	if !strings.EqualFold(toAddress, request.Recipient) || amount.String() != request.Amount {
 		return false
 	}

--- a/pkg/tempo/abi_regression_test.go
+++ b/pkg/tempo/abi_regression_test.go
@@ -1,0 +1,28 @@
+package tempo
+
+import "testing"
+
+// TestMatchTransferCalldata_RejectsMalformedAmountHex proves that
+// MatchTransferCalldata no longer silently treats a non-hex amount field as
+// zero. Before the fix, big.Int.SetString's ok return value was ignored, so
+// malformed calldata with the correct selector and length would parse the
+// amount as 0 and could spuriously match a zero-amount ChargeRequest.
+func TestMatchTransferCalldata_RejectsMalformedAmountHex(t *testing.T) {
+	t.Parallel()
+
+	selector := TransferWithMemoSelector
+	toAddr := "000000000000000000000000" + "70997970c51812dc3a010c7d01b50e0d17dc79c8"
+	// 64 hex chars expected for amount, but this is not valid hex.
+	malformedAmount := "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+	memo := "0000000000000000000000000000000000000000000000000000000000000000"[:64]
+	dataHex := "0x" + selector + toAddr + malformedAmount + memo
+
+	request := ChargeRequest{
+		Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+		Amount:    "0", // matches what a swallowed parse error would silently produce
+	}
+
+	if MatchTransferCalldata(dataHex, request, "example.com", "challenge-1") {
+		t.Fatal("MatchTransferCalldata() = true, want false for calldata with non-hex amount field")
+	}
+}


### PR DESCRIPTION
## Problem
`MatchTransferCalldata` in `pkg/tempo/abi.go` ignores the success flag returned by `big.Int.SetString` when parsing the transfer amount out of calldata:

```go
amount := new(big.Int)
amount.SetString(dataHex[72:136], 16)
```

If `dataHex[72:136]` isn't valid hex (while still passing the earlier selector and total-length checks), `SetString` returns `(nil, false)` and leaves `amount` at its zero value instead of erroring. The function then proceeds to compare `amount.String()` (`"0"`) against `request.Amount`, so malformed calldata is silently treated as a zero-amount transfer instead of being rejected.

## Why it matters / precedent
Every other `SetString` call in this package already checks `ok` before using the result:
- `pkg/tempo/rpc.go:47`
- `pkg/tempo/request.go:592`
- `pkg/tempo/client/method.go:272,279`
- `pkg/mpp/units.go:73`

`MatchTransferCalldata` is the one call site that doesn't, which looks like an oversight rather than an intentional exception. There's also a direct precedent for treating this class of bug as a `patch`-level fix: `.changelog/parseunits-negative-decimals.md` rejects a bad numeric input in `ParseUnits` instead of letting it fall through silently.

## Fix
Capture and check the `ok` return value; return `false` immediately on a non-hex amount field, consistent with the other early-return checks already in this function (bad selector, bad length, etc).

## Tests
Added `TestMatchTransferCalldata_RejectsMalformedAmountHex` in `pkg/tempo/abi_regression_test.go`, which feeds calldata with a correct selector/length but a non-hex amount field and asserts `MatchTransferCalldata` returns `false`. Before the fix this calldata would spuriously match a `ChargeRequest{Amount: "0"}`.

I verified the core `big.Int.SetString` behavior (malformed hex → `ok=false`, receiver stays zero) in an isolated Go program. I was not able to run the full `go test ./pkg/tempo/...` suite in my sandbox because network egress there blocks `proxy.golang.org` (this repo's `go.mod` requires Go 1.26, and the module's dependencies like `go-ethereum`/`tempo-go` couldn't be fetched). I'd appreciate it if CI (or a maintainer) confirms the new test passes and nothing else regresses.

## Scope / trade-off
`MatchTransferCalldata` isn't currently called anywhere else in this module (`pkg/tempo/server/charge.go` verifies via receipt/log matching instead) — it's exported, public API with its own unit tests, presumably used by external consumers doing calldata-based verification directly (the TODO comment above it mentions `pympp` carrying similar logic). So this fix doesn't change any in-repo behavior today, but it closes a real gap for anyone calling this function on unvalidated calldata.

## Changeset
Added `.changelog/match-transfer-calldata-amount-parse.md` with a `patch` bump, matching the `parseunits-negative-decimals.md` precedent for the same bug class (reject malformed numeric input instead of silently defaulting).