### PR TITLE
feat(tempo): expose native credential lifecycle

### DIFF
--- a/.changelog/tempo-native-lifecycle.md
+++ b/.changelog/tempo-native-lifecycle.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Expose public split-intent interfaces and support non-mutating validation with the built-in Tempo charge intent.

--- a/.changelog/tempo-native-lifecycle.md
+++ b/.changelog/tempo-native-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-github.com/tempoxyz/mpp-go: minor
+github.com/tempoxyz/mpp-go: patch
 ---
 
 Expose public split-intent interfaces and support non-mutating validation with the built-in Tempo charge intent.

--- a/README.md
+++ b/README.md
@@ -182,23 +182,25 @@ intent, err := server.NewIntent("charge", server.IntentHooks{
 })
 ```
 
-The constructed intent still satisfies the existing `server.Intent` interface;
-its `Verify` method calls `Validate` and then `Broadcast`. Servers can also run
-the phases independently:
+The constructed intent satisfies the public `server.BroadcastingIntent`
+interface as well as the backwards-compatible `server.Intent` interface. Custom
+intents can implement `server.ValidatingIntent` or `server.BroadcastingIntent`
+directly. Servers can run the phases independently:
 
 ```go
 validation, err := payment.ValidateCredential(ctx, credential)
 receipt, err := payment.BroadcastCredential(ctx, credential)
 ```
 
-`ValidateCredential` requires an intent constructed with split hooks and must
-not consume replay state, sign fee-payer transactions, or broadcast.
+`ValidateCredential` requires a `server.ValidatingIntent` and must not consume
+replay state, sign fee-payer transactions, or broadcast.
 `BroadcastCredential` re-validates before settlement. `VerifyCredential`
 remains an alias for the mutating broadcast path, and legacy intents that only
 implement `Verify` continue to work for paid routes and broadcasts.
 
-Tempo relay methods implement the split lifecycle by delegating validation to
-`POST /v1/mpp/validate` and finalization to `POST /v1/mpp/broadcast`.
+The built-in Tempo charge intent implements the split lifecycle locally. Tempo
+relay methods implement the same lifecycle by delegating validation to `POST
+/v1/mpp/validate` and finalization to `POST /v1/mpp/broadcast`.
 
 ## Web Frameworks
 

--- a/pkg/server/lifecycle.go
+++ b/pkg/server/lifecycle.go
@@ -17,7 +17,7 @@ func validateCredential(
 	request map[string]any,
 	method string,
 ) (*Validation, error) {
-	split, ok := intent.(*splitHookIntent)
+	validating, ok := intent.(ValidatingIntent)
 	if !ok {
 		err := mpp.ErrVerificationFailed(fmt.Sprintf(
 			"%s/%s does not support non-mutating credential validation",
@@ -27,7 +27,7 @@ func validateCredential(
 		err.Details = map[string]any{"intent": intent.Name(), "method": method}
 		return nil, err
 	}
-	return split.validate(ctx, credential, request)
+	return validating.Validate(ctx, credential, request)
 }
 
 // prepareCredential authenticates the echoed stateless challenge, enforces its

--- a/pkg/server/lifecycle.go
+++ b/pkg/server/lifecycle.go
@@ -30,6 +30,20 @@ func validateCredential(
 	return validating.Validate(ctx, credential, request)
 }
 
+// broadcastCredential dispatches the split lifecycle when available and keeps
+// legacy intents on their combined Verify path.
+func broadcastCredential(
+	ctx context.Context,
+	intent Intent,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if broadcasting, ok := intent.(BroadcastingIntent); ok {
+		return broadcasting.Broadcast(ctx, credential, request)
+	}
+	return intent.Verify(ctx, credential, request)
+}
+
 // prepareCredential authenticates the echoed stateless challenge, enforces its
 // server bindings and expiry, and resolves the intent request for dispatch.
 func (m *Mpp) prepareCredential(credential *mpp.Credential) (Intent, map[string]any, error) {

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -17,6 +17,54 @@ type splitTestIntent struct {
 	broadcastErr   error
 }
 
+type publicSplitTestIntent struct {
+	validateCalls  int
+	broadcastCalls int
+	verifyCalls    int
+}
+
+var _ BroadcastingIntent = (*publicSplitTestIntent)(nil)
+
+func (i *publicSplitTestIntent) Name() string { return "charge" }
+
+func (i *publicSplitTestIntent) Validate(
+	_ context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*Validation, error) {
+	i.validateCalls++
+	return &Validation{
+		Challenge:  credential.Challenge,
+		Credential: credential,
+		Details:    map[string]any{"implementation": "public"},
+		Intent:     i.Name(),
+		Method:     "tempo",
+		Request:    request,
+		Source:     credential.Source,
+	}, nil
+}
+
+func (i *publicSplitTestIntent) Broadcast(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if _, err := i.Validate(ctx, credential, request); err != nil {
+		return nil, err
+	}
+	i.broadcastCalls++
+	return mpp.Success("0xpublic", mpp.WithReceiptMethod("tempo")), nil
+}
+
+func (i *publicSplitTestIntent) Verify(
+	context.Context,
+	*mpp.Credential,
+	map[string]any,
+) (*mpp.Receipt, error) {
+	i.verifyCalls++
+	return mpp.Success("0xlegacy"), nil
+}
+
 func (i *splitTestIntent) Name() string { return "charge" }
 
 func (i *splitTestIntent) Validate(
@@ -120,6 +168,32 @@ func TestMppCredentialLifecycle(t *testing.T) {
 	assert.Equal(t, "0xsplit", receipt.Reference)
 	assert.Equal(t, 3, intent.validateCalls)
 	assert.Equal(t, 2, intent.broadcastCalls)
+}
+
+func TestMppCredentialLifecycleUsesPublicInterfaces(t *testing.T) {
+	t.Parallel()
+	intent := &publicSplitTestIntent{}
+	payment := newTestServer(t,
+		chargeTestMethod{intents: map[string]Intent{"charge": intent}},
+		"api.example.com",
+		"test-secret-key-minimum-32-byte-secret",
+	)
+	request := map[string]any{"amount": "1", "currency": "0x123"}
+	credential := splitCredential("test-secret-key-minimum-32-byte-secret", request)
+
+	validation, err := payment.ValidateCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, "public", validation.Details["implementation"])
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Zero(t, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+
+	receipt, err := payment.BroadcastCredential(context.Background(), credential)
+	require.NoError(t, err)
+	assert.Equal(t, "0xpublic", receipt.Reference)
+	assert.Equal(t, 2, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
 }
 
 func TestNewIntentSynthesizesVerify(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -215,10 +215,7 @@ func (m *Mpp) BroadcastCredential(ctx context.Context, credential *mpp.Credentia
 	if err != nil {
 		return nil, err
 	}
-	if broadcasting, ok := intent.(BroadcastingIntent); ok {
-		return broadcasting.Broadcast(ctx, credential, request)
-	}
-	return intent.Verify(ctx, credential, request)
+	return broadcastCredential(ctx, intent, credential, request)
 }
 
 // VerifyCredential is a backwards-compatible alias for BroadcastCredential.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,26 @@ type Intent interface {
 	Verify(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error)
 }
 
+// ValidatingIntent supports non-mutating credential validation.
+//
+// Validate must not consume replay state, sign transactions, broadcast, or
+// otherwise mutate payment state. Callers must use BroadcastCredential to
+// accept a payment after validation.
+type ValidatingIntent interface {
+	Intent
+	Validate(ctx context.Context, credential *mpp.Credential, request map[string]any) (*Validation, error)
+}
+
+// BroadcastingIntent supports a split validation and settlement lifecycle.
+//
+// Broadcast must revalidate the credential before performing its terminal
+// payment operation. Verify remains the compatibility path for callers that do
+// not use the split lifecycle explicitly.
+type BroadcastingIntent interface {
+	ValidatingIntent
+	Broadcast(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error)
+}
+
 // Validation describes a credential accepted without consuming or broadcasting it.
 type Validation struct {
 	// Challenge is the server-issued challenge echoed by the credential.
@@ -80,6 +100,8 @@ type splitHookIntent struct {
 	broadcast BroadcastFunc
 }
 
+var _ BroadcastingIntent = (*splitHookIntent)(nil)
+
 // NewIntent builds an Intent from either Verify or Validate and Broadcast hooks.
 func NewIntent(name string, hooks IntentHooks) (Intent, error) {
 	if name == "" {
@@ -106,15 +128,33 @@ func (i *verifyHookIntent) Verify(
 
 func (i *splitHookIntent) Name() string { return i.name }
 
+// Validate performs the configured non-mutating credential check.
+func (i *splitHookIntent) Validate(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*Validation, error) {
+	return i.validate(ctx, credential, request)
+}
+
+// Broadcast revalidates the credential before invoking the settlement hook.
+func (i *splitHookIntent) Broadcast(
+	ctx context.Context,
+	credential *mpp.Credential,
+	request map[string]any,
+) (*mpp.Receipt, error) {
+	if _, err := i.Validate(ctx, credential, request); err != nil {
+		return nil, err
+	}
+	return i.broadcast(ctx, credential, request)
+}
+
 func (i *splitHookIntent) Verify(
 	ctx context.Context,
 	credential *mpp.Credential,
 	request map[string]any,
 ) (*mpp.Receipt, error) {
-	if _, err := i.validate(ctx, credential, request); err != nil {
-		return nil, err
-	}
-	return i.broadcast(ctx, credential, request)
+	return i.Broadcast(ctx, credential, request)
 }
 
 // Method is the interface for server-side payment methods.
@@ -174,6 +214,9 @@ func (m *Mpp) BroadcastCredential(ctx context.Context, credential *mpp.Credentia
 	intent, request, err := m.prepareCredential(credential)
 	if err != nil {
 		return nil, err
+	}
+	if broadcasting, ok := intent.(BroadcastingIntent); ok {
+		return broadcasting.Broadcast(ctx, credential, request)
 	}
 	return intent.Verify(ctx, credential, request)
 }

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -188,8 +188,8 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		return challengeResultError(challenge, err)
 	}
 
-	// 9. Hook-built intents synthesize Verify from validation and broadcast.
-	receipt, err := params.Intent.Verify(ctx, credential, params.Request)
+	// 9. Dispatch split intents through Broadcast and legacy intents through Verify.
+	receipt, err := broadcastCredential(ctx, params.Intent, credential, params.Request)
 	if err != nil {
 		if pe, ok := err.(*mpp.PaymentError); ok {
 			if pe.Status != http.StatusPaymentRequired {

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -69,6 +69,42 @@ func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {
 
 }
 
+func TestVerifyOrChallenge_UsesPublicBroadcastingIntent(t *testing.T) {
+	request := map[string]any{"amount": "100", "currency": "0xabc", "recipient": "0xdef"}
+	challenge := mpp.NewChallenge(
+		"secret-key",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential := &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+	intent := &publicSplitTestIntent{}
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        intent,
+		Request:       request,
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+		Expires:       challenge.Expires,
+	})
+	if !assert.NoError(t, err) || !assert.NotNil(t, result) {
+		return
+	}
+	if assert.NotNil(t, result.Receipt) {
+		assert.Equal(t, "0xpublic", result.Receipt.Reference)
+	}
+	assert.Equal(t, 1, intent.validateCalls)
+	assert.Equal(t, 1, intent.broadcastCalls)
+	assert.Zero(t, intent.verifyCalls)
+}
+
 func TestVerifyOrChallenge_PreservesEmptyOpaqueMaps(t *testing.T) {
 	request := map[string]any{
 		"amount":    "100",

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -161,7 +161,7 @@ func (i *Intent) Validate(
 		Details:    details,
 		Intent:     tempo.IntentCharge,
 		Method:     tempo.MethodName,
-		Request:    validated.request.Map(),
+		Request:    requestMap,
 		Source:     credential.Source,
 	}, nil
 }
@@ -176,7 +176,9 @@ func validationTransferDetails(request tempo.ChargeRequest) []map[string]any {
 		}
 		if transfer.memo != "" {
 			detail["memo"] = transfer.memo
-		} else {
+		} else if transfer.requireAttribution {
+			detail["requireAttribution"] = true
+		} else if transfer.allowAnyMemo {
 			detail["allowAnyMemo"] = true
 		}
 		details = append(details, detail)
@@ -510,8 +512,12 @@ func (i *Intent) broadcastTransaction(
 		if err := simulateSponsoredTransactionExecution(ctx, rpc, tx, feePayerAddress); err != nil {
 			return nil, err
 		}
-	} else if err := simulateTransactionExecution(ctx, rpc, tx); err != nil {
-		return nil, err
+	} else {
+		// Match mppx's final pre-broadcast simulation to narrow the window in
+		// which account or contract state can change after validation.
+		if err := simulateTransactionExecution(ctx, rpc, tx); err != nil {
+			return nil, err
+		}
 	}
 	if err := validateChallengeExpiry(credential); err != nil {
 		return nil, err

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
+	mppserver "github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
 	"github.com/tempoxyz/tempo-go/pkg/keychain"
 	temposigner "github.com/tempoxyz/tempo-go/pkg/signer"
@@ -77,6 +78,17 @@ type Intent struct {
 	store          tempo.Store
 }
 
+var _ mppserver.BroadcastingIntent = (*Intent)(nil)
+
+type validatedChargeCredential struct {
+	payload tempo.ChargeCredentialPayload
+	request tempo.ChargeRequest
+	rpc     tempo.RPCClient
+	sender  common.Address
+	source  *sourceDID
+	tx      *tempotx.Tx
+}
+
 // NewIntent constructs a Tempo charge verifier.
 func NewIntent(config IntentConfig) (*Intent, error) {
 	feePayerPrivateKey := config.FeePayerPrivateKey
@@ -116,12 +128,92 @@ func (i *Intent) Name() string {
 	return tempo.IntentCharge
 }
 
-// Verify validates a Tempo charge Credential against the supplied request.
+// Validate checks a Tempo charge Credential without consuming replay state,
+// signing a sponsored transaction, or broadcasting.
+func (i *Intent) Validate(
+	ctx context.Context,
+	credential *mpp.Credential,
+	requestMap map[string]any,
+) (*mppserver.Validation, error) {
+	validated, err := i.validateCredential(ctx, credential, requestMap)
+	if err != nil {
+		return nil, err
+	}
+	mode := string(tempo.ChargeModePull)
+	if validated.payload.Type == tempo.CredentialTypeHash {
+		mode = string(tempo.ChargeModePush)
+	} else if validated.payload.Type == tempo.CredentialTypeProof {
+		mode = string(tempo.CredentialTypeProof)
+	}
+	details := map[string]any{"mode": mode}
+	if validated.sender != (common.Address{}) {
+		details["sender"] = validated.sender.Hex()
+	}
+	if validated.payload.Type == tempo.CredentialTypeHash || validated.payload.Type == tempo.CredentialTypeTransaction {
+		details["transfers"] = validationTransferDetails(validated.request)
+	}
+	if validated.payload.Type == tempo.CredentialTypeTransaction {
+		details["serializedTransaction"] = validated.payload.Signature
+	}
+	return &mppserver.Validation{
+		Challenge:  credential.Challenge,
+		Credential: credential,
+		Details:    details,
+		Intent:     tempo.IntentCharge,
+		Method:     tempo.MethodName,
+		Request:    validated.request.Map(),
+		Source:     credential.Source,
+	}, nil
+}
+
+func validationTransferDetails(request tempo.ChargeRequest) []map[string]any {
+	transfers := expectedTransfers(request)
+	details := make([]map[string]any, 0, len(transfers))
+	for _, transfer := range transfers {
+		detail := map[string]any{
+			"amount":    transfer.amount,
+			"recipient": transfer.recipient,
+		}
+		if transfer.memo != "" {
+			detail["memo"] = transfer.memo
+		} else {
+			detail["allowAnyMemo"] = true
+		}
+		details = append(details, detail)
+	}
+	return details
+}
+
+// Broadcast revalidates and settles a Tempo charge Credential.
+func (i *Intent) Broadcast(
+	ctx context.Context,
+	credential *mpp.Credential,
+	requestMap map[string]any,
+) (*mpp.Receipt, error) {
+	validated, err := i.validateCredential(ctx, credential, requestMap)
+	if err != nil {
+		return nil, err
+	}
+	return i.broadcastCredential(ctx, credential, validated)
+}
+
+// Verify is the backwards-compatible combined validation and broadcast path.
 func (i *Intent) Verify(
 	ctx context.Context,
 	credential *mpp.Credential,
 	requestMap map[string]any,
 ) (*mpp.Receipt, error) {
+	return i.Broadcast(ctx, credential, requestMap)
+}
+
+func (i *Intent) validateCredential(
+	ctx context.Context,
+	credential *mpp.Credential,
+	requestMap map[string]any,
+) (*validatedChargeCredential, error) {
+	if credential == nil {
+		return nil, mpp.ErrMalformedCredential("credential is required")
+	}
 	request, err := tempo.ParseChargeRequest(requestMap)
 	if err != nil {
 		return nil, mpp.ErrBadRequest(err.Error())
@@ -149,157 +241,210 @@ func (i *Intent) Verify(
 		return nil, err
 	}
 
+	validated := &validatedChargeCredential{
+		payload: payload,
+		request: request,
+		rpc:     rpc,
+		source:  source,
+	}
 	switch payload.Type {
 	case tempo.CredentialTypeHash:
-		return i.verifyHash(ctx, rpc, credential, request, payload.Hash, source)
+		if err := i.validateHash(ctx, credential, validated); err != nil {
+			return nil, err
+		}
 	case tempo.CredentialTypeProof:
-		return i.verifyProof(ctx, rpc, credential, request, payload.Signature, source)
+		if err := i.validateProof(ctx, credential, validated); err != nil {
+			return nil, err
+		}
 	case tempo.CredentialTypeTransaction:
-		return i.verifyTransaction(ctx, rpc, credential, request, payload.Signature, source)
+		if err := i.validateTransaction(ctx, credential, validated); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, mpp.ErrInvalidPayload(fmt.Sprintf("unsupported credential type %q", payload.Type))
 	}
+	return validated, nil
 }
 
-func (i *Intent) verifyHash(
+func (i *Intent) validateHash(
 	ctx context.Context,
-	rpc tempo.RPCClient,
 	credential *mpp.Credential,
-	request tempo.ChargeRequest,
-	hash string,
-	source *sourceDID,
-) (*mpp.Receipt, error) {
+	validated *validatedChargeCredential,
+) error {
+	request := validated.request
+	source := validated.source
 	if request.MethodDetails.Memo != "" {
-		return nil, mpp.ErrInvalidPayload("hash credentials are not supported when the primary transfer uses an explicit memo")
+		return mpp.ErrInvalidPayload("hash credentials are not supported when the primary transfer uses an explicit memo")
 	}
 	if source == nil {
-		return nil, mpp.ErrInvalidPayload("hash credential must include a source")
+		return mpp.ErrInvalidPayload("hash credential must include a source")
 	}
-	receiptMap, err := fetchReceipt(ctx, rpc, hash)
+	receiptMap, err := fetchReceipt(ctx, validated.rpc, validated.payload.Hash)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if !receiptMatches(receiptMap, credential, request, source.address) {
-		return nil, mpp.ErrVerificationFailed("transaction receipt does not satisfy the charge request")
+		return mpp.ErrVerificationFailed("transaction receipt does not satisfy the charge request")
 	}
-	accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeStoreKey(hash), hash)
-	if err != nil {
-		return nil, err
-	}
-	if !accepted {
-		return nil, mpp.ErrVerificationFailed("transaction hash already used")
-	}
-	return mpp.Success(
-		hash,
-		mpp.WithReceiptMethod(tempo.MethodName),
-		mpp.WithExternalID(request.ExternalID),
-	), nil
+	validated.sender = common.HexToAddress(source.address)
+	return nil
 }
 
-func (i *Intent) verifyProof(
+func (i *Intent) validateProof(
 	ctx context.Context,
-	rpc tempo.RPCClient,
 	credential *mpp.Credential,
-	request tempo.ChargeRequest,
-	signature string,
-	source *sourceDID,
-) (*mpp.Receipt, error) {
+	validated *validatedChargeCredential,
+) error {
+	request := validated.request
+	source := validated.source
 	if request.Amount != "0" {
-		return nil, mpp.ErrInvalidPayload("proof credentials are only valid for zero-amount challenges")
+		return mpp.ErrInvalidPayload("proof credentials are only valid for zero-amount challenges")
 	}
 	if source == nil {
-		return nil, mpp.ErrInvalidPayload("proof credential must include a source")
+		return mpp.ErrInvalidPayload("proof credential must include a source")
 	}
-	chainID, err := resolveChallengeChainID(ctx, rpc, request)
+	chainID, err := resolveChallengeChainID(ctx, validated.rpc, request)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if source.chainID != chainID {
-		return nil, mpp.ErrInvalidPayload("credential source chain id does not match the challenge")
+		return mpp.ErrInvalidPayload("credential source chain id does not match the challenge")
 	}
 	// Bind the digest to the claimed payer so a proof cannot be replayed
 	// against a different account (e.g. via a shared access key).
 	proofHash, err := tempo.ProofTypedDataHash(chainID, common.HexToAddress(source.address), credential.Challenge.ID, credential.Challenge.Realm)
 	if err != nil {
-		return nil, mpp.ErrVerificationFailed("failed to construct proof payload")
+		return mpp.ErrVerificationFailed("failed to construct proof payload")
 	}
-	proofSigner, err := recoverProofSigner(proofHash, signature, common.HexToAddress(source.address))
+	proofSigner, err := recoverProofSigner(proofHash, validated.payload.Signature, common.HexToAddress(source.address))
 	if err != nil {
-		return nil, mpp.ErrInvalidPayload("proof signature is invalid")
+		return mpp.ErrInvalidPayload("proof signature is invalid")
 	}
 	if !strings.EqualFold(proofSigner.Hex(), source.address) {
-		active, err := isActiveAccessKey(ctx, rpc, common.HexToAddress(source.address), proofSigner)
+		active, err := isActiveAccessKey(ctx, validated.rpc, common.HexToAddress(source.address), proofSigner)
 		if err != nil || !active {
-			return nil, mpp.ErrInvalidPayload("proof signature does not match source")
+			return mpp.ErrInvalidPayload("proof signature does not match source")
 		}
 	}
-	accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeProofStoreKey(credential.Challenge.ID), credential.Challenge.ID)
-	if err != nil {
-		return nil, err
-	}
-	if !accepted {
-		return nil, mpp.ErrVerificationFailed("proof credential already used")
-	}
-	return mpp.Success(
-		credential.Challenge.ID,
-		mpp.WithReceiptMethod(tempo.MethodName),
-		mpp.WithExternalID(request.ExternalID),
-	), nil
+	validated.sender = common.HexToAddress(source.address)
+	return nil
 }
 
-func (i *Intent) verifyTransaction(
+func (i *Intent) validateTransaction(
 	ctx context.Context,
-	rpc tempo.RPCClient,
 	credential *mpp.Credential,
-	request tempo.ChargeRequest,
-	raw string,
-	source *sourceDID,
-) (*mpp.Receipt, error) {
-	tx, feePayerForm, err := deserializeTransactionCredential(raw)
+	validated *validatedChargeCredential,
+) error {
+	request := validated.request
+	tx, feePayerForm, err := deserializeTransactionCredential(validated.payload.Signature)
 	if err != nil {
-		return nil, mpp.ErrInvalidPayload("failed to deserialize transaction payload")
+		return mpp.ErrInvalidPayload("failed to deserialize transaction payload")
 	}
 	if !transactionMatches(tx, request, credential.Challenge.Realm, credential.Challenge.ID) {
-		return nil, mpp.ErrInvalidPayload("transaction does not contain a matching Tempo transfer")
+		return mpp.ErrInvalidPayload("transaction does not contain a matching Tempo transfer")
 	}
 
 	sender, err := verifyTransactionSender(tx)
 	if err != nil {
-		return nil, mpp.ErrInvalidPayload("transaction signature is invalid")
+		return mpp.ErrInvalidPayload("transaction signature is invalid")
 	}
-	if source != nil && !strings.EqualFold(source.address, sender.Hex()) {
-		return nil, mpp.ErrInvalidPayload("credential source does not match transaction signer")
+	if validated.source != nil && !strings.EqualFold(validated.source.address, sender.Hex()) {
+		return mpp.ErrInvalidPayload("credential source does not match transaction signer")
 	}
+	tx.From = sender
 
 	if request.MethodDetails.FeePayer {
 		policy, err := i.feePayerPolicyFor(request.Currency)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		// tempo-go exposes the signing primitives already; this package keeps the
 		// sponsor policy checks local until a shared helper exists upstream.
 		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires, policy); err != nil {
-			return nil, err
+			return err
 		}
 		if !tx.AwaitingFeePayer {
-			return nil, mpp.ErrInvalidPayload("fee payer transaction must be marked as awaiting a fee payer")
+			return mpp.ErrInvalidPayload("fee payer transaction must be marked as awaiting a fee payer")
 		}
 		if tx.ValidBefore == 0 || time.Now().Unix() >= int64(tx.ValidBefore) {
-			return nil, mpp.ErrVerificationFailed("fee payer transaction has expired")
+			return mpp.ErrVerificationFailed("fee payer transaction has expired")
 		}
 		if tx.NonceKey == nil || tx.NonceKey.Cmp(tempo.ExpiringNonceKey) != 0 {
-			return nil, mpp.ErrInvalidPayload("fee payer transaction must use the expiring nonce key")
+			return mpp.ErrInvalidPayload("fee payer transaction must use the expiring nonce key")
 		}
 		requestFeeToken := common.HexToAddress(request.Currency)
 		if !feePayerForm && tx.FeeToken != (common.Address{}) {
-			return nil, mpp.ErrInvalidPayload("fee payer transaction must omit fee token before co-signing")
+			return mpp.ErrInvalidPayload("fee payer transaction must omit fee token before co-signing")
 		}
 		if feePayerForm && tx.FeeToken != (common.Address{}) && tx.FeeToken != requestFeeToken {
-			return nil, mpp.ErrInvalidPayload("fee payer transaction fee token does not match the charge request")
+			return mpp.ErrInvalidPayload("fee payer transaction fee token does not match the charge request")
 		}
+	} else if err := simulateTransactionExecution(ctx, validated.rpc, tx); err != nil {
+		return err
+	}
+	validated.sender = sender
+	validated.tx = tx
+	return nil
+}
+
+func (i *Intent) broadcastCredential(
+	ctx context.Context,
+	credential *mpp.Credential,
+	validated *validatedChargeCredential,
+) (*mpp.Receipt, error) {
+	switch validated.payload.Type {
+	case tempo.CredentialTypeHash:
+		hash := validated.payload.Hash
+		accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeStoreKey(hash), hash)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			return nil, mpp.ErrVerificationFailed("transaction hash already used")
+		}
+		return mpp.Success(hash, mpp.WithReceiptMethod(tempo.MethodName), mpp.WithExternalID(validated.request.ExternalID)), nil
+	case tempo.CredentialTypeProof:
+		challengeID := credential.Challenge.ID
+		accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeProofStoreKey(challengeID), challengeID)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			return nil, mpp.ErrVerificationFailed("proof credential already used")
+		}
+		return mpp.Success(challengeID, mpp.WithReceiptMethod(tempo.MethodName), mpp.WithExternalID(validated.request.ExternalID)), nil
+	case tempo.CredentialTypeTransaction:
+		return i.broadcastTransaction(ctx, credential, validated)
+	default:
+		return nil, mpp.ErrInvalidPayload(fmt.Sprintf("unsupported credential type %q", validated.payload.Type))
+	}
+}
+
+func (i *Intent) broadcastTransaction(
+	ctx context.Context,
+	credential *mpp.Credential,
+	validated *validatedChargeCredential,
+) (*mpp.Receipt, error) {
+	request := validated.request
+	rpc := validated.rpc
+	sender := validated.sender
+	tx := validated.tx
+	sponsoredClaimKey := ""
+	releaseSponsoredClaim := false
+	defer func() {
+		if releaseSponsoredClaim {
+			_ = i.store.Delete(context.WithoutCancel(ctx), sponsoredClaimKey)
+		}
+	}()
+
+	if request.MethodDetails.FeePayer {
+		if err := simulateSponsoredSenderExecution(ctx, rpc, tx); err != nil {
+			return nil, err
+		}
+		sponsoredClaimKey = tempo.ChargeSponsoredChallengeStoreKey(credential.Challenge.ID)
 		accepted, err := i.store.PutIfAbsent(
 			ctx,
-			tempo.ChargeSponsoredChallengeStoreKey(credential.Challenge.ID),
+			sponsoredClaimKey,
 			credential.Challenge.ID,
 		)
 		if err != nil {
@@ -308,15 +453,16 @@ func (i *Intent) verifyTransaction(
 		if !accepted {
 			return nil, mpp.ErrVerificationFailed("fee payer challenge already used")
 		}
+		releaseSponsoredClaim = true
+		requestFeeToken := common.HexToAddress(request.Currency)
 		if i.feePayerSigner != nil {
-			tx.From = sender
 			tx.FeeToken = requestFeeToken
 			tx.AwaitingFeePayer = false
 			if err := tempotx.AddFeePayerSignature(tx, i.feePayerSigner); err != nil {
 				return nil, mpp.ErrVerificationFailed("failed to co-sign fee payer transaction")
 			}
 		} else if request.MethodDetails.FeePayerURL != "" {
-			coSignedRaw, err := signWithRemoteFeePayer(ctx, request.MethodDetails.FeePayerURL, raw)
+			coSignedRaw, err := signWithRemoteFeePayer(ctx, request.MethodDetails.FeePayerURL, validated.payload.Signature)
 			if err != nil {
 				return nil, err
 			}
@@ -329,6 +475,10 @@ func (i *Intent) verifyTransaction(
 		}
 		if !transactionMatches(tx, request, credential.Challenge.Realm, credential.Challenge.ID) {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction does not contain a matching Tempo transfer")
+		}
+		policy, err := i.feePayerPolicyFor(request.Currency)
+		if err != nil {
+			return nil, err
 		}
 		if err := validateFeePayerTransaction(tx, credential.Challenge.Expires, policy); err != nil {
 			return nil, err
@@ -346,13 +496,16 @@ func (i *Intent) verifyTransaction(
 		if coSignedSender != sender {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction sender does not match the credential signer")
 		}
-		if _, err := tempotx.VerifyFeePayerSignature(tx, coSignedSender); err != nil {
+		feePayerAddress, err := tempotx.VerifyFeePayerSignature(tx, coSignedSender)
+		if err != nil {
 			return nil, mpp.ErrVerificationFailed("co-signed transaction failed signature verification")
 		}
 		tx.From = coSignedSender
-		if err := simulateTransactionPreflight(ctx, rpc, tx); err != nil {
+		if err := simulateSponsoredTransactionExecution(ctx, rpc, tx, feePayerAddress); err != nil {
 			return nil, err
 		}
+	} else if err := simulateTransactionExecution(ctx, rpc, tx); err != nil {
+		return nil, err
 	}
 
 	serialized, err := tempotx.Serialize(tx, nil)
@@ -380,6 +533,9 @@ func (i *Intent) verifyTransaction(
 	}
 
 	if shouldBroadcast {
+		if request.MethodDetails.FeePayer {
+			releaseSponsoredClaim = false
+		}
 		var err error
 		txHash, err = rpc.SendRawTransaction(ctx, serialized)
 		if err != nil {
@@ -968,8 +1124,30 @@ func signWithRemoteFeePayer(ctx context.Context, feePayerURL, raw string) (strin
 	return serialized, nil
 }
 
-func simulateTransactionPreflight(ctx context.Context, rpc tempo.RPCClient, tx *tempotx.Tx) error {
-	response, err := rpc.SendRequest(ctx, "eth_estimateGas", transactionCallObject(tx))
+func simulateSponsoredSenderExecution(ctx context.Context, rpc tempo.RPCClient, tx *tempotx.Tx) error {
+	return simulateCall(ctx, rpc, map[string]any{
+		"calls": callsCallObject(tx.Calls),
+		"from":  tx.From.Hex(),
+	})
+}
+
+func simulateSponsoredTransactionExecution(
+	ctx context.Context,
+	rpc tempo.RPCClient,
+	tx *tempotx.Tx,
+	feePayer common.Address,
+) error {
+	callObject := transactionCallObject(tx)
+	callObject["feePayer"] = feePayer.Hex()
+	return simulateCall(ctx, rpc, callObject)
+}
+
+func simulateTransactionExecution(ctx context.Context, rpc tempo.RPCClient, tx *tempotx.Tx) error {
+	return simulateCall(ctx, rpc, transactionCallObject(tx))
+}
+
+func simulateCall(ctx context.Context, rpc tempo.RPCClient, callObject map[string]any) error {
+	response, err := rpc.SendRequest(ctx, "eth_call", callObject, "latest")
 	if err != nil {
 		return mpp.ErrVerificationFailed("transaction preflight failed")
 	}

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -194,6 +194,9 @@ func (i *Intent) Broadcast(
 	if err != nil {
 		return nil, err
 	}
+	if err := validateChallengeExpiry(credential); err != nil {
+		return nil, err
+	}
 	return i.broadcastCredential(ctx, credential, validated)
 }
 
@@ -424,7 +427,7 @@ func (i *Intent) broadcastTransaction(
 	ctx context.Context,
 	credential *mpp.Credential,
 	validated *validatedChargeCredential,
-) (*mpp.Receipt, error) {
+) (receipt *mpp.Receipt, err error) {
 	request := validated.request
 	rpc := validated.rpc
 	sender := validated.sender
@@ -433,7 +436,10 @@ func (i *Intent) broadcastTransaction(
 	releaseSponsoredClaim := false
 	defer func() {
 		if releaseSponsoredClaim {
-			_ = i.store.Delete(context.WithoutCancel(ctx), sponsoredClaimKey)
+			if releaseErr := i.store.Delete(context.WithoutCancel(ctx), sponsoredClaimKey); releaseErr != nil {
+				receipt = nil
+				err = withReplayReleaseError(err, releaseErr)
+			}
 		}
 	}()
 
@@ -507,6 +513,9 @@ func (i *Intent) broadcastTransaction(
 	} else if err := simulateTransactionExecution(ctx, rpc, tx); err != nil {
 		return nil, err
 	}
+	if err := validateChallengeExpiry(credential); err != nil {
+		return nil, err
+	}
 
 	serialized, err := tempotx.Serialize(tx, nil)
 	if err != nil {
@@ -567,6 +576,37 @@ func (i *Intent) broadcastTransaction(
 		mpp.WithReceiptMethod(tempo.MethodName),
 		mpp.WithExternalID(request.ExternalID),
 	), nil
+}
+
+func validateChallengeExpiry(credential *mpp.Credential) error {
+	if credential == nil {
+		return mpp.ErrMalformedCredential("credential is required")
+	}
+	expiresValue := credential.Challenge.Expires
+	if expiresValue == "" {
+		return mpp.ErrInvalidChallenge(credential.Challenge.ID, "missing required expires")
+	}
+	expires, err := parseExpires(expiresValue)
+	if err != nil {
+		return mpp.ErrInvalidChallenge(credential.Challenge.ID, "invalid expires format")
+	}
+	if !time.Now().UTC().Before(expires) {
+		return mpp.ErrPaymentExpired(expiresValue)
+	}
+	return nil
+}
+
+func withReplayReleaseError(settlementErr, releaseErr error) error {
+	detail := fmt.Sprintf("failed to release sponsored replay claim: %v", releaseErr)
+	if settlementErr == nil {
+		return mpp.ErrVerificationFailed(detail)
+	}
+	if paymentErr, ok := settlementErr.(*mpp.PaymentError); ok {
+		combined := *paymentErr
+		combined.Detail += "; " + detail
+		return &combined
+	}
+	return fmt.Errorf("%w; %s", settlementErr, detail)
 }
 
 func (i *Intent) resolveRPC(request tempo.ChargeRequest) (tempo.RPCClient, error) {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -183,12 +183,18 @@ func TestIntentTransactionCredentialLifecycle(t *testing.T) {
 	ctx := context.Background()
 	request := buildRequest(t, false, []tempo.ChargeMode{tempo.ChargeModePull})
 	rpc := newMockRPC(request)
+	requestMap := request.Map()
+	scope := map[string]any{
+		"resource": "/paid",
+		"route":    "/paid",
+	}
+	requestMap["_mppx_scope"] = scope
 	challenge := mpp.NewChallenge(
 		"test-secret-key-minimum-32-byte-secret",
 		testRealm,
 		tempo.MethodName,
 		tempo.IntentCharge,
-		request.Map(),
+		requestMap,
 		mpp.WithExpires(mpp.Expires.Minutes(5)),
 	)
 	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, challenge)
@@ -207,6 +213,7 @@ func TestIntentTransactionCredentialLifecycle(t *testing.T) {
 	assert.NotEmpty(t, validation.Details["sender"])
 	assert.Equal(t, credential.Payload["signature"], validation.Details["serializedTransaction"])
 	assert.Len(t, validation.Details["transfers"], 1)
+	assert.Equal(t, scope, validation.Request["_mppx_scope"])
 	assert.Empty(t, rpc.sentRawTxs)
 	assert.Len(t, rpc.callRequests, 1)
 	assert.Zero(t, store.putCalls)
@@ -219,6 +226,21 @@ func TestIntentTransactionCredentialLifecycle(t *testing.T) {
 	assert.Len(t, rpc.sentRawTxs, 1)
 	assert.Len(t, rpc.callRequests, 3)
 	assert.Equal(t, 1, store.putIfAbsentCalls)
+}
+
+func TestValidationTransferDetailsDistinguishesAttributionFromWildcardMemo(t *testing.T) {
+	request := buildRequest(t, false, []tempo.ChargeMode{tempo.ChargeModePull})
+	request.MethodDetails.Splits = []tempo.Split{{
+		Amount:    "100000",
+		Recipient: "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+	}}
+
+	details := validationTransferDetails(request)
+	require.Len(t, details, 2)
+	assert.Equal(t, true, details[0]["requireAttribution"])
+	assert.NotContains(t, details[0], "allowAnyMemo")
+	assert.Equal(t, true, details[1]["allowAnyMemo"])
+	assert.NotContains(t, details[1], "requireAttribution")
 }
 
 func TestIntentValidateTransactionRejectsFailedSimulationWithoutMutation(t *testing.T) {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -3,6 +3,7 @@ package chargeserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -88,6 +89,7 @@ type mockRPC struct {
 
 type recordingStore struct {
 	inner            tempo.Store
+	deleteErr        error
 	deleteCalls      int
 	putCalls         int
 	putIfAbsentCalls int
@@ -113,6 +115,9 @@ func (s *recordingStore) PutIfAbsent(ctx context.Context, key, value string) (bo
 
 func (s *recordingStore) Delete(ctx context.Context, key string) error {
 	s.deleteCalls++
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	return s.inner.Delete(ctx, key)
 }
 
@@ -236,6 +241,62 @@ func TestIntentValidateTransactionRejectsFailedSimulationWithoutMutation(t *test
 	assert.Len(t, rpc.callRequests, 1)
 	assert.Zero(t, store.putIfAbsentCalls)
 	assert.Zero(t, store.deleteCalls)
+}
+
+func TestIntentBroadcastRejectsCredentialExpiringDuringValidation(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, []tempo.ChargeMode{tempo.ChargeModePull})
+	rpc := newMockRPC(request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, buildChallenge(t, request))
+	require.NoError(t, err)
+	rpc.callRequests = nil
+	rpc.onCall = func(...interface{}) (*temporpc.JSONRPCResponse, error) {
+		credential.Challenge.Expires = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+		return &temporpc.JSONRPCResponse{Result: rpc.callResult}, nil
+	}
+	store := newRecordingStore()
+	intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store})
+	require.NoError(t, err)
+
+	_, err = intent.Broadcast(ctx, credential, request.Map())
+	require.ErrorContains(t, err, "expired")
+	assert.Len(t, rpc.callRequests, 1)
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Zero(t, store.putIfAbsentCalls)
+	assert.Zero(t, store.deleteCalls)
+}
+
+func TestIntentBroadcastSurfacesSponsoredReplayReleaseFailure(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, []tempo.ChargeMode{tempo.ChargeModePull})
+	rpc := newMockRPC(request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, buildChallenge(t, request))
+	require.NoError(t, err)
+	rpc.callRequests = nil
+	simulations := 0
+	rpc.onCall = func(...interface{}) (*temporpc.JSONRPCResponse, error) {
+		simulations++
+		if simulations == 2 {
+			credential.Challenge.Expires = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+		}
+		return &temporpc.JSONRPCResponse{Result: rpc.callResult}, nil
+	}
+	store := newRecordingStore()
+	store.deleteErr = errors.New("delete unavailable")
+	intent, err := NewIntent(IntentConfig{
+		RPC:                rpc,
+		Store:              store,
+		FeePayerPrivateKey: feePayerKey,
+	})
+	require.NoError(t, err)
+
+	_, err = intent.Broadcast(ctx, credential, request.Map())
+	require.ErrorContains(t, err, "expired")
+	require.ErrorContains(t, err, "failed to release sponsored replay claim: delete unavailable")
+	assert.Len(t, rpc.callRequests, 2)
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Equal(t, 1, store.putIfAbsentCalls)
+	assert.Equal(t, 1, store.deleteCalls)
 }
 
 func TestIntentValidatePushAndProofCredentialsDoesNotConsumeReplayState(t *testing.T) {

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
@@ -77,10 +78,42 @@ type mockRPC struct {
 	callResult       string
 	receipts         map[string]map[string]any
 	sentRawTxs       []string
+	callRequests     []map[string]any
 	estimateGasCalls []map[string]any
+	onCall           func(params ...interface{}) (*temporpc.JSONRPCResponse, error)
 	onSend           func(raw string) (string, map[string]any, error)
 	onEstimateGas    func(params ...interface{}) (*temporpc.JSONRPCResponse, error)
 	onGetReceipt     func(hash string) (*temporpc.JSONRPCResponse, error)
+}
+
+type recordingStore struct {
+	inner            tempo.Store
+	deleteCalls      int
+	putCalls         int
+	putIfAbsentCalls int
+}
+
+func newRecordingStore() *recordingStore {
+	return &recordingStore{inner: tempo.NewMemoryStore()}
+}
+
+func (s *recordingStore) Get(ctx context.Context, key string) (string, bool, error) {
+	return s.inner.Get(ctx, key)
+}
+
+func (s *recordingStore) Put(ctx context.Context, key, value string) error {
+	s.putCalls++
+	return s.inner.Put(ctx, key, value)
+}
+
+func (s *recordingStore) PutIfAbsent(ctx context.Context, key, value string) (bool, error) {
+	s.putIfAbsentCalls++
+	return s.inner.PutIfAbsent(ctx, key, value)
+}
+
+func (s *recordingStore) Delete(ctx context.Context, key string) error {
+	s.deleteCalls++
+	return s.inner.Delete(ctx, key)
 }
 
 func (m *mockRPC) GetChainID(context.Context) (uint64, error) {
@@ -121,6 +154,14 @@ func (m *mockRPC) SendRequest(_ context.Context, method string, params ...interf
 		}
 		return &temporpc.JSONRPCResponse{Result: m.estimateGas}, nil
 	case "eth_call":
+		if len(params) > 0 {
+			if callObject, ok := params[0].(map[string]any); ok {
+				m.callRequests = append(m.callRequests, callObject)
+			}
+		}
+		if m.onCall != nil {
+			return m.onCall(params...)
+		}
 		return &temporpc.JSONRPCResponse{Result: m.callResult}, nil
 	case "eth_getTransactionReceipt":
 		hash := params[0].(string)
@@ -131,6 +172,183 @@ func (m *mockRPC) SendRequest(_ context.Context, method string, params ...interf
 	default:
 		return nil, fmt.Errorf("unexpected rpc method %q", method)
 	}
+}
+
+func TestIntentTransactionCredentialLifecycle(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, []tempo.ChargeMode{tempo.ChargeModePull})
+	rpc := newMockRPC(request)
+	challenge := mpp.NewChallenge(
+		"test-secret-key-minimum-32-byte-secret",
+		testRealm,
+		tempo.MethodName,
+		tempo.IntentCharge,
+		request.Map(),
+		mpp.WithExpires(mpp.Expires.Minutes(5)),
+	)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, challenge)
+	require.NoError(t, err)
+	rpc.callRequests = nil
+	store := newRecordingStore()
+	method, err := MethodFromConfig(Config{RPC: rpc, Store: store})
+	require.NoError(t, err)
+	payment, err := server.New(method, testRealm, "test-secret-key-minimum-32-byte-secret")
+	require.NoError(t, err)
+
+	validation, err := payment.ValidateCredential(ctx, credential)
+	require.NoError(t, err)
+	assert.Equal(t, "pull", validation.Details["mode"])
+	assert.Equal(t, credential.Source, validation.Source)
+	assert.NotEmpty(t, validation.Details["sender"])
+	assert.Equal(t, credential.Payload["signature"], validation.Details["serializedTransaction"])
+	assert.Len(t, validation.Details["transfers"], 1)
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Len(t, rpc.callRequests, 1)
+	assert.Zero(t, store.putCalls)
+	assert.Zero(t, store.putIfAbsentCalls)
+	assert.Zero(t, store.deleteCalls)
+
+	receipt, err := payment.BroadcastCredential(ctx, credential)
+	require.NoError(t, err)
+	assert.Equal(t, testReceiptHash, receipt.Reference)
+	assert.Len(t, rpc.sentRawTxs, 1)
+	assert.Len(t, rpc.callRequests, 3)
+	assert.Equal(t, 1, store.putIfAbsentCalls)
+}
+
+func TestIntentValidateTransactionRejectsFailedSimulationWithoutMutation(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, false, []tempo.ChargeMode{tempo.ChargeModePull})
+	rpc := newMockRPC(request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, buildChallenge(t, request))
+	require.NoError(t, err)
+	rpc.callRequests = nil
+	rpc.onCall = func(...interface{}) (*temporpc.JSONRPCResponse, error) {
+		return temporpc.NewJSONRPCErrorResponse(1, temporpc.InvalidTransactionType, "execution reverted", nil), nil
+	}
+	store := newRecordingStore()
+	intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store})
+	require.NoError(t, err)
+
+	_, err = intent.Validate(ctx, credential, request.Map())
+	require.ErrorContains(t, err, "transaction preflight failed")
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Len(t, rpc.callRequests, 1)
+	assert.Zero(t, store.putIfAbsentCalls)
+	assert.Zero(t, store.deleteCalls)
+}
+
+func TestIntentValidatePushAndProofCredentialsDoesNotConsumeReplayState(t *testing.T) {
+	tests := []struct {
+		name           string
+		credentialType tempo.CredentialType
+		prepareRequest func(tempo.ChargeRequest) tempo.ChargeRequest
+		wantMode       string
+	}{
+		{
+			name:           "push",
+			credentialType: tempo.CredentialTypeHash,
+			prepareRequest: func(request tempo.ChargeRequest) tempo.ChargeRequest {
+				request.MethodDetails.SupportedModes = []tempo.ChargeMode{tempo.ChargeModePush}
+				return request
+			},
+			wantMode: "push",
+		},
+		{
+			name:           "proof",
+			credentialType: tempo.CredentialTypeProof,
+			prepareRequest: func(request tempo.ChargeRequest) tempo.ChargeRequest {
+				request.Amount = "0"
+				return request
+			},
+			wantMode: "proof",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			request := tt.prepareRequest(buildRequest(t, false, nil))
+			rpc := newMockRPC(request)
+			credential, err := newClientMethod(t, rpc, tt.credentialType).CreateCredential(ctx, buildChallenge(t, request))
+			require.NoError(t, err)
+			store := newRecordingStore()
+			intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store})
+			require.NoError(t, err)
+
+			for range 2 {
+				validation, err := intent.Validate(ctx, credential, request.Map())
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantMode, validation.Details["mode"])
+			}
+			assert.Zero(t, store.putIfAbsentCalls)
+
+			_, err = intent.Broadcast(ctx, credential, request.Map())
+			require.NoError(t, err)
+			assert.Equal(t, 1, store.putIfAbsentCalls)
+
+			_, err = intent.Validate(ctx, credential, request.Map())
+			require.NoError(t, err)
+			_, err = intent.Broadcast(ctx, credential, request.Map())
+			require.ErrorContains(t, err, "already used")
+			assert.Equal(t, 2, store.putIfAbsentCalls)
+		})
+	}
+}
+
+func TestIntentValidateSponsoredCredentialDoesNotInvokeFeePayer(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, []tempo.ChargeMode{tempo.ChargeModePull})
+	feePayerCalls := 0
+	feePayerServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		feePayerCalls++
+	}))
+	defer feePayerServer.Close()
+	request.MethodDetails.FeePayerURL = feePayerServer.URL
+	rpc := newMockRPC(request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, buildChallenge(t, request))
+	require.NoError(t, err)
+	rpc.estimateGasCalls = nil
+	rpc.callRequests = nil
+	store := newRecordingStore()
+	intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store})
+	require.NoError(t, err)
+
+	validation, err := intent.Validate(ctx, credential, request.Map())
+	require.NoError(t, err)
+	assert.Equal(t, "pull", validation.Details["mode"])
+	assert.Zero(t, feePayerCalls)
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Empty(t, rpc.estimateGasCalls)
+	assert.Empty(t, rpc.callRequests)
+	assert.Zero(t, store.putIfAbsentCalls)
+}
+
+func TestIntentBroadcastSponsoredCredentialSimulatesBeforeFeePayer(t *testing.T) {
+	ctx := context.Background()
+	request := buildRequest(t, true, []tempo.ChargeMode{tempo.ChargeModePull})
+	feePayerCalls := 0
+	feePayerServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		feePayerCalls++
+	}))
+	defer feePayerServer.Close()
+	request.MethodDetails.FeePayerURL = feePayerServer.URL
+	rpc := newMockRPC(request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeTransaction).CreateCredential(ctx, buildChallenge(t, request))
+	require.NoError(t, err)
+	rpc.callRequests = nil
+	rpc.onCall = func(...interface{}) (*temporpc.JSONRPCResponse, error) {
+		return temporpc.NewJSONRPCErrorResponse(1, temporpc.InvalidTransactionType, "execution reverted", nil), nil
+	}
+	store := newRecordingStore()
+	intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store})
+	require.NoError(t, err)
+
+	_, err = intent.Broadcast(ctx, credential, request.Map())
+	require.ErrorContains(t, err, "transaction preflight failed")
+	assert.Len(t, rpc.callRequests, 1)
+	assert.Zero(t, feePayerCalls)
+	assert.Empty(t, rpc.sentRawTxs)
+	assert.Zero(t, store.putIfAbsentCalls)
 }
 
 func TestChargeFlow_FeePayerTransactionViaRemoteSigner(t *testing.T) {
@@ -1173,35 +1391,39 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 	ctx := context.Background()
 	request := buildRequest(t, true, nil)
 	rpc := newMockRPC(request)
-	rpc.onEstimateGas = func(params ...interface{}) (*temporpc.JSONRPCResponse, error) {
+	rpc.onCall = func(params ...interface{}) (*temporpc.JSONRPCResponse, error) {
 		callObject, ok := params[0].(map[string]any)
 		if !assert.Truef(t, ok,
-			"estimateGas params[0] type = %T, want map[string]any", params[0]) {
+			"eth_call params[0] type = %T, want map[string]any", params[0]) {
 			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
 
-		if _, ok := callObject["calls"]; !ok {
-			return &temporpc.JSONRPCResponse{Result: rpc.estimateGas}, nil
+		if _, finalEnvelope := callObject["feePayer"]; !finalEnvelope {
+			assert.Equal(t, map[string]any{
+				"calls": callObject["calls"],
+				"from":  callObject["from"],
+			}, callObject)
+			return &temporpc.JSONRPCResponse{Result: rpc.callResult}, nil
 		}
 		if !assert.NotEqual(t, "", callObject["from"],
-			"estimateGas call object missing from") {
+			"eth_call object missing from") {
 			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
 		if !assert.Equalf(t, request.Currency, callObject["feeToken"],
-			"estimateGas feeToken = %v, want %s", callObject["feeToken"], request.Currency) {
+			"eth_call feeToken = %v, want %s", callObject["feeToken"], request.Currency) {
 			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
 
 		calls, ok := callObject["calls"].([]map[string]any)
 		if !assert.Falsef(t, !ok || len(calls) == 0,
-			"estimateGas calls = %#v, want non-empty call batch", callObject["calls"]) {
+			"eth_call calls = %#v, want non-empty call batch", callObject["calls"]) {
 			return *new(*temporpc.JSONRPCResponse), *new(error)
 		}
 		{
 
 			_, ok := callObject["nonceKey"]
 			if !assert.True(t, ok,
-				"estimateGas call object missing nonceKey") {
+				"eth_call object missing nonceKey") {
 				return *new(*temporpc.JSONRPCResponse), *new(error)
 			}
 		}
@@ -1209,7 +1431,7 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 
 			_, ok := callObject["validBefore"]
 			if !assert.True(t, ok,
-				"estimateGas call object missing validBefore") {
+				"eth_call object missing validBefore") {
 				return *new(*temporpc.JSONRPCResponse), *new(error)
 			}
 		}
@@ -1225,7 +1447,8 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 		return
 	}
 
-	intent, err := NewIntent(IntentConfig{RPC: rpc, FeePayerPrivateKey: feePayerKey})
+	store := newRecordingStore()
+	intent, err := NewIntent(IntentConfig{RPC: rpc, Store: store, FeePayerPrivateKey: feePayerKey})
 	if !assert.NoErrorf(t, err,
 		"NewIntent() error = %v", err) {
 		return
@@ -1242,10 +1465,12 @@ func TestChargeFlow_FeePayerTransactionFailsPreflightBeforeBroadcast(t *testing.
 		"expected no broadcast after failed preflight, got %d", len(rpc.sentRawTxs)) {
 		return
 	}
-	if !assert.Falsef(t, len(rpc.estimateGasCalls) < 2,
-		"expected client estimate and server preflight calls, got %d", len(rpc.estimateGasCalls)) {
+	if !assert.Lenf(t, rpc.callRequests, 2,
+		"expected sender and final-envelope simulations, got %d", len(rpc.callRequests)) {
 		return
 	}
+	assert.Equal(t, 1, store.putIfAbsentCalls)
+	assert.Equal(t, 1, store.deleteCalls)
 
 }
 


### PR DESCRIPTION
## Motivation

Allow local Tempo charge servers to validate credentials without consuming or broadcasting them, matching the mppx lifecycle without routing through the relay API.

## Summary

- expose public validating and broadcasting intent interfaces
- implement non-mutating validation and revalidating broadcast in the built-in Tempo charge intent
- simulate ordinary pull credentials during validation and expose validation metadata
- preserve push and proof replay protection for the broadcast phase

## Key design considerations

- retain `Verify` compatibility and legacy intent fallback
- keep replay writes, fee-payer signing, and transaction submission in the terminal phase
- keep sponsored validation static, then run sender and final-envelope simulations during broadcast
- release sponsored replay reservations when settlement fails before submission