### PR TITLE
fix(server): return fresh compose challenges for malformed credentials

### DIFF
--- a/.changelog/client-skip-empty-expires.md
+++ b/.changelog/client-skip-empty-expires.md
@@ -1,0 +1,4 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+Skip Payment challenges whose `expires` field is empty so the client does not pay credentials the server rejects with "missing required expires".

--- a/.changelog/compose-malformed-credential-challenge.md
+++ b/.changelog/compose-malformed-credential-challenge.md
@@ -1,0 +1,4 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+Return fresh WWW-Authenticate challenges from ComposeMiddleware when a Payment credential is malformed, matching the retry behavior of ChargeMiddleware and VerifyOrChallenge.

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -56,18 +56,21 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	now := time.Now().UTC()
 	for i := range challenges {
 		ch := &challenges[i]
-		if ch.Expires != "" {
-			expiry, err := parseChallengeExpiry(ch.Expires)
-			if err != nil {
-				// Unparseable expiry: the issuing server rejects such a
-				// credential (server.VerifyOrChallenge returns "invalid expires
-				// format"), so don't waste a payment on a challenge it would
-				// refuse. Skip it.
-				continue
-			}
-			if expiry.Before(now) {
-				continue
-			}
+		if ch.Expires == "" {
+			// Missing expiry: server.VerifyOrChallenge rejects credentials
+			// without expires ("missing required expires"), so don't pay.
+			continue
+		}
+		expiry, err := parseChallengeExpiry(ch.Expires)
+		if err != nil {
+			// Unparseable expiry: the issuing server rejects such a
+			// credential (server.VerifyOrChallenge returns "invalid expires
+			// format"), so don't waste a payment on a challenge it would
+			// refuse. Skip it.
+			continue
+		}
+		if expiry.Before(now) {
+			continue
 		}
 		if m, ok := t.methods[ch.Method]; ok {
 			matched = ch

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -49,6 +49,7 @@ func challengeForURL(t *testing.T, rawURL, method string, request map[string]any
 		return *new(*mpp.Challenge)
 	}
 
+	opts = append([]mpp.ChallengeOption{mpp.WithExpires(mpp.Expires.Minutes(5))}, opts...)
 	return mpp.NewChallenge("secret", parsedURL.Host, method, "payment", request, opts...)
 }
 
@@ -182,6 +183,29 @@ func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {
 		return
 	}
 
+}
+
+func TestTransport_RoundTrip_402EmptyExpiresIsSkipped(t *testing.T) {
+	challenge := mpp.NewChallenge("secret", "realm", "tempo", "payment", nil)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate("realm"))
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte("missing expires"))
+	}))
+	defer srv.Close()
+
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+	assert.Equalf(t, 0, method.calls,
+		"CreateCredential() calls = %d, want 0 for missing expires", method.calls)
 }
 
 func TestTransport_RoundTrip_402UnparseableExpiresIsSkipped(t *testing.T) {

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -83,12 +84,16 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 			// Credential present — find the matching entry.
 			cred, err := mpp.ParseCredential(paymentAuth)
 			if err != nil {
-				WritePaymentError(w, mpp.ErrMalformedCredential(err.Error()))
+				writeComposeMalformedCredentialError(w, r, entries, realm, body, scope, nil, mpp.ErrMalformedCredential(err.Error()))
 				return
 			}
 
 			entry, ok, err := findMatchingEntry(entries, cred, scope)
 			if err != nil {
+				if isMalformedCredential(err) {
+					writeComposeMalformedCredentialError(w, r, entries, realm, body, scope, cred, err)
+					return
+				}
 				WritePaymentError(w, err)
 				return
 			}
@@ -128,51 +133,118 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 // composeChallenges issues a 402 with all configured challenges merged into
 // separate WWW-Authenticate header values.
 func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string, body []byte, scope map[string]string) {
+	challenges, err := collectComposeChallenges(r.Context(), entries, body, scope)
+	if err != nil {
+		WritePaymentError(w, err)
+		return
+	}
+	writeComposeChallengeResponse(w, challenges, realm, nil)
+}
+
+func collectComposeChallenges(ctx context.Context, entries []composedEntry, body []byte, scope map[string]string) ([]*mpp.Challenge, error) {
 	var challenges []*mpp.Challenge
 	for _, entry := range entries {
-		params := entry.params
-		params.Authorization = ""
-		if len(scope) > 0 {
-			params.MppxScope = scope
-		}
-		if len(body) > 0 {
-			params.Body = body
-		}
-
-		result, err := entry.mpp.Charge(r.Context(), params)
+		challenge, err := freshComposeChallenge(ctx, entry, body, scope)
 		if err != nil {
+			return nil, err
+		}
+		if challenge != nil {
+			challenges = append(challenges, challenge)
+		}
+	}
+	if len(challenges) == 0 {
+		return nil, mpp.ErrBadRequest("no challenges could be generated")
+	}
+	return challenges, nil
+}
+
+func freshComposeChallenge(ctx context.Context, entry composedEntry, body []byte, scope map[string]string) (*mpp.Challenge, error) {
+	params := entry.params
+	params.Authorization = ""
+	if len(scope) > 0 {
+		params.MppxScope = scope
+	}
+	if len(body) > 0 {
+		params.Body = body
+	}
+
+	result, err := entry.mpp.Charge(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Challenge, nil
+}
+
+func writeComposeMalformedCredentialError(
+	w http.ResponseWriter,
+	r *http.Request,
+	entries []composedEntry,
+	realm string,
+	body []byte,
+	scope map[string]string,
+	cred *mpp.Credential,
+	err error,
+) {
+	var challenges []*mpp.Challenge
+	if cred != nil {
+		if entry, ok := findEntryByMethodIntent(entries, cred); ok {
+			challenge, chErr := freshComposeChallenge(r.Context(), entry, body, scope)
+			if chErr == nil && challenge != nil {
+				challenges = []*mpp.Challenge{challenge}
+			}
+		}
+	}
+	if len(challenges) == 0 {
+		var collectErr error
+		challenges, collectErr = collectComposeChallenges(r.Context(), entries, body, scope)
+		if collectErr != nil {
 			WritePaymentError(w, err)
 			return
 		}
-		if result.Challenge != nil {
-			challenges = append(challenges, result.Challenge)
+	}
+	writeComposeChallengeResponse(w, challenges, realm, err)
+}
+
+func writeComposeChallengeResponse(w http.ResponseWriter, challenges []*mpp.Challenge, realm string, err error) {
+	for _, challenge := range challenges {
+		header, headerErr := challenge.ToAuthenticateStrict(realm)
+		if headerErr != nil {
+			WritePaymentError(w, mpp.ErrBadRequest(headerErr.Error()))
+			return
 		}
+		w.Header().Add("WWW-Authenticate", header)
 	}
 
-	if len(challenges) == 0 {
-		WritePaymentError(w, mpp.ErrBadRequest("no challenges could be generated"))
+	if err != nil {
+		WritePaymentError(w, err)
 		return
 	}
 
-	var headers []string
-	for _, challenge := range challenges {
-		header, err := challenge.ToAuthenticateStrict(realm)
-		if err != nil {
-			WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
-			return
-		}
-		headers = append(headers, header)
-	}
-
-	for _, header := range headers {
-		w.Header().Add("WWW-Authenticate", header)
-	}
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusPaymentRequired)
 
 	problem := mpp.ErrPaymentRequired(realm, "")
 	json.NewEncoder(w).Encode(problem.ProblemDetails(""))
+}
+
+func isMalformedCredential(err error) bool {
+	pe, ok := err.(*mpp.PaymentError)
+	return ok && pe.Type == mpp.ErrorTypeMalformedCredential
+}
+
+func findEntryByMethodIntent(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool) {
+	for _, entry := range entries {
+		method := entry.mpp.method
+		if cred.Challenge.Method != method.Name() {
+			continue
+		}
+		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
+			continue
+		}
+		return entry, true
+	}
+	return composedEntry{}, false
 }
 
 // findMatchingEntry selects the entry whose method, intent, and canonical

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -562,6 +562,56 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 		return
 	}
 
