### PR TITLE
fix(tempo/server): support Tempo CLI keychain fee payer credentials

### DIFF
--- a/.changelog/fix-tempo-cli-keychain.md
+++ b/.changelog/fix-tempo-cli-keychain.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Accept Tempo CLI fee-payer credentials signed by keychain access keys.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@c5dde8faa684b79e2df665143cf7cd731608c079
     with:
       protocol-paths: |
         pkg/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@c5dde8faa684b79e2df665143cf7cd731608c079
     with:
       adapter: go
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	"github.com/tempoxyz/tempo-go/pkg/keychain"
@@ -254,7 +255,7 @@ func (i *Intent) verifyTransaction(
 	raw string,
 	source *sourceDID,
 ) (*mpp.Receipt, error) {
-	tx, err := tempotx.Deserialize(raw)
+	tx, feePayerForm, err := deserializeTransactionCredential(raw)
 	if err != nil {
 		return nil, mpp.ErrInvalidPayload("failed to deserialize transaction payload")
 	}
@@ -262,7 +263,7 @@ func (i *Intent) verifyTransaction(
 		return nil, mpp.ErrInvalidPayload("transaction does not contain a matching Tempo transfer")
 	}
 
-	sender, err := tempotx.VerifySignature(tx)
+	sender, err := verifyTransactionSender(tx)
 	if err != nil {
 		return nil, mpp.ErrInvalidPayload("transaction signature is invalid")
 	}
@@ -289,8 +290,12 @@ func (i *Intent) verifyTransaction(
 		if tx.NonceKey == nil || tx.NonceKey.Cmp(tempo.ExpiringNonceKey) != 0 {
 			return nil, mpp.ErrInvalidPayload("fee payer transaction must use the expiring nonce key")
 		}
-		if tx.FeeToken != (common.Address{}) {
+		requestFeeToken := common.HexToAddress(request.Currency)
+		if !feePayerForm && tx.FeeToken != (common.Address{}) {
 			return nil, mpp.ErrInvalidPayload("fee payer transaction must omit fee token before co-signing")
+		}
+		if feePayerForm && tx.FeeToken != (common.Address{}) && tx.FeeToken != requestFeeToken {
+			return nil, mpp.ErrInvalidPayload("fee payer transaction fee token does not match the charge request")
 		}
 		accepted, err := i.store.PutIfAbsent(
 			ctx,
@@ -305,7 +310,7 @@ func (i *Intent) verifyTransaction(
 		}
 		if i.feePayerSigner != nil {
 			tx.From = sender
-			tx.FeeToken = common.HexToAddress(request.Currency)
+			tx.FeeToken = requestFeeToken
 			tx.AwaitingFeePayer = false
 			if err := tempotx.AddFeePayerSignature(tx, i.feePayerSigner); err != nil {
 				return nil, mpp.ErrVerificationFailed("failed to co-sign fee payer transaction")
@@ -331,15 +336,18 @@ func (i *Intent) verifyTransaction(
 		if tx.AwaitingFeePayer {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction must clear the awaiting fee payer marker")
 		}
-		if tx.FeeToken != common.HexToAddress(request.Currency) {
+		if tx.FeeToken != requestFeeToken {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction fee token does not match the charge request")
 		}
-		coSignedSender, _, err := tempotx.VerifyDualSignatures(tx)
+		coSignedSender, err := verifyTransactionSender(tx)
 		if err != nil {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
 		}
 		if coSignedSender != sender {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction sender does not match the credential signer")
+		}
+		if _, err := tempotx.VerifyFeePayerSignature(tx, coSignedSender); err != nil {
+			return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
 		}
 		tx.From = coSignedSender
 		if err := simulateTransactionPreflight(ctx, rpc, tx); err != nil {
@@ -422,13 +430,125 @@ func (i *Intent) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, error
 	return tempo.NewRPCClient(tempo.DefaultRPCURLForChain(0)), nil
 }
 
+// deserializeTransactionCredential accepts both the broadcast transaction
+// envelope (0x76) and the fee-payer signing form (0x78). tempo-go v0.5 only
+// decodes 0x76, so the 0x78 body is validated and converted to the equivalent
+// awaiting-fee-payer shape before delegating the remaining decoding.
+func deserializeTransactionCredential(serialized string) (*tempotx.Tx, bool, error) {
+	hexValue := serialized
+	if strings.HasPrefix(hexValue, "0x") || strings.HasPrefix(hexValue, "0X") {
+		hexValue = hexValue[2:]
+	}
+	encoded, err := hex.DecodeString(hexValue)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode transaction: %w", err)
+	}
+	if len(encoded) < 2 {
+		return nil, false, fmt.Errorf("transaction is too short")
+	}
+
+	switch encoded[0] {
+	case 0x76:
+		tx, err := tempotx.Deserialize("0x" + hex.EncodeToString(encoded))
+		return tx, false, err
+	case 0x78:
+		var fields []rlp.RawValue
+		if err := rlp.DecodeBytes(encoded[1:], &fields); err != nil {
+			return nil, false, fmt.Errorf("decode fee-payer transaction body: %w", err)
+		}
+		if len(fields) != 13 && len(fields) != 14 && len(fields) != 15 {
+			return nil, false, fmt.Errorf("invalid fee-payer transaction field count %d", len(fields))
+		}
+
+		var senderBytes []byte
+		if err := rlp.DecodeBytes(fields[11], &senderBytes); err != nil {
+			return nil, false, fmt.Errorf("decode fee-payer transaction sender: %w", err)
+		}
+		if len(senderBytes) != common.AddressLength {
+			return nil, false, fmt.Errorf("invalid fee-payer transaction sender length %d", len(senderBytes))
+		}
+		sender := common.BytesToAddress(senderBytes)
+		if sender == (common.Address{}) {
+			return nil, false, fmt.Errorf("fee-payer transaction sender is required")
+		}
+
+		awaitingFeePayer, err := rlp.EncodeToBytes([]byte{0})
+		if err != nil {
+			return nil, false, fmt.Errorf("encode fee-payer marker: %w", err)
+		}
+		fields[11] = awaitingFeePayer
+		body, err := rlp.EncodeToBytes(fields)
+		if err != nil {
+			return nil, false, fmt.Errorf("encode transaction body: %w", err)
+		}
+
+		tx, err := tempotx.Deserialize("0x76" + hex.EncodeToString(body))
+		if err != nil {
+			return nil, false, err
+		}
+		tx.AwaitingFeePayer = true
+		tx.From = sender
+		return tx, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported transaction prefix 0x%02x", encoded[0])
+	}
+}
+
+// verifyTransactionSender verifies a transaction's sender signature and
+// returns the authorizing account. Keychain signatures are made by an access
+// key but authorize the root account embedded in the envelope.
+func verifyTransactionSender(tx *tempotx.Tx) (common.Address, error) {
+	if tx.Signature == nil {
+		return common.Address{}, fmt.Errorf("transaction has no sender signature")
+	}
+
+	if tx.Signature.Type != "keychain" {
+		sender, err := tempotx.VerifySignature(tx)
+		if err != nil {
+			return common.Address{}, err
+		}
+		if tx.From != (common.Address{}) && tx.From != sender {
+			return common.Address{}, fmt.Errorf("transaction sender does not match signature")
+		}
+		return sender, nil
+	}
+
+	_, rootAccount, innerSignature, err := keychain.ParseKeychainSignature(tx.Signature.Raw)
+	if err != nil {
+		return common.Address{}, err
+	}
+	switch innerSignature.YParity {
+	case 0, 1:
+	case 27, 28:
+		innerSignature.YParity -= 27
+	default:
+		return common.Address{}, fmt.Errorf("invalid keychain signature y parity %d", innerSignature.YParity)
+	}
+
+	txForVerify := *tx
+	signatureForVerify := *tx.Signature
+	signatureForVerify.Raw = keychain.BuildKeychainSignature(innerSignature, rootAccount)
+	txForVerify.Signature = &signatureForVerify
+	_, verifiedRoot, err := keychain.VerifyAccessKeySignature(&txForVerify)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if verifiedRoot != rootAccount {
+		return common.Address{}, fmt.Errorf("keychain signature root account mismatch")
+	}
+	if tx.From != (common.Address{}) && tx.From != rootAccount {
+		return common.Address{}, fmt.Errorf("transaction sender does not match keychain root account")
+	}
+	return rootAccount, nil
+}
+
 // TODO(tempo-go): extract the Tempo transaction/receipt matching and fee-payer
 // verification helpers below once tempo-go exposes a shared verifier surface for
 // TIP-20 charge flows.
 
 func transactionMatches(tx *tempotx.Tx, request tempo.ChargeRequest, realm, challengeID string) bool {
 	expected := expectedTransfers(request)
-	if len(tx.Calls) != len(expected) || len(tx.AccessList) != 0 || tx.KeyAuthorization != nil {
+	if len(tx.Calls) != len(expected) || len(tx.AccessList) != 0 {
 		return false
 	}
 	actual := make([]decodedTransfer, 0, len(tx.Calls))

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	"github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	"github.com/tempoxyz/mpp-go/pkg/tempo/client"
 	temporpc "github.com/tempoxyz/tempo-go/pkg/client"
@@ -28,7 +29,9 @@ const (
 	// testPrivateKey is the fixed payer key used across Tempo charge tests.
 	testPrivateKey = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 	// feePayerKey is the co-signer key used for sponsored-transaction tests.
-	feePayerKey     = "0xdd83cd66cd98801a07e0b7c1a5b02364b369e696da7c0ab444acffea5cca86fc"
+	feePayerKey = "0xdd83cd66cd98801a07e0b7c1a5b02364b369e696da7c0ab444acffea5cca86fc"
+	// accessKey is a deterministic test-only key authorized by testPrivateKey.
+	accessKey       = "0x0000000000000000000000000000000000000000000000000000000000000003"
 	testCurrency    = "0x20c0000000000000000000000000000000000001"
 	testRecipient   = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
 	testRealm       = "api.example.com"
@@ -304,6 +307,238 @@ func TestChargeFlow_FeePayerTransactionViaRemoteSignerRejectsTamperedFeeToken(t 
 		return
 	}
 
+}
+
+func TestChargeHTTPFlow_KeychainFeePayerSigningForm(t *testing.T) {
+	cases := []struct {
+		name          string
+		legacyYParity bool
+	}{
+		{name: "canonical y parity"},
+		{name: "legacy y parity", legacyYParity: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			request := buildRequest(t, true, nil)
+			rpc := newMockRPC(request)
+
+			rootSigner, err := temposigner.NewSigner(testPrivateKey)
+			if err != nil {
+				t.Fatalf("NewSigner(root) error = %v", err)
+			}
+			feePayerSigner, err := temposigner.NewSigner(feePayerKey)
+			if err != nil {
+				t.Fatalf("NewSigner(fee payer) error = %v", err)
+			}
+
+			rpc.onSend = func(raw string) (string, map[string]any, error) {
+				broadcast, err := tempotx.Deserialize(raw)
+				if err != nil {
+					return "", nil, err
+				}
+				if broadcast.Signature == nil || broadcast.Signature.Type != "keychain" {
+					return "", nil, fmt.Errorf("broadcast signature = %#v, want keychain", broadcast.Signature)
+				}
+				if broadcast.KeyAuthorization == nil {
+					return "", nil, fmt.Errorf("broadcast omitted key authorization")
+				}
+				if broadcast.FeeToken != common.HexToAddress(request.Currency) {
+					return "", nil, fmt.Errorf("broadcast fee token = %s, want %s", broadcast.FeeToken.Hex(), request.Currency)
+				}
+				gotParity := broadcast.Signature.Raw[keychain.KeychainSignatureLength-1]
+				if tc.legacyYParity && gotParity != 27 && gotParity != 28 {
+					return "", nil, fmt.Errorf("broadcast y parity = %d, want unmodified legacy parity", gotParity)
+				}
+				if !tc.legacyYParity && gotParity != 0 && gotParity != 1 {
+					return "", nil, fmt.Errorf("broadcast y parity = %d, want canonical parity", gotParity)
+				}
+				feePayer, err := tempotx.VerifyFeePayerSignature(broadcast, rootSigner.Address())
+				if err != nil {
+					return "", nil, err
+				}
+				if feePayer != feePayerSigner.Address() {
+					return "", nil, fmt.Errorf("broadcast fee payer = %s, want %s", feePayer.Hex(), feePayerSigner.Address().Hex())
+				}
+				return testReceiptHash, buildReceipt(raw, request, rootSigner.Address()), nil
+			}
+
+			intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+			if err != nil {
+				t.Fatalf("NewIntent() error = %v", err)
+			}
+			method := NewMethod(MethodConfig{
+				Intent:    intent,
+				Currency:  testCurrency,
+				Recipient: testRecipient,
+				ChainID:   42431,
+				FeePayer:  true,
+			})
+			payment, err := server.New(method, testRealm, "test-secret-key-at-least-32-bytes")
+			if err != nil {
+				t.Fatalf("server.New() error = %v", err)
+			}
+			handler := server.ChargeMiddleware(payment, server.ChargeParams{
+				Amount:   "0.50",
+				FeePayer: true,
+			})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			httpServer := httptest.NewServer(handler)
+			defer httpServer.Close()
+
+			challengeResponse, err := httpServer.Client().Get(httpServer.URL)
+			if err != nil {
+				t.Fatalf("GET challenge error = %v", err)
+			}
+			_ = challengeResponse.Body.Close()
+			if challengeResponse.StatusCode != http.StatusPaymentRequired {
+				t.Fatalf("challenge status = %d, want %d", challengeResponse.StatusCode, http.StatusPaymentRequired)
+			}
+			challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+			if err != nil {
+				t.Fatalf("ParseChallenge() error = %v", err)
+			}
+			credential := buildKeychainFeePayerCredential(t, rpc, challenge, keychainCredentialOptions{
+				legacyYParity: tc.legacyYParity,
+			})
+
+			paidRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL, nil)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext() error = %v", err)
+			}
+			paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+			paidResponse, err := httpServer.Client().Do(paidRequest)
+			if err != nil {
+				t.Fatalf("paid GET error = %v", err)
+			}
+			_ = paidResponse.Body.Close()
+			if paidResponse.StatusCode != http.StatusOK {
+				t.Fatalf("paid status = %d, want %d", paidResponse.StatusCode, http.StatusOK)
+			}
+			if _, err := mpp.ParseReceipt(paidResponse.Header.Get("Payment-Receipt")); err != nil {
+				t.Fatalf("ParseReceipt() error = %v", err)
+			}
+			if len(rpc.sentRawTxs) != 1 {
+				t.Fatalf("broadcast count = %d, want 1", len(rpc.sentRawTxs))
+			}
+		})
+	}
+}
+
+func TestChargeFlow_KeychainFeePayerSigningFormRejectsTampering(t *testing.T) {
+	cases := []struct {
+		name      string
+		options   keychainCredentialOptions
+		wantError string
+	}{
+		{
+			name:      "sender does not match keychain root",
+			options:   keychainCredentialOptions{sender: common.HexToAddress("0x1111111111111111111111111111111111111111")},
+			wantError: "transaction signature is invalid",
+		},
+		{
+			name:      "sender is zero address",
+			options:   keychainCredentialOptions{zeroSender: true},
+			wantError: "failed to deserialize transaction payload",
+		},
+		{
+			name:      "fee token does not match request",
+			options:   keychainCredentialOptions{feeToken: common.HexToAddress("0x20c0000000000000000000000000000000000002")},
+			wantError: "fee payer transaction fee token does not match the charge request",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := buildRequest(t, true, nil)
+			rpc := newMockRPC(request)
+			challenge := buildChallenge(t, request)
+			credential := buildKeychainFeePayerCredential(t, rpc, challenge, tc.options)
+			intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+			if err != nil {
+				t.Fatalf("NewIntent() error = %v", err)
+			}
+
+			_, err = intent.Verify(context.Background(), credential, request.Map())
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("Verify() error = %v, want %q", err, tc.wantError)
+			}
+			if len(rpc.sentRawTxs) != 0 {
+				t.Fatalf("broadcast count = %d, want 0", len(rpc.sentRawTxs))
+			}
+		})
+	}
+}
+
+type keychainCredentialOptions struct {
+	feeToken      common.Address
+	legacyYParity bool
+	sender        common.Address
+	zeroSender    bool
+}
+
+func buildKeychainFeePayerCredential(
+	t *testing.T,
+	rpc tempo.RPCClient,
+	challenge *mpp.Challenge,
+	options keychainCredentialOptions,
+) *mpp.Credential {
+	t.Helper()
+
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(context.Background(), challenge)
+	if err != nil {
+		t.Fatalf("CreateCredential() error = %v", err)
+	}
+	tx, err := tempotx.Deserialize(credential.Payload["signature"].(string))
+	if err != nil {
+		t.Fatalf("Deserialize(seed) error = %v", err)
+	}
+
+	rootSigner, err := temposigner.NewSigner(testPrivateKey)
+	if err != nil {
+		t.Fatalf("NewSigner(root) error = %v", err)
+	}
+	accessSigner, err := temposigner.NewSigner(accessKey)
+	if err != nil {
+		t.Fatalf("NewSigner(access) error = %v", err)
+	}
+	tx.Signature = nil
+	tx.From = common.Address{}
+	feeToken := options.feeToken
+	if feeToken == (common.Address{}) {
+		feeToken = common.HexToAddress(testCurrency)
+	}
+	tx.FeeToken = feeToken
+	authorization := keychain.NewKeyAuthorization(42431, keychain.SignatureTypeSecp256k1, accessSigner.Address()).
+		WithExpiry(uint64(time.Now().Add(5 * time.Minute).Unix()))
+	if err := authorization.SignAndAttach(tx, rootSigner); err != nil {
+		t.Fatalf("SignAndAttach() error = %v", err)
+	}
+	if err := keychain.SignWithAccessKey(tx, accessSigner, rootSigner.Address()); err != nil {
+		t.Fatalf("SignWithAccessKey() error = %v", err)
+	}
+	if options.legacyYParity {
+		tx.Signature.Raw[keychain.KeychainSignatureLength-1] += 27
+	}
+
+	sender := options.sender
+	if sender == (common.Address{}) && !options.zeroSender {
+		sender = rootSigner.Address()
+	}
+	serialized, err := tempotx.Serialize(tx, &tempotx.SerializeOptions{
+		Format: tempotx.FormatFeePayer,
+		Sender: sender,
+	})
+	if err != nil {
+		t.Fatalf("Serialize(FormatFeePayer) error = %v", err)
+	}
+	if !strings.HasPrefix(serialized, "0x78") {
+		t.Fatalf("serialized transaction prefix = %.4s, want 0x78", serialized)
+	}
+	credential.Payload["signature"] = serialized
+	return credential
 }
 
 func TestChargeFlow_ProofCredentialWithAccessKey(t *testing.T) {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	chargeclient "github.com/tempoxyz/mpp-go/pkg/tempo/client"
 	chargeserver "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+	"github.com/tempoxyz/tempo-go/pkg/keychain"
 	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
+	tempotx "github.com/tempoxyz/tempo-go/pkg/transaction"
 )
 
 const (
@@ -231,6 +233,72 @@ func TestIntegrationChargeFlow_LocalNodeFeePayer(t *testing.T) {
 		return
 	}
 
+}
+
+func TestIntegrationChargeFlow_LocalNodeKeychainFeePayerForm(t *testing.T) {
+	rpcURL := integrationRPCURL(t)
+	rpc := tempo.NewRPCClient(rpcURL)
+	ctx := context.Background()
+	chainID := waitForRPC(t, ctx, rpc)
+	rootSigner := newSigner(t)
+	accessSigner := newSigner(t)
+	feePayerSigner := newSigner(t)
+	fundAddress(t, ctx, rpc, rootSigner.Address())
+	fundAddress(t, ctx, rpc, feePayerSigner.Address())
+
+	httpServer := newPaidServer(t, rpcURL, chainID, feePayerSigner)
+	defer httpServer.Close()
+
+	challengeResponse, err := http.Get(httpServer.URL + "/paid-fee-payer")
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+
+	clientMethod, err := chargeclient.New(chargeclient.Config{
+		Signer:  rootSigner,
+		RPCURL:  rpcURL,
+		ChainID: int64(chainID),
+	})
+	require.NoError(t, err)
+	credential, err := clientMethod.CreateCredential(ctx, challenge)
+	require.NoError(t, err)
+	tx, err := tempotx.Deserialize(credential.Payload["signature"].(string))
+	require.NoError(t, err)
+
+	tx.Signature = nil
+	tx.From = common.Address{}
+	tx.FeeToken = common.HexToAddress(integrationCurrency)
+	tx.Gas = 1_000_000
+	authorization := keychain.NewKeyAuthorization(chainID, keychain.SignatureTypeSecp256k1, accessSigner.Address()).
+		WithExpiry(uint64(time.Now().Add(5 * time.Minute).Unix()))
+	require.NoError(t, authorization.SignAndAttach(tx, rootSigner))
+	require.NoError(t, keychain.SignWithAccessKey(tx, accessSigner, rootSigner.Address()))
+	// Tempo CLI 1.6 emits the inner recovery byte in legacy 27/28 form.
+	tx.Signature.Raw[keychain.KeychainSignatureLength-1] += 27
+	serialized, err := tempotx.Serialize(tx, &tempotx.SerializeOptions{
+		Format: tempotx.FormatFeePayer,
+		Sender: rootSigner.Address(),
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(serialized, "0x78"))
+	credential.Payload["signature"] = serialized
+
+	paidRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/paid-fee-payer", nil)
+	require.NoError(t, err)
+	paidRequest.Header.Set("Authorization", credential.ToAuthorization())
+	paidResponse, err := http.DefaultClient.Do(paidRequest)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	if paidResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(paidResponse.Body)
+		t.Fatalf("paid response status = %d, want %d: %s", paidResponse.StatusCode, http.StatusOK, body)
+	}
+	receipt, err := mpp.ParsePaymentReceipt(paidResponse.Header.Get("Payment-Receipt"))
+	require.NoError(t, err)
+	require.Equal(t, "success", receipt.Status)
+	require.NotEmpty(t, receipt.Reference)
 }
 
 func TestIntegrationChargeFlow_LocalNodeHashReplayProtected(t *testing.T) {


### PR DESCRIPTION
## Motivation

Tempo CLI 1.6+ submits sponsored transactions in the `0x78` fee-payer signing form and may sign them through a keychain access key. The server currently only decodes `0x76` transactions and verifies direct secp256k1 signatures, causing valid payments to fail.

## Summary

- decode and validate `0x78` fee-payer signing credentials
- verify keychain sender signatures with canonical or legacy recovery parity
- preserve key authorization and sender signature bytes when co-signing
- validate fee token and sender binding before sponsorship
- add HTTP-flow, tampering, and localnet coverage

## Key design considerations

- delegate the canonical transaction decoding to `tempo-go` after strictly adapting the unsupported `0x78` sender field
- verify sender and fee-payer signatures independently so keychain sender envelopes remain supported
- keep the original keychain signature bytes unchanged for broadcast compatibility