### PR TITLE
fix: reject zero/expired ValidBefore on co-signed fee payer transactions

### DIFF
--- a/.changelog/fee-payer-validbefore-guard.md
+++ b/.changelog/fee-payer-validbefore-guard.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject a co-signed fee payer transaction with `ValidBefore == 0` (or already expired) after remote co-signing, not just before it. `validateFeePayerTransaction` only enforces its sponsor-policy upper bound when `ValidBefore` is non-zero, and the standalone zero/expired guard applied to the original client-submitted transaction was never re-applied to the transaction returned by a remote fee payer (`FeePayerURL`), so a co-signed response with `ValidBefore` reset to 0 could bypass the sponsor's validity-window policy entirely.

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -328,6 +328,14 @@ func (i *Intent) verifyTransaction(
 		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires, policy); err != nil {
 			return nil, err
 		}
+		// validateFeePayerTransaction only checks the sponsor-policy upper
+		// bound when ValidBefore is non-zero, so re-apply the same
+		// zero/expired guard used before co-signing. This matters most for
+		// the remote fee payer path just above, where tx was replaced with
+		// whatever tempotx.Deserialize parsed out of the remote response.
+		if tx.ValidBefore == 0 || time.Now().Unix() >= int64(tx.ValidBefore) {
+			return nil, mpp.ErrVerificationFailed("co-signed fee payer transaction has expired")
+		}
 		if tx.AwaitingFeePayer {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction must clear the awaiting fee payer marker")
 		}

--- a/pkg/tempo/server/charge_feepayer_validbefore_test.go
+++ b/pkg/tempo/server/charge_feepayer_validbefore_test.go
@@ -1,0 +1,100 @@
+package chargeserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+// TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsZeroValidBefore
+// proves that a remote fee payer response can't sponsor a transaction with
+// ValidBefore reset to 0. Before the fix, validateFeePayerTransaction only
+// enforced the sponsor-policy upper bound when ValidBefore was non-zero, and
+// the standalone "ValidBefore == 0 || expired" guard applied to the original
+// client-submitted tx was never re-applied to the co-signed tx returned by
+// the remote fee payer, so a co-signed ValidBefore of 0 slipped through both
+// checks.
+func TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsZeroValidBefore(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, nil)
+	rpc := newMockRPC(request)
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if !assert.NoErrorf(t, err,
+		"CreateCredential() error = %v", err) {
+		return
+	}
+
+	raw := credential.Payload["signature"].(string)
+
+	feePayerSigner, err := temposigner.NewSigner(feePayerKey)
+	if !assert.NoErrorf(t, err,
+		"NewSigner() error = %v", err) {
+		return
+	}
+
+	feePayerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coSignedTx, err := tempotx.Deserialize(raw)
+		if !assert.NoErrorf(t, err,
+			"Deserialize(raw) error = %v", err) {
+			return
+		}
+
+		sender, err := tempotx.VerifySignature(coSignedTx)
+		if !assert.NoErrorf(t, err,
+			"VerifySignature() error = %v", err) {
+			return
+		}
+
+		coSignedTx.From = sender
+		coSignedTx.FeeToken = common.HexToAddress(request.Currency)
+		coSignedTx.AwaitingFeePayer = false
+		// The regression under test: the remote fee payer hands back a
+		// transaction with ValidBefore zeroed out instead of preserving the
+		// caller's original expiry.
+		coSignedTx.ValidBefore = 0
+		{
+			err := tempotx.AddFeePayerSignature(coSignedTx, feePayerSigner)
+			if !assert.NoErrorf(t, err,
+				"AddFeePayerSignature() error = %v", err) {
+				return
+			}
+		}
+
+		serialized, err := tempotx.Serialize(coSignedTx, nil)
+		if !assert.NoErrorf(t, err,
+			"Serialize() error = %v", err) {
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": serialized})
+	}))
+	defer feePayerServer.Close()
+	request.MethodDetails.FeePayerURL = feePayerServer.URL
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
+	if !assert.NoErrorf(t, err,
+		"NewIntent() error = %v", err) {
+		return
+	}
+
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "expired") {
+		assert.Failf(t, "", "Verify() error = %v, want expiry rejection", err)
+		return
+	}
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected zero-ValidBefore transaction to be rejected before broadcast, got %d broadcasts", len(rpc.sentRawTxs)) {
+		return
+	}
+}