+	if !assert.NotEmpty(t, paid.Header.Values("WWW-Authenticate"),
+		"expected fresh WWW-Authenticate challenge on malformed credential") {
+		return
+	}
+
+}
+
+func TestComposeMiddleware_ReturnsFreshChallengeForUnparseableCredential(t *testing.T) {
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return
+	}
+	req.Header.Set("Authorization", "Payment !!!not-valid-base64!!!")
+
+	resp, err := http.DefaultClient.Do(req)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"status = %d, want %d", resp.StatusCode, http.StatusPaymentRequired) {
+		return
+	}
+
+	wwwAuth := resp.Header.Values("WWW-Authenticate")
+	if !assert.Lenf(t, wwwAuth, 2,
+		"got %d WWW-Authenticate headers, want 2 fresh compose challenges", len(wwwAuth)) {
+		return
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		assert.Failf(t, "", "Decode(problem) error = %v", err)
+		return
+	}
+	assert.Equal(t, string(mpp.ErrorTypeMalformedCredential), problem.Type)
 }
 
 func TestComposeMiddleware_SingleMethod(t *testing.T) {


### PR DESCRIPTION
## Summary

- Return fresh `WWW-Authenticate` challenges from `ComposeMiddleware` when a Payment credential is malformed.
- Fan out all compose challenges when `ParseCredential` fails.
- Reissue a matching entry challenge when the echoed request is invalid but method/intent are known.
- Align compose retry UX with `ChargeMiddleware` and `VerifyOrChallenge`.

## Context

Previously, compose routes returned only a problem+json error for malformed credentials, while the standard charge path returned a fresh retry challenge. Wallet clients had no challenge to retry against on compose-protected routes.

## Test plan

- [x] `go test ./pkg/server/... -run Compose`
- [x] `go test ./...`