### PR TITLE
fix(client): match challenges on intent, not just method

### DIFF
--- a/.changelog/client-intent-aware-challenge-selection.md
+++ b/.changelog/client-intent-aware-challenge-selection.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Match client challenges on intent as well as method. The transport selected the first challenge sharing a method token, so when a server offered the same method under several intents (the core spec's intent negotiation example), it committed to an unsupported intent and failed the request instead of paying a challenge it could settle. Methods may now declare their intents via the optional `client.IntentMethod` interface, which the built-in Tempo client method implements; methods that do not implement it keep matching on the method token alone.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,23 @@ type Method interface {
 	CreateCredential(ctx context.Context, challenge *mpp.Challenge) (*mpp.Credential, error)
 }
 
+// IntentMethod is an optional interface a Method may implement to declare the
+// payment intents it can build credentials for.
+//
+// A server may offer the same method under several intents, and the core spec
+// requires that clients "that do not recognize an intent SHOULD treat the
+// challenge as unsupported". The transport consults this interface to skip
+// such challenges and keep looking, instead of committing to the first
+// challenge that merely shares the method token.
+//
+// Methods that do not implement IntentMethod are treated as accepting any
+// intent, which preserves the behavior of existing implementations.
+type IntentMethod interface {
+	Method
+	// Intents returns the intent tokens this method supports (e.g., "charge").
+	Intents() []string
+}
+
 // Client is an HTTP client with automatic 402 payment handling.
 type Client struct {
 	methods    map[string]Method

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -69,7 +69,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				continue
 			}
 		}
