### PR TITLE
test: use bootstrapped Tempo localnet

### DIFF
--- a/.changelog/tempo-localnet-integration.md
+++ b/.changelog/tempo-localnet-integration.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Use the bootstrapped Tempo localnet image for reproducible integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    env:
-      TEMPO_TAG: latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,52 +80,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-integration-
 
-      - name: Resolve Tempo image digest
-        id: tempo-digest
-        run: |
-          digest=$(docker buildx imagetools inspect "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" --raw | sha256sum | cut -d' ' -f1)
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Tempo Docker image
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: docker-cache
-        with:
-          path: /tmp/tempo-image.tar
-          key: tempo-image-${{ steps.tempo-digest.outputs.digest }}
-
-      - name: Load cached Tempo image
-        if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/tempo-image.tar
-
-      - name: Pull and cache Tempo image
-        if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: |
-          docker pull "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}"
-          docker save "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" -o /tmp/tempo-image.tar
-
-      - name: Start Tempo devnet
-        run: docker compose up -d
-
-      - name: Wait for Tempo RPC
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf -X POST -H 'Content-Type: application/json' \
-              -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
-              http://localhost:8545 > /dev/null 2>&1; then
-              echo "Tempo RPC ready"
-              exit 0
-            fi
-            echo "Waiting for Tempo RPC... ($i/30)"
-            sleep 2
-          done
-          echo "Tempo RPC not ready after 60s"
-          docker compose logs
-          exit 1
+      - name: Start Tempo localnet
+        run: docker compose up -d --wait
 
       - name: Run integration tests
         run: go test -race -count=1 -tags=integration -timeout=120s ./tests/...
 
-      - name: Stop Tempo devnet
+      - name: Stop Tempo localnet
         if: always()
         run: docker compose down
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@924710544d534332220d164bfa5747340bb85f93
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
     with:
       protocol-paths: |
         pkg/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@924710544d534332220d164bfa5747340bb85f93
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
     with:
       adapter: go
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,7 @@
 services:
   tempo-node:
-    image: ghcr.io/tempoxyz/tempo:latest
-    platform: linux/amd64
-    container_name: mpp-go-tempo-dev-node
-    command: >
-      node --dev
-      --dev.block-time 1sec
-      --http
-      --http.addr 0.0.0.0
-      --http.port 8545
-      --http.api all
-      --chain dev
-      --faucet.enabled
-      --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-      --faucet.amount 1000000000000000
-      --faucet.address 0x20c0000000000000000000000000000000000000
+    image: ${TEMPO_LOCALNET_IMAGE:-ghcr.io/tempoxyz/tempo-localnet@sha256:86f199f161be85d3610d990e5bc2653ece29de3ee9c91e8c8e768cf2b8c05c3b}
+    command: ["--block-time", "1ms"]
     ports:
-      - "8545:8545"
-      - "30303:30303"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8545"]
-      interval: 2s
-      timeout: 5s
-      retries: 15
+      - "127.0.0.1:8545:8545"
+    stop_grace_period: 10s

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -29,7 +29,6 @@ import (
 	chargeclient "github.com/tempoxyz/mpp-go/pkg/tempo/client"
 	chargeserver "github.com/tempoxyz/mpp-go/pkg/tempo/server"
 	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
-	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
 const (
@@ -40,9 +39,7 @@ const (
 	// integrationCurrency is the fixed TIP-20 token used in the local devnet tests.
 	integrationCurrency = "0x20c0000000000000000000000000000000000000"
 	// integrationRecipient is the account that receives paid transfers during tests.
-	integrationRecipient = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
-	// integrationDevPrivateKey is Anvil's default funded dev key used for fallback funding.
-	integrationDevPrivateKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	integrationRecipient     = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
 	receiptPollingTimeout    = 45 * time.Second
 	receiptPollingInterval   = 500 * time.Millisecond
 	rpcReadinessTimeout      = 45 * time.Second
@@ -712,80 +709,25 @@ func fundAddress(t *testing.T, ctx context.Context, rpc tempo.RPCClient, address
 	t.Helper()
 
 	response, err := rpc.SendRequest(ctx, "tempo_fundAddress", address.Hex())
-	if err == nil {
-		if err := response.CheckError(); err == nil {
-			switch result := response.Result.(type) {
-			case string:
-				if result != "" {
-					waitForReceipt(t, ctx, rpc, result)
-					waitForTokenBalance(t, ctx, rpc, address, integrationFundingAmount)
-					return
-				}
-			case []any:
-				for _, item := range result {
-					hash, ok := item.(string)
-					if ok && hash != "" {
-						waitForReceipt(t, ctx, rpc, hash)
-					}
-				}
-				waitForTokenBalance(t, ctx, rpc, address, integrationFundingAmount)
-				return
-			}
+	require.NoError(t, err)
+	require.NoError(t, response.CheckError())
+
+	switch result := response.Result.(type) {
+	case string:
+		require.NotEmpty(t, result)
+		waitForReceipt(t, ctx, rpc, result)
+	case []any:
+		require.NotEmpty(t, result)
+		for _, item := range result {
+			hash, ok := item.(string)
+			require.True(t, ok)
+			require.NotEmpty(t, hash)
+			waitForReceipt(t, ctx, rpc, hash)
 		}
+	default:
+		require.Failf(t, "unexpected faucet response", "result type = %T", result)
 	}
 
-	devSigner, err := temposigner.NewSigner(integrationDevPrivateKey)
-	if !assert.NoErrorf(t, err,
-		"NewSigner(dev key) error = %v", err) {
-		return
-	}
-
-	chainID, err := rpc.GetChainID(ctx)
-	if !assert.NoErrorf(t, err,
-		"GetChainID(funding tx) error = %v", err) {
-		return
-	}
-
-	gasPrice := mustGasPrice(t, ctx, rpc)
-	nonce, err := rpc.GetTransactionCount(ctx, devSigner.Address().Hex())
-	if !assert.NoErrorf(t, err,
-		"GetTransactionCount(dev signer) error = %v", err) {
-		return
-	}
-
-	transferData := common.FromHex(tempo.EncodeTransfer(address.Hex(), integrationFundingAmount))
-	gasLimit := mustEstimateGas(t, ctx, rpc, devSigner.Address(), common.HexToAddress(integrationCurrency), transferData)
-	tx, err := tempotx.NewBuilder(new(big.Int).SetUint64(chainID)).
-		SetMaxFeePerGas(gasPrice).
-		SetMaxPriorityFeePerGas(new(big.Int).Set(gasPrice)).
-		SetGas(gasLimit).
-		SetNonceKey(big.NewInt(0)).
-		SetNonce(nonce).
-		SetFeeToken(common.HexToAddress(integrationCurrency)).
-		AddCall(common.HexToAddress(integrationCurrency), big.NewInt(0), transferData).
-		BuildAndValidate()
-	if !assert.NoErrorf(t, err,
-		"BuildAndValidate(funding tx) error = %v", err) {
-		return
-	}
-
-	if err := tempotx.SignTransaction(tx, devSigner); err != nil {
-		assert.Failf(t, "", "SignTransaction(funding tx) error = %v", err)
-		return
-	}
-	serialized, err := tempotx.Serialize(tx, nil)
-	if !assert.NoErrorf(t, err,
-		"Serialize(funding tx) error = %v", err) {
-		return
-	}
-
-	hash, err := rpc.SendRawTransaction(ctx, serialized)
-	if !assert.NoErrorf(t, err,
-		"SendRawTransaction(funding tx) error = %v", err) {
-		return
-	}
-
-	waitForReceipt(t, ctx, rpc, hash)
 	waitForTokenBalance(t, ctx, rpc, address, integrationFundingAmount)
 }
 


### PR DESCRIPTION
## Motivation

The Go SDK integration suite should use Tempo’s canonical deterministic faucet setup instead of duplicating raw node configuration and fallback funding transactions.

## Summary

- replace the hand-configured Tempo node with the digest-pinned localnet image
- require the canonical tempo_fundAddress fixture in integration tests
- simplify CI image startup and readiness handling

## Key design considerations

- preserve TEMPO_LOCALNET_IMAGE overrides for testing newer images
- use health-based Compose readiness and a 1 ms block interval for reliable bootstrap
