### PR TITLE
fix(client): skip challenges with missing expires instead of paying them

### DIFF
--- a/.changelog/client-skip-empty-expires.md
+++ b/.changelog/client-skip-empty-expires.md
@@ -1,0 +1,4 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+Skip Payment challenges whose `expires` field is empty so the client does not pay credentials the server rejects with "missing required expires".

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -56,18 +56,21 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	now := time.Now().UTC()
 	for i := range challenges {
 		ch := &challenges[i]
-		if ch.Expires != "" {
-			expiry, err := parseChallengeExpiry(ch.Expires)
-			if err != nil {
-				// Unparseable expiry: the issuing server rejects such a
-				// credential (server.VerifyOrChallenge returns "invalid expires
-				// format"), so don't waste a payment on a challenge it would
-				// refuse. Skip it.
-				continue
-			}
-			if expiry.Before(now) {
-				continue
-			}
+		if ch.Expires == "" {
+			// Missing expiry: server.VerifyOrChallenge rejects credentials
+			// without expires ("missing required expires"), so don't pay.
+			continue
+		}
+		expiry, err := parseChallengeExpiry(ch.Expires)
+		if err != nil {
+			// Unparseable expiry: the issuing server rejects such a
+			// credential (server.VerifyOrChallenge returns "invalid expires
+			// format"), so don't waste a payment on a challenge it would
+			// refuse. Skip it.
+			continue
+		}
+		if expiry.Before(now) {
+			continue
 		}
 		if m, ok := t.methods[ch.Method]; ok {
 			matched = ch

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -49,6 +49,7 @@ func challengeForURL(t *testing.T, rawURL, method string, request map[string]any
 		return *new(*mpp.Challenge)
 	}
 
+	opts = append([]mpp.ChallengeOption{mpp.WithExpires(mpp.Expires.Minutes(5))}, opts...)
 	return mpp.NewChallenge("secret", parsedURL.Host, method, "payment", request, opts...)
 }
 
@@ -182,6 +183,29 @@ func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
 		return
 	}
 
+}
+
+func TestTransport_RoundTrip_402EmptyExpiresIsSkipped(t *testing.T) {
+	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("missing expires"))
+	}))
+	defer srv.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+	assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0 for missing expires", method.calls)
 }
 
 func TestTransport_RoundTrip_402UnparseableExpiresIsSkipped(t *testing.T) {


### PR DESCRIPTION
## Summary

- Skip Payment challenges with an empty `expires` field in the client transport, matching server rejection of credentials without expiry.
- Extend the existing unparseable-expires guard (#88) so missing expiry is treated the same as invalid expiry.
- Add `TestTransport_RoundTrip_402EmptyExpiresIsSkipped` and default test challenges to a valid future `expires`.

## Context

`server.VerifyOrChallenge` rejects credentials when `expires` is missing (`"missing required expires"`). The client previously accepted such challenges and could attempt payment for credentials the server would refuse.

## Test plan

- [x] `go test ./pkg/client/...`
- [x] `go test ./...`