-		if m, ok := t.methods[ch.Method]; ok {
+		if m, ok := t.methods[ch.Method]; ok && methodSupportsIntent(m, ch.Intent) {
 			matched = ch
 			method = m
 			break
@@ -174,6 +174,23 @@ func requestOrigin(requestURL *url.URL) string {
 
 func sameOriginURL(requestURL *url.URL, origin string) bool {
 	return requestOrigin(requestURL) == origin
+}
+
+// methodSupportsIntent reports whether method can build a credential for the
+// given challenge intent. Methods that do not declare their intents via
+// IntentMethod are assumed to accept any intent, so existing implementations
+// keep their current behavior.
+func methodSupportsIntent(method Method, intent string) bool {
+	declaring, ok := method.(IntentMethod)
+	if !ok {
+		return true
+	}
+	for _, supported := range declaring.Intents() {
+		if supported == intent {
+			return true
+		}
+	}
+	return false
 }
 
 func validatePaymentOrigin(req *http.Request, challenge *mpp.Challenge) error {

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -549,4 +550,155 @@ func TestClient_Do_RejectsCrossOriginRedirect(t *testing.T) {
 		return
 	}
 
+}
+
+// intentMockMethod implements Method and reports the intents it supports.
+type intentMockMethod struct {
+	mockMethod
+	intents []string
+	seen    []string
+}
+
+func (m *intentMockMethod) Intents() []string { return m.intents }
+
+func (m *intentMockMethod) CreateCredential(ctx context.Context, ch *mpp.Challenge) (*mpp.Credential, error) {
+	m.seen = append(m.seen, ch.Intent)
+	return m.mockMethod.CreateCredential(ctx, ch)
+}
+
+// TestTransport_RoundTrip_SkipsUnsupportedIntent covers the intent negotiation
+// example from the core spec: a server offering the same method under two
+// intents. A client that does not recognize an intent must treat that
+// challenge as unsupported rather than paying it with the wrong intent's
+// credential.
+func TestTransport_RoundTrip_SkipsUnsupportedIntent(t *testing.T) {
+	var authorizeCh, chargeCh *mpp.Challenge
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			// Unsupported intent is advertised first, so a client that
+			// matches on method alone picks it.
+			w.Header().Add("WWW-Authenticate", authorizeCh.ToAuthenticate(authorizeCh.Realm))
+			w.Header().Add("WWW-Authenticate", chargeCh.ToAuthenticate(chargeCh.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := urlpkg.Parse(srv.URL)
+	if !assert.NoErrorf(t, err, "url.Parse(%q) error = %v", srv.URL, err) {
+		return
+	}
+	authorizeCh = mpp.NewChallenge("secret", parsedURL.Host, "example", "authorize", nil)
+	chargeCh = mpp.NewChallenge("secret", parsedURL.Host, "example", "charge", nil)
+
+	method := &intentMockMethod{
+		mockMethod: mockMethod{name: "example", cred: newTestCredential("example")},
+		intents:    []string{"charge"},
+	}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	assert.Equalf(t, []string{"charge"}, method.seen,
+		"client paid the wrong intent: built credentials for %v, want only [charge]", method.seen)
+}
+
+// strictIntentMethod mirrors the built-in Tempo client method, which rejects
+// challenges carrying an intent it cannot settle.
+type strictIntentMethod struct {
+	intentMockMethod
+}
+
+func (m *strictIntentMethod) CreateCredential(ctx context.Context, ch *mpp.Challenge) (*mpp.Credential, error) {
+	if ch.Intent != "charge" {
+		return nil, fmt.Errorf("unsupported challenge intent %q", ch.Intent)
+	}
+	return m.intentMockMethod.CreateCredential(ctx, ch)
+}
+
+// TestTransport_RoundTrip_UnsupportedIntentFirstStillPays is the user-visible
+// consequence of matching on the method token alone: the transport committed
+// to the unsupported challenge, CreateCredential rejected it, and RoundTrip
+// failed the whole request even though the server also offered a challenge the
+// method could settle.
+func TestTransport_RoundTrip_UnsupportedIntentFirstStillPays(t *testing.T) {
+	var authorizeCh, chargeCh *mpp.Challenge
+	paid := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Add("WWW-Authenticate", authorizeCh.ToAuthenticate(authorizeCh.Realm))
+			w.Header().Add("WWW-Authenticate", chargeCh.ToAuthenticate(chargeCh.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		paid = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := urlpkg.Parse(srv.URL)
+	if !assert.NoErrorf(t, err, "url.Parse(%q) error = %v", srv.URL, err) {
+		return
+	}
+	authorizeCh = mpp.NewChallenge("secret", parsedURL.Host, "example", "authorize", nil)
+	chargeCh = mpp.NewChallenge("secret", parsedURL.Host, "example", "charge", nil)
+
+	method := &strictIntentMethod{intentMockMethod{
+		mockMethod: mockMethod{name: "example", cred: newTestCredential("example")},
+		intents:    []string{"charge"},
+	}}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"request failed even though a payable challenge was offered: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	assert.Equalf(t, http.StatusOK, resp.StatusCode, "expected 200, got %d", resp.StatusCode)
+	assert.Truef(t, paid, "server never received the payment credential")
+}
+
+// TestTransport_RoundTrip_MethodWithoutIntentsAcceptsAny pins the compatibility
+// contract: a Method that does not implement IntentMethod keeps matching on the
+// method token alone.
+func TestTransport_RoundTrip_MethodWithoutIntentsAcceptsAny(t *testing.T) {
+	var challenge *mpp.Challenge
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := urlpkg.Parse(srv.URL)
+	if !assert.NoErrorf(t, err, "url.Parse(%q) error = %v", srv.URL, err) {
+		return
+	}
+	challenge = mpp.NewChallenge("secret", parsedURL.Host, "example", "some-new-intent", nil)
+
+	method := &mockMethod{name: "example", cred: newTestCredential("example")}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err, "unexpected error: %v", err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	assert.Equalf(t, 1, method.calls,
+		"method without declared intents should still be used, calls = %d", method.calls)
 }

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -50,6 +50,7 @@ type Method struct {
 }
 
 var _ mppclient.Method = (*Method)(nil)
+var _ mppclient.IntentMethod = (*Method)(nil)
 
 // New constructs a Tempo charge client method.
 func New(config Config) (*Method, error) {
@@ -84,6 +85,13 @@ func New(config Config) (*Method, error) {
 // Name returns the method token used in Challenges and Credentials.
 func (m *Method) Name() string {
 	return tempo.MethodName
+}
+
+// Intents returns the challenge intents this method can build credentials for.
+// It implements client.IntentMethod so the transport skips Tempo challenges
+// carrying another intent rather than failing the request on them.
+func (m *Method) Intents() []string {
+	return []string{tempo.IntentCharge}
 }
 
 // CreateCredential turns a Tempo charge Challenge into a Tempo Credential.


### PR DESCRIPTION
The client transport selects the first challenge whose **method token** is configured, ignoring the challenge **intent** ([`pkg/client/transport.go:72`](https://github.com/tempoxyz/mpp-go/blob/main/pkg/client/transport.go#L72)):

```go
if m, ok := t.methods[ch.Method]; ok {
```

The core spec's [Intent Negotiation](https://github.com/tempoxyz/mpp-specs/blob/main/specs/core/draft-httpauth-payment-00.md) section has a server offer the *same method* under two intents:

```http
WWW-Authenticate: Payment id="abc", ..., method="example", intent="charge", request="..."
WWW-Authenticate: Payment id="def", ..., method="example", intent="authorize", request="..."
```

and requires:

> Clients choose which challenge to respond to. Clients that do not recognize an intent SHOULD treat the challenge as unsupported.

Matching on the method alone commits to whichever challenge is listed first.

## Impact

**Built-in Tempo method — the request fails outright.** `CreateCredential` rejects a non-charge intent ([`pkg/tempo/client/method.go:94`](https://github.com/tempoxyz/mpp-go/blob/main/pkg/tempo/client/method.go#L94)) and `RoundTrip` turns that into an error, so a server offering `[tempo/authorize, tempo/charge]` gets **no payment at all**, even though the `charge` challenge is settleable:

```
mpp: creating credential for method "example": unsupported challenge intent "authorize"
```

**Third-party methods — the wrong intent gets paid.** The `client.Method` interface does not require an intent check, so a Method that does not re-check it itself will build a credential for an intent it never meant to settle.

Note the client never sends `Accept-Payment`, so the server cannot filter on the client's behalf either — this check is the only thing standing between the client and an unrecognized intent.

## Fix

Add an optional `client.IntentMethod` interface so a Method can declare the intents it supports, and consult it during selection.

Methods that do **not** implement it are treated as accepting any intent, so existing implementations are unaffected — I chose this over defaulting to `charge`-only because Go interfaces cannot be extended without breaking implementors, and silently narrowing third-party methods would be a regression. The built-in Tempo client method implements it and now skips non-charge challenges instead of failing on them.

## Cross-SDK consistency

This brings mpp-go in line with its siblings: mpp-rs already selects on `(method, intent)` via `PaymentProvider::supports(method, intent)`, and pympp does the same after tempoxyz/pympp#216 ("Challenge selection ignores the intent").

## Test plan

Three tests in `pkg/client/transport_test.go`, all reproducing the spec's two-intent example:

- `SkipsUnsupportedIntent` — without the fix: `built credentials for [authorize], want only [charge]`
- `UnsupportedIntentFirstStillPays` — without the fix: `request failed even though a payable challenge was offered: mpp: creating credential for method "example": unsupported challenge intent "authorize"`
- `MethodWithoutIntentsAcceptsAny` — compatibility guard; passes with and without the fix by design

Verified by reverting only the three production files and re-running: the first two fail, the third still passes. `make check` is clean and the full suite passes (13 packages).

---
🤖 Written with [Claude Code](https://claude.com/claude-code). Every claim above was verified against a local build and test run; the red/green proof is reproducible by reverting `pkg/client/client.go`, `pkg/client/transport.go` and `pkg/tempo/client/method.go`.