### PR TITLE
fix(server): return fresh compose challenges for malformed credentials

### DIFF
--- a/.changelog/compose-malformed-credential-challenge.md
+++ b/.changelog/compose-malformed-credential-challenge.md
@@ -1,0 +1,4 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+Return fresh WWW-Authenticate challenges from ComposeMiddleware when a Payment credential is malformed, matching the retry behavior of ChargeMiddleware and VerifyOrChallenge.

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -83,12 +84,16 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 			// Credential present — find the matching entry.
 			cred, err := mpp.ParseCredential(paymentAuth)
 			if err != nil {
-				WritePaymentError(w, mpp.ErrMalformedCredential(err.Error()))
+				writeComposeMalformedCredentialError(w, r, entries, realm, body, scope, nil, mpp.ErrMalformedCredential(err.Error()))
 				return
 			}
 
 			entry, ok, err := findMatchingEntry(entries, cred, scope)
 			if err != nil {
+				if isMalformedCredential(err) {
+					writeComposeMalformedCredentialError(w, r, entries, realm, body, scope, cred, err)
+					return
+				}
 				WritePaymentError(w, err)
 				return
 			}
@@ -128,51 +133,118 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 // composeChallenges issues a 402 with all configured challenges merged into
 // separate WWW-Authenticate header values.
 func composeChallenges(w http.ResponseWriter, r *http.Request, entries []composedEntry, realm string, body []byte, scope map[string]string) {
+	challenges, err := collectComposeChallenges(r.Context(), entries, body, scope)
+	if err != nil {
+		WritePaymentError(w, err)
+		return
+	}
+	writeComposeChallengeResponse(w, challenges, realm, nil)
+}
+
+func collectComposeChallenges(ctx context.Context, entries []composedEntry, body []byte, scope map[string]string) ([]*mpp.Challenge, error) {
 	var challenges []*mpp.Challenge
 	for _, entry := range entries {
-		params := entry.params
-		params.Authorization = ""
-		if len(scope) > 0 {
-			params.MppxScope = scope
-		}
-		if len(body) > 0 {
-			params.Body = body
-		}
-
-		result, err := entry.mpp.Charge(r.Context(), params)
+		challenge, err := freshComposeChallenge(ctx, entry, body, scope)
 		if err != nil {
+			return nil, err
+		}
+		if challenge != nil {
+			challenges = append(challenges, challenge)
+		}
+	}
+	if len(challenges) == 0 {
+		return nil, mpp.ErrBadRequest("no challenges could be generated")
+	}
+	return challenges, nil
+}
+
+func freshComposeChallenge(ctx context.Context, entry composedEntry, body []byte, scope map[string]string) (*mpp.Challenge, error) {
+	params := entry.params
+	params.Authorization = ""
+	if len(scope) > 0 {
+		params.MppxScope = scope
+	}
+	if len(body) > 0 {
+		params.Body = body
+	}
+
+	result, err := entry.mpp.Charge(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Challenge, nil
+}
+
+func writeComposeMalformedCredentialError(
+	w http.ResponseWriter,
+	r *http.Request,
+	entries []composedEntry,
+	realm string,
+	body []byte,
+	scope map[string]string,
+	cred *mpp.Credential,
+	err error,
+) {
+	var challenges []*mpp.Challenge
+	if cred != nil {
+		if entry, ok := findEntryByMethodIntent(entries, cred); ok {
+			challenge, chErr := freshComposeChallenge(r.Context(), entry, body, scope)
+			if chErr == nil && challenge != nil {
+				challenges = []*mpp.Challenge{challenge}
+			}
+		}
+	}
+	if len(challenges) == 0 {
+		var collectErr error
+		challenges, collectErr = collectComposeChallenges(r.Context(), entries, body, scope)
+		if collectErr != nil {
 			WritePaymentError(w, err)
 			return
 		}
-		if result.Challenge != nil {
-			challenges = append(challenges, result.Challenge)
+	}
+	writeComposeChallengeResponse(w, challenges, realm, err)
+}
+
+func writeComposeChallengeResponse(w http.ResponseWriter, challenges []*mpp.Challenge, realm string, err error) {
+	for _, challenge := range challenges {
+		header, headerErr := challenge.ToAuthenticateStrict(realm)
+		if headerErr != nil {
+			WritePaymentError(w, mpp.ErrBadRequest(headerErr.Error()))
+			return
 		}
+		w.Header().Add("WWW-Authenticate", header)
 	}
 
-	if len(challenges) == 0 {
-		WritePaymentError(w, mpp.ErrBadRequest("no challenges could be generated"))
+	if err != nil {
+		WritePaymentError(w, err)
 		return
 	}
 
-	var headers []string
-	for _, challenge := range challenges {
-		header, err := challenge.ToAuthenticateStrict(realm)
-		if err != nil {
-			WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
-			return
-		}
-		headers = append(headers, header)
-	}
-
-	for _, header := range headers {
-		w.Header().Add("WWW-Authenticate", header)
-	}
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusPaymentRequired)
 
 	problem := mpp.ErrPaymentRequired(realm, "")
 	json.NewEncoder(w).Encode(problem.ProblemDetails(""))
+}
+
+func isMalformedCredential(err error) bool {
+	pe, ok := err.(*mpp.PaymentError)
+	return ok && pe.Type == mpp.ErrorTypeMalformedCredential
+}
+
+func findEntryByMethodIntent(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool) {
+	for _, entry := range entries {
+		method := entry.mpp.method
+		if cred.Challenge.Method != method.Name() {
+			continue
+		}
+		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
+			continue
+		}
+		return entry, true
+	}
+	return composedEntry{}, false
 }
 
 // findMatchingEntry selects the entry whose method, intent, and canonical

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -187,11 +187,12 @@ func writeComposeMalformedCredentialError(
 ) {
 	var challenges []*mpp.Challenge
 	if cred != nil {
-		if entry, ok := findEntryByMethodIntent(entries, cred); ok {
+		for _, entry := range findEntriesByMethodIntent(entries, cred) {
 			challenge, chErr := freshComposeChallenge(r.Context(), entry, body, scope)
-			if chErr == nil && challenge != nil {
-				challenges = []*mpp.Challenge{challenge}
+			if chErr != nil || challenge == nil {
+				continue
 			}
+			challenges = append(challenges, challenge)
 		}
 	}
 	if len(challenges) == 0 {
@@ -206,12 +207,18 @@ func writeComposeMalformedCredentialError(
 }
 
 func writeComposeChallengeResponse(w http.ResponseWriter, challenges []*mpp.Challenge, realm string, err error) {
+	// Serialize every challenge before writing headers so a later
+	// ToAuthenticateStrict failure cannot leave a partial usable set.
+	headers := make([]string, 0, len(challenges))
 	for _, challenge := range challenges {
 		header, headerErr := challenge.ToAuthenticateStrict(realm)
 		if headerErr != nil {
 			WritePaymentError(w, mpp.ErrBadRequest(headerErr.Error()))
 			return
 		}
+		headers = append(headers, header)
+	}
+	for _, header := range headers {
 		w.Header().Add(mpp.HeaderWWWAuthenticate, header)
 	}
 
@@ -233,7 +240,12 @@ func isMalformedCredential(err error) bool {
 	return ok && pe.Type == mpp.ErrorTypeMalformedCredential
 }
 
-func findEntryByMethodIntent(entries []composedEntry, cred *mpp.Credential) (composedEntry, bool) {
+// findEntriesByMethodIntent returns every compose entry whose method and intent
+// match the credential. Multiple configs can share method+intent while differing
+// by amount, currency, or opaque metadata; reissue all of them so the client can
+// retry the option it originally selected.
+func findEntriesByMethodIntent(entries []composedEntry, cred *mpp.Credential) []composedEntry {
+	var matched []composedEntry
 	for _, entry := range entries {
 		method := entry.mpp.method
 		if cred.Challenge.Method != method.Name() {
@@ -242,9 +254,9 @@ func findEntryByMethodIntent(entries []composedEntry, cred *mpp.Credential) (com
 		if _, ok := method.Intents()[cred.Challenge.Intent]; !ok {
 			continue
 		}
-		return entry, true
+		matched = append(matched, entry)
 	}
-	return composedEntry{}, false
+	return matched
 }
 
 // findMatchingEntry selects the entry whose method, intent, and canonical

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -562,6 +562,56 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 		return
 	}
 
+	if !assert.NotEmpty(t, paid.Header.Values("WWW-Authenticate"),
+		"expected fresh WWW-Authenticate challenge on malformed credential") {
+		return
+	}
+
+}
+
+func TestComposeMiddleware_ReturnsFreshChallengeForUnparseableCredential(t *testing.T) {
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if !assert.NoErrorf(t, err,
+		"http.NewRequest() error = %v", err) {
+		return
+	}
+	req.Header.Set("Authorization", "Payment !!!not-valid-base64!!!")
+
+	resp, err := http.DefaultClient.Do(req)
+	if !assert.NoErrorf(t, err,
+		"Do() error = %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	if !assert.Equalf(t, http.StatusPaymentRequired, resp.StatusCode,
+		"status = %d, want %d", resp.StatusCode, http.StatusPaymentRequired) {
+		return
+	}
+
+	wwwAuth := resp.Header.Values("WWW-Authenticate")
+	if !assert.Lenf(t, wwwAuth, 2,
+		"got %d WWW-Authenticate headers, want 2 fresh compose challenges", len(wwwAuth)) {
+		return
+	}
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		assert.Failf(t, "", "Decode(problem) error = %v", err)
+		return
+	}
+	assert.Equal(t, string(mpp.ErrorTypeMalformedCredential), problem.Type)
 }
 
 func TestComposeMiddleware_SingleMethod(t *testing.T) {

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -562,11 +562,94 @@ func TestComposeMiddleware_ReturnsMalformedCredentialForInvalidEchoedRequest(t *
 		return
 	}
 
-	if !assert.NotEmpty(t, paid.Header.Values("WWW-Authenticate"),
+	if !assert.NotEmpty(t, paid.Header.Values(mpp.HeaderWWWAuthenticate),
 		"expected fresh WWW-Authenticate challenge on malformed credential") {
 		return
 	}
 
+}
+
+func TestComposeMiddleware_ReissuesAllSameMethodChallengesForMalformedCredential(t *testing.T) {
+	// Same method+intent with different amounts: a malformed echoed request
+	// must reissue every matching option, not only the first compose entry.
+	methodCheap := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+	methodExpensive := newTestServer(t, composeTestMethod{name: "tempo"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodCheap, Params: ChargeParams{Amount: "0.01"}},
+		ComposeConfig{Mpp: methodExpensive, Params: ChargeParams{Amount: "10.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	var expensiveChallenge *mpp.Challenge
+	for _, h := range resp.Header.Values(mpp.HeaderWWWAuthenticate) {
+		c, err := mpp.ParseChallenge(h)
+		if !assert.NoErrorf(t, err, "ParseChallenge() error = %v", err) {
+			resp.Body.Close()
+			return
+		}
+		if amt, ok := c.Request["amount"]; ok && amt == "10.00" {
+			expensiveChallenge = c
+			break
+		}
+	}
+	resp.Body.Close()
+	if !assert.NotNil(t, expensiveChallenge, "did not find the 10.00 amount challenge") {
+		return
+	}
+
+	credential := &mpp.Credential{
+		Challenge: expensiveChallenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc"},
+	}
+	credential.Challenge.Request = "%%%"
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if !assert.NoErrorf(t, err, "http.NewRequest() error = %v", err) {
+		return
+	}
+	req.Header.Set("Authorization", credential.ToAuthorization())
+
+	paid, err := http.DefaultClient.Do(req)
+	if !assert.NoErrorf(t, err, "Do() error = %v", err) {
+		return
+	}
+	defer paid.Body.Close()
+
+	if !assert.Equalf(t, http.StatusPaymentRequired, paid.StatusCode,
+		"status = %d, want %d", paid.StatusCode, http.StatusPaymentRequired) {
+		return
+	}
+
+	wwwAuth := paid.Header.Values(mpp.HeaderWWWAuthenticate)
+	if !assert.Lenf(t, wwwAuth, 2,
+		"got %d WWW-Authenticate headers, want both tempo amount options", len(wwwAuth)) {
+		return
+	}
+
+	amounts := map[string]bool{}
+	for _, h := range wwwAuth {
+		c, err := mpp.ParseChallenge(h)
+		if !assert.NoErrorf(t, err, "ParseChallenge() error = %v", err) {
+			return
+		}
+		assert.Equal(t, "tempo", c.Method)
+		if amt, ok := c.Request["amount"].(string); ok {
+			amounts[amt] = true
+		}
+	}
+	assert.True(t, amounts["0.01"], "missing 0.01 challenge")
+	assert.True(t, amounts["10.00"], "missing 10.00 challenge")
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(paid.Body).Decode(&problem); err != nil {
+		assert.Failf(t, "", "Decode(problem) error = %v", err)
+		return
+	}
+	assert.Equal(t, string(mpp.ErrorTypeMalformedCredential), problem.Type)
 }
 
 func TestComposeMiddleware_ReturnsFreshChallengeForUnparseableCredential(t *testing.T) {
@@ -672,6 +755,41 @@ func TestComposeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Empty(t, resp.Header.Values("WWW-Authenticate"))
+
+	var problem struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&problem))
+	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
+}
+
+func TestComposeMiddleware_DoesNotWritePartialChallengesOnSerializeFailure(t *testing.T) {
+	// A later challenge that fails strict serialization must not leave earlier
+	// WWW-Authenticate headers already written on the response.
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret)
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret)
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{
+			Mpp: methodB,
+			Params: ChargeParams{
+				Amount:      "2.00",
+				Description: "Line one\r\nLine two",
+			},
+		},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if !assert.NoErrorf(t, err, "http.Get() error = %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Empty(t, resp.Header.Values(mpp.HeaderWWWAuthenticate),
+		"partial WWW-Authenticate headers must not be written before serialize failure")
 
 	var problem struct {
 		Type string `json:"type"`


### PR DESCRIPTION
## Summary

- Return fresh `WWW-Authenticate` challenges from `ComposeMiddleware` when a Payment credential is malformed.
- Fan out all compose challenges when `ParseCredential` fails.
- Reissue a matching entry challenge when the echoed request is invalid but method/intent are known.
- Align compose retry UX with `ChargeMiddleware` and `VerifyOrChallenge`.

## Context

Previously, compose routes returned only a problem+json error for malformed credentials, while the standard charge path returned a fresh retry challenge. Wallet clients had no challenge to retry against on compose-protected routes.

## Test plan

- [x] `go test ./pkg/server/... -run Compose`
- [x] `go test ./...`