### PR TITLE
fix: release sponsored challenge key on pre-broadcast failure

### DIFF
--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -254,6 +254,19 @@ func (i *Intent) verifyTransaction(
 	raw string,
 	source *sourceDID,
 ) (*mpp.Receipt, error) {
+	// sponsoredKeyToRelease tracks the fee-payer idempotency key written by
+	// PutIfAbsent. It is cleared once SendRawTransaction is called, because
+	// after that point the transaction may already be in the mempool and
+	// releasing the key could allow a conflicting retry. Any pre-broadcast
+	// failure (co-signing error, preflight revert, serialization error, etc.)
+	// sets this so the deferred cleanup can restore retryability.
+	var sponsoredKeyToRelease string
+	defer func() {
+		if sponsoredKeyToRelease != "" {
+			_ = i.store.Delete(ctx, sponsoredKeyToRelease)
+		}
+	}()
+
 	tx, err := tempotx.Deserialize(raw)
 	if err != nil {
 		return nil, mpp.ErrInvalidPayload("failed to deserialize transaction payload")
@@ -303,6 +316,9 @@ func (i *Intent) verifyTransaction(
 		if !accepted {
 			return nil, mpp.ErrVerificationFailed("fee payer challenge already used")
 		}
+		// Mark the key for deferred cleanup. It is cleared before SendRawTransaction
+		// so that post-broadcast failures do not undo the replay protection.
+		sponsoredKeyToRelease = tempo.ChargeSponsoredChallengeStoreKey(credential.Challenge.ID)
 		if i.feePayerSigner != nil {
 			tx.From = sender
 			tx.FeeToken = common.HexToAddress(request.Currency)
@@ -372,6 +388,9 @@ func (i *Intent) verifyTransaction(
 	}
 
 	if shouldBroadcast {
+		// Clear before calling SendRawTransaction: once the tx may be in the
+		// mempool, the sponsored challenge key must not be released on failure.
+		sponsoredKeyToRelease = ""
 		var err error
 		txHash, err = rpc.SendRawTransaction(ctx, serialized)
 		if err != nil {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -1014,6 +1014,69 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 
 }
 
+func TestChargeFlow_FeePayerTransactionIsRetryableAfterPreflightFailure(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, nil)
+	rpc := newMockRPC(request)
+
+	// First call: preflight fails.
+	preflightAttempts := 0
+	rpc.onEstimateGas = func(params ...interface{}) (*temporpc.JSONRPCResponse, error) {
+		callObject, ok := params[0].(map[string]any)
+		if !ok {
+			return &temporpc.JSONRPCResponse{Result: rpc.estimateGas}, nil
+		}
+		// Server-side preflight calls include a "calls" key.
+		if _, ok := callObject["calls"]; ok {
+			preflightAttempts++
+			if preflightAttempts == 1 {
+				return temporpc.NewJSONRPCErrorResponse(1, temporpc.InvalidTransactionType, "execution reverted", nil), nil
+			}
+		}
+		return &temporpc.JSONRPCResponse{Result: rpc.estimateGas}, nil
+	}
+
+	clientMethod := newClientMethod(t, rpc, tempo.CredentialTypeTransaction)
+	challenge := buildChallenge(t, request)
+
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	if !assert.NoErrorf(t, err, "CreateCredential() error = %v", err) {
+		return
+	}
+
+	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+	if !assert.NoErrorf(t, err, "NewIntent() error = %v", err) {
+		return
+	}
+
+	// First Verify: preflight fails — sponsored key must be released.
+	{
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.Falsef(t, err == nil || !strings.Contains(err.Error(), "transaction preflight failed"),
+			"first Verify() error = %v, want preflight failure", err) {
+			return
+		}
+	}
+	if !assert.Lenf(t, rpc.sentRawTxs, 0,
+		"expected no broadcast after failed preflight, got %d", len(rpc.sentRawTxs)) {
+		return
+	}
+
+	// Second Verify with the same credential: preflight now succeeds, so the
+	// full flow should complete. If the sponsored key was NOT released after the
+	// first failure, this call would return "fee payer challenge already used".
+	{
+		_, err := intent.Verify(ctx, credential, request.Map())
+		if !assert.NoErrorf(t, err, "second Verify() after preflight retry error = %v", err) {
+			return
+		}
+	}
+	if !assert.Lenf(t, rpc.sentRawTxs, 1,
+		"expected 1 broadcast on successful retry, got %d", len(rpc.sentRawTxs)) {
+		return
+	}
+}
+
 func TestChargeFlow_RejectsUnsupportedFeePayerToken(t *testing.T) {
 	ctx := context.Background()
 	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{


### PR DESCRIPTION
## Problem

When a fee-payer (sponsored) transaction fails **after** `PutIfAbsent` stores the `ChargeSponsoredChallengeStoreKey` but **before** `SendRawTransaction` is called, the store entry is never cleaned up.

This means any pre-broadcast failure (co-signing error, preflight revert, serialization error, etc.) permanently blocks retries with the same credential even though no transaction ever reached the network.

The non-fee-payer path already handles this correctly: it deletes `ChargeStoreKey` when broadcast fails. The sponsored path had no equivalent.

Reproducer: `TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast` verifies no broadcast happens, but does **not** verify that a subsequent retry succeeds masking the bug.

Fixes #126

## Fix

Uses the same defer+flag pattern as the non-fee-payer broadcast-failure cleanup:

- `sponsoredKeyToRelease` is set to the store key after `PutIfAbsent` succeeds.
- A `defer` deletes it if it is still set when `verifyTransaction` returns.
- Before calling `SendRawTransaction`, `sponsoredKeyToRelease` is cleared so post-broadcast failures (reverted tx, etc.) correctly retain the replay protection, matching the existing behaviour tested by `TestChargeFlow_FeePayerTransactionUsesChallengeOnceAfterRevert`.

## Tests

Added `TestChargeFlow_FeePayerTransactionIsRetryableAfterPreflightFailure`: the first `Verify` call fails at preflight; the second call with the same credential succeeds and results in exactly one broadcast.