### PR DESCRIPTION
## Problem
In `pkg/tempo/server/charge.go`'s `verifyTransaction`, the fee-payer flow validates the transaction's `ValidBefore` field twice: once on the original client-submitted transaction (before co-signing), and once again after co-signing. But these two checks aren't equivalent:

**Before co-signing** (line ~286):
```go
if tx.ValidBefore == 0 || time.Now().Unix() >= int64(tx.ValidBefore) {
    return nil, mpp.ErrVerificationFailed("fee payer transaction has expired")
}
```

**After co-signing** (line ~328, before this fix): only `validateFeePayerTransaction(tx, ...)` is called, which internally does:
```go
if tx.ValidBefore != 0 {
    // ...sponsor-policy upper bound check...
}
```
i.e. it silently skips its check entirely when `ValidBefore == 0`. There is no standalone re-check afterward.

For the local `feePayerSigner` path this is harmless, since `tx` is mutated in place and its `ValidBefore` was already validated pre-signing. But for the **remote fee payer** path (`request.MethodDetails.FeePayerURL`), `tx` is replaced wholesale:
```go
tx, err = tempotx.Deserialize(coSignedRaw)
```
`coSignedRaw` comes from an external HTTP response (`signWithRemoteFeePayer`). If that response contains a transaction with `ValidBefore` reset to `0`, neither the post-co-sign `validateFeePayerTransaction` call nor any other check catches it, and the transaction proceeds to signature verification, preflight, and broadcast.

## Why it matters / precedent
The pre-signing check already establishes that `ValidBefore == 0` is treated as invalid (grouped with "already expired"), not as "never expires." The gap is that this same invariant isn't re-enforced on the transaction that actually gets broadcast when it originates from a remote fee payer response. `feePayerMaxValidityWindow` (15 minutes) is meant to bound how long a sponsor is on the hook for a transaction; a `ValidBefore` of 0 defeats that bound entirely for the remote co-signing path.

## Fix
Re-apply the same `ValidBefore == 0 || expired` guard immediately after the second `validateFeePayerTransaction` call, mirroring the pre-signing check.

## Tests
Added `TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsZeroValidBefore` in `pkg/tempo/server/charge_feepayer_validbefore_test.go`, modeled directly on the existing `TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsTamperedFeeToken` test. It runs a fake remote fee payer HTTP server that co-signs the transaction but zeroes `ValidBefore`, and asserts `Verify()` rejects it with an "expired" error before any broadcast (`rpc.sentRawTxs` stays empty).

I was not able to run the full `go test ./pkg/tempo/server/...` suite in my sandbox — network egress there blocks `proxy.golang.org` (this repo's `go.mod` requires Go 1.26, and dependencies like `go-ethereum`/`tempo-go` couldn't be fetched), the same limitation noted on #122. I traced the fix and test logic by hand against the existing `TestChargeFlow_FeePayerTransactionViaRemoteSigner*` tests' structure, but I'd appreciate CI or a maintainer confirming the new test passes (and fails without the fix) before merge.

## Scope / trade-off
This only affects the `FeePayerURL` (remote fee payer) path. The local `feePayerSigner` path was never affected, since it mutates the original, already-validated `tx` in place rather than replacing it. I have not audited whether `tempotx.Deserialize` or `VerifyDualSignatures` independently enforce a non-zero `ValidBefore` at the transaction-format level — this fix adds the check at the mpp-go verification layer regardless, consistent with the existing pre-signing check.

## Changeset
Added `.changelog/fee-payer-validbefore-guard.md` with a `patch` bump.