### PR TITLE
fix: return EncodeTransferWithMemo error instead of discarding it in transferDataHex

### DIFF
--- a/.changelog/transfer-data-hex-swallowed-memo-error.md
+++ b/.changelog/transfer-data-hex-swallowed-memo-error.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Return the error from `EncodeTransferWithMemo` instead of discarding it in `transferDataHex`. A malformed memo (not exactly 32 bytes of hex) previously caused `transferDataHex` to silently return an empty calldata string, which the client would then sign and return as a real, broadcast-ready transaction that called the token contract with no data at all instead of the intended `transferWithMemo` call. `ChargeRequest` is an exported struct that can be constructed without going through `NormalizeChargeRequest`, so a caller-supplied or otherwise unvalidated memo could reach this path directly.

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -198,7 +198,10 @@ func (m *Method) buildTransfer(
 	token := common.HexToAddress(request.Currency)
 	gasLimit := tempo.DefaultGasLimit
 	if len(transfers) == 1 {
-		dataHex := transferDataHex(transfers[0])
+		dataHex, err := transferDataHex(transfers[0])
+		if err != nil {
+			return "", err
+		}
 		if estimated, err := m.estimateGas(ctx, rpc, token.Hex(), dataHex); err == nil && estimated+5_000 > gasLimit {
 			gasLimit = estimated + 5_000
 		}
@@ -210,7 +213,11 @@ func (m *Method) buildTransfer(
 		SetGas(gasLimit).
 		SetNonceKey(big.NewInt(0))
 	for _, transfer := range transfers {
-		builder.AddCall(token, big.NewInt(0), common.FromHex(transferDataHex(transfer)))
+		dataHex, err := transferDataHex(transfer)
+		if err != nil {
+			return "", err
+		}
+		builder.AddCall(token, big.NewInt(0), common.FromHex(dataHex))
 	}
 
 	if request.MethodDetails.FeePayer {
@@ -295,12 +302,11 @@ func buildTransfers(request tempo.ChargeRequest, memo string) ([]transfer, error
 	return transfers, nil
 }
 
-func transferDataHex(transfer transfer) string {
+func transferDataHex(transfer transfer) (string, error) {
 	if transfer.memo != "" {
-		dataHex, _ := tempo.EncodeTransferWithMemo(transfer.recipient, transfer.amount, transfer.memo)
-		return dataHex
+		return tempo.EncodeTransferWithMemo(transfer.recipient, transfer.amount, transfer.memo)
 	}
-	return tempo.EncodeTransfer(transfer.recipient, transfer.amount)
+	return tempo.EncodeTransfer(transfer.recipient, transfer.amount), nil
 }
 
 // TODO(tempo-go): replace these JSON-RPC helpers with shared transaction-prep

--- a/pkg/tempo/client/transfer_data_hex_memo_error_test.go
+++ b/pkg/tempo/client/transfer_data_hex_memo_error_test.go
@@ -1,0 +1,71 @@
+package chargeclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/tempo"
+)
+
+// TestCreateCredentialRejectsMalformedMemoInsteadOfBroadcastingEmptyCalldata
+// proves that a ChargeRequest with a malformed MethodDetails.Memo causes
+// CreateCredential to fail loudly instead of silently signing and returning
+// a transaction with empty calldata.
+//
+// ChargeRequest is an exported struct; nothing forces a caller to build one
+// through NormalizeChargeRequest, so a hand-constructed (or otherwise
+// unvalidated) ChargeRequest with a malformed memo can reach the client
+// directly via a Challenge's request payload. Before this fix,
+// transferDataHex discarded the error from EncodeTransferWithMemo and
+// returned "" as calldata, which common.FromHex("") turns into an empty
+// byte slice: the client would go on to build, sign, and return a real
+// transaction that calls the token contract with no data at all, instead of
+// the intended transferWithMemo call - silently dropping the transfer.
+func TestCreateCredentialRejectsMalformedMemoInsteadOfBroadcastingEmptyCalldata(t *testing.T) {
+	t.Parallel()
+
+	rpc := &mockRPC{chainID: 42431, gasPrice: "0x3b9aca00", estimateGas: "0x5208"}
+	method, err := New(Config{
+		PrivateKey:     testPrivateKey,
+		ChainID:        42431,
+		RPC:            rpc,
+		CredentialType: tempo.CredentialTypeTransaction,
+	})
+	if !assert.NoErrorf(t, err,
+		"New() error = %v", err) {
+		return
+	}
+
+	// Bypass NormalizeChargeRequest entirely, mirroring a hand-built or
+	// otherwise unvalidated ChargeRequest: a memo that is not exactly 32
+	// bytes of hex.
+	request := tempo.ChargeRequest{
+		Amount:    "500000",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		MethodDetails: tempo.MethodDetails{
+			Memo: "not-a-valid-memo",
+		},
+	}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		testRealm,
+		tempo.MethodName,
+		tempo.IntentCharge,
+		request.Map(),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+
+	_, err = method.CreateCredential(context.Background(), challenge)
+	if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "memo"),
+		"CreateCredential() error = %v, want an error mentioning the malformed memo", err) {
+		return
+	}
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected malformed memo to be rejected before any transaction was built, got %d", len(rpc.sentRawTxs)) {
+		return
+	}
+}


### PR DESCRIPTION
## Problem
`transferDataHex` in `pkg/tempo/client/method.go` discards the error returned by `tempo.EncodeTransferWithMemo`:

```go
func transferDataHex(transfer transfer) string {
	if transfer.memo != "" {
		dataHex, _ := tempo.EncodeTransferWithMemo(transfer.recipient, transfer.amount, transfer.memo)
		return dataHex
	}
	return tempo.EncodeTransfer(transfer.recipient, transfer.amount)
}
```

`EncodeTransferWithMemo` returns an error whenever the memo isn't exactly 32 bytes of hex. When that happens here, `dataHex` is `""`, and `transferDataHex`'s own signature (`string`, no error) has no way to surface the failure to its caller.

Both call sites in `buildTransfer` then use that empty string directly:
```go
builder.AddCall(token, big.NewInt(0), common.FromHex(transferDataHex(transfer)))
```
`common.FromHex("")` is an empty byte slice, so the transaction gets built, signed, and returned as a normal, broadcast-ready transaction - just one that calls the token contract with **no calldata at all**, instead of the intended `transferWithMemo` call. The caller has no way to know anything went wrong; `buildTransfer`/`CreateCredential` return success.

## Why it matters / precedent
`ChargeRequest` (and its `MethodDetails.Memo` field) is an exported struct. The normal server-side path validates the memo via `normalizeMemo` inside `NormalizeChargeRequest`, but nothing enforces that every `ChargeRequest` a client processes was built that way - a `Challenge`'s request payload is just a map that gets unmarshalled back into a `ChargeRequest`, and any caller/integration constructing one directly (or a future server-side path that doesn't call `NormalizeChargeRequest`) can hand the client a malformed memo. Every other memo-parsing path in this codebase (`normalizeMemo`, `EncodeTransferWithMemo` itself) treats a malformed memo as a hard error rather than something to paper over - `transferDataHex` is the one place that silently drops it.

