### PR TITLE
feat(client): add an Authorize hook to verify challenges before auto-payment

### DIFF
--- a/.changelog/client-authorize-hook.md
+++ b/.changelog/client-authorize-hook.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Add a client-side `Authorize` hook (`Transport.Authorize` field and `client.WithAuthorize` option) that is called with the matched challenge before a payment credential is created. Returning an error declines the payment and returns the server's original 402 response unmodified. This gives Go clients the interception point the core spec's "Amount Verification" requirements assume, matching mppx's `onChallenge`, mpp-rs's `challenge.received` handlers, and pympp's `on_challenge_received`.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	methods            []Method
 	httpClient         *http.Client
 	paymentPreferences PaymentPreferences
+	authorize          func(ctx context.Context, challenge *mpp.Challenge) error
 }
 
 // Option configures the Client.
@@ -63,6 +64,13 @@ func WithHTTPClient(c *http.Client) Option {
 func WithPaymentPreferences(preferences PaymentPreferences) Option {
 	return func(c *Client) {
 		c.paymentPreferences = clonePaymentPreferences(preferences)
+	}
+}
+
+// WithAuthorize sets a hook consulted before each payment; see Transport.Authorize.
+func WithAuthorize(fn func(ctx context.Context, challenge *mpp.Challenge) error) Option {
+	return func(cl *Client) {
+		cl.authorize = fn
 	}
 }
 
@@ -90,6 +98,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req = req.WithContext(withPaymentOrigin(req.Context(), origin))
 
 	transport := NewTransport(c.methods, inner, WithTransportPaymentPreferences(c.paymentPreferences))
+	transport.Authorize = c.authorize
 
 	// Use a copy of the http.Client with our payment-aware transport.
 	hc := *c.httpClient

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -21,6 +21,11 @@ type Transport struct {
 	paymentPreferences []paymentPreference
 	acceptPayment      string
 	configErr          error
+
+	// Authorize, if set, is consulted with the selected challenge before
+	// the transport pays it. If it returns an error the transport does not
+	// pay and returns the server's 402 response unmodified.
+	Authorize func(ctx context.Context, challenge *mpp.Challenge) error
 }
 
 const defaultMaxPaymentRetries = 3
@@ -101,6 +106,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err := validatePaymentOrigin(request, selected.challenge); err != nil {
 			drainAndClose(resp.Body)
 			return nil, err
+		}
+
+		// Runs before the body drain so a declined 402 is returned intact.
+		if t.Authorize != nil {
+			if err := t.Authorize(baseRequest.Context(), selected.challenge); err != nil {
+				return resp, nil
+			}
 		}
 
 		drainAndClose(resp.Body)

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -744,3 +744,134 @@ func TestClient_Do_RejectsCrossOriginRedirect(t *testing.T) {
 	}
 
 }
+
+func TestTransport_RoundTrip_AuthorizeDeclinesPayment(t *testing.T) {
+	var challenge *mpp.Challenge
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("pay me"))
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	tr.Authorize = func(_ context.Context, _ *mpp.Challenge) error {
+		return context.Canceled
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected the original 402, got %d", resp.StatusCode) {
+		return
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !assert.Equalf(t, "pay me", string(body),
+		"expected the untouched 402 body, got %q", string(body)) {
+		return
+	}
+	if !assert.EqualValuesf(t, 0, method.calls,
+		"CreateCredential must not run after Authorize declines, got %d calls", method.calls) {
+		return
+	}
+	if !assert.EqualValuesf(t, 1, callCount,
+		"expected no retry after declined payment, got %d server calls", callCount) {
+		return
+	}
+}
+
+func TestTransport_RoundTrip_AuthorizeSeesMatchedChallenge(t *testing.T) {
+	var challenge *mpp.Challenge
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			w.Write([]byte("pay me"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("paid"))
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", map[string]any{"amount": "1000"})
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	var seen *mpp.Challenge
+	tr.Authorize = func(_ context.Context, ch *mpp.Challenge) error {
+		seen = ch
+		return nil
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected payment to proceed with an approving hook, got %d", resp.StatusCode) {
+		return
+	}
+	if !assert.NotNilf(t, seen, "Authorize was never called") {
+		return
+	}
+	if !assert.Equalf(t, challenge.ID, seen.ID,
+		"Authorize saw challenge %q, want the matched challenge %q", seen.ID, challenge.ID) {
+		return
+	}
+	if !assert.Equalf(t, "tempo", seen.Method,
+		"Authorize saw method %q, want tempo", seen.Method) {
+		return
+	}
+	if !assert.EqualValuesf(t, 1, method.calls,
+		"expected exactly one CreateCredential call, got %d", method.calls) {
+		return
+	}
+}
+
+func TestClient_WithAuthorize(t *testing.T) {
+	var challenge *mpp.Challenge
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("pay me"))
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	c := New([]Method{method}, WithAuthorize(func(_ context.Context, _ *mpp.Challenge) error {
+		return context.Canceled
+	}))
+
+	resp, err := c.Get(context.Background(), srv.URL)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"expected the original 402 through Client.Do, got %d", resp.StatusCode) {
+		return
+	}
+	if !assert.EqualValuesf(t, 0, method.calls,
+		"CreateCredential must not run after WithAuthorize declines, got %d calls", method.calls) {
+		return
+	}
+}


### PR DESCRIPTION
`client.Transport` auto-pays the first matching challenge: `RoundTrip` calls `CreateCredential` with no interception point, so an application cannot verify amount, recipient, or asset before its wallet signs. The core spec makes that verification a client MUST and says clients MUST NOT trust `description` (Security Considerations, "Amount Verification"). mpp-go is the only SDK without such a hook: mppx has `onChallenge`, mpp-rs has `challenge.received` handlers, pympp has `on_challenge_received`.

This adds the smallest surface for it: an optional `Authorize func(ctx context.Context, challenge *mpp.Challenge) error` field on `Transport`, plus a `WithAuthorize` option for `Client.Do` users. Nil keeps current behavior byte-for-byte. Returning an error declines the payment: `CreateCredential` never runs and the caller gets the server's original 402 unmodified, the same semantics as the existing no-matching-method path.

Not a spend cap on purpose: `Challenge` has no top-level amount (amounts live in method-specific request maps), and rail-level budgets already have a home in Tempo access keys. The client-side MUST needs a seam, not a policy engine.

Composes with #118: if the multi-challenge retry loop lands, the hook guards each candidate.

Tests: declined payment returns the untouched 402 with zero `CreateCredential` calls and no retry; an approving hook sees the matched challenge; the option plumbs through `Client.Do`. `go build`, `go vet`, and `go test ./...` pass locally. Changelog fragment included (minor).