## Fix
Change `transferDataHex` to return `(string, error)` and propagate `EncodeTransferWithMemo`'s error, and handle the error at both call sites in `buildTransfer` (gas estimation and the transfer-building loop), returning early instead of building a transaction with empty calldata.

## Tests
Added `TestCreateCredentialRejectsMalformedMemoInsteadOfBroadcastingEmptyCalldata` in `pkg/tempo/client/transfer_data_hex_memo_error_test.go`. It bypasses `NormalizeChargeRequest` on purpose (mirroring the real reachability path described above) by hand-building a `ChargeRequest` with a malformed `MethodDetails.Memo` and feeding it through `ChargeRequest.Map()` into a `Challenge`, then asserts `CreateCredential` returns an error mentioning the memo and that no transaction was broadcast (`rpc.sentRawTxs` stays empty). I explicitly set `CredentialType: tempo.CredentialTypeTransaction` so the test can't accidentally pass for the wrong reason (a hash-credential-type challenge rejects any memo outright, with an unrelated error that also happens to contain the word "memo").

As with #122 and #123, I couldn't run the full `go test ./pkg/tempo/...` suite in my sandbox - network egress there blocks `proxy.golang.org`, and this repo's `go.mod` requires Go 1.26 with dependencies (`go-ethereum`, `tempo-go`) that couldn't be fetched. I traced the fix and test by hand against the existing `TestCreateCredentialScenarios` table and `buildChallenge` helper in the same package, but I'd appreciate CI or a maintainer confirming the new test passes (and fails without the fix) before merge.

## Scope / trade-off
This changes `transferDataHex`'s signature from `string` to `(string, error)`, which is a private, unexported function local to this package, so it's not a breaking change to any public API. I didn't audit every other caller of `EncodeTransfer`/`EncodeTransferWithMemo` in the repo for the same pattern - `transferDataHex` was the one I found with a concrete, demonstrated reachability path.

## Changeset
Added `.changelog/transfer-data-hex-swallowed-memo-error.md` with a `patch` bump, consistent with #122 and #123 for the same "swallowed error" bug class.