### PR TITLE
fix(client): match challenges by method and intent

### DIFF
--- a/.changelog/client-method-intent.md
+++ b/.changelog/client-method-intent.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Require client payment methods to declare their supported intent and match challenges by method and intent.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,13 +14,24 @@ import (
 type Method interface {
 	// Name returns the method name this handler supports (e.g., "tempo").
 	Name() string
+	// Intent returns the payment intent this handler supports (e.g., "charge").
+	Intent() string
 	// CreateCredential creates a payment credential for the given challenge.
 	CreateCredential(ctx context.Context, challenge *mpp.Challenge) (*mpp.Credential, error)
 }
 
+type methodKey struct {
+	name   string
+	intent string
+}
+
+func keyForMethod(method Method) methodKey {
+	return methodKey{name: method.Name(), intent: method.Intent()}
+}
+
 // Client is an HTTP client with automatic 402 payment handling.
 type Client struct {
-	methods    map[string]Method
+	methods    map[methodKey]Method
 	httpClient *http.Client
 }
 
@@ -37,11 +48,11 @@ func WithHTTPClient(c *http.Client) Option {
 // New creates a Client with the given payment methods.
 func New(methods []Method, opts ...Option) *Client {
 	c := &Client{
-		methods:    make(map[string]Method, len(methods)),
+		methods:    make(map[methodKey]Method, len(methods)),
 		httpClient: http.DefaultClient,
 	}
 	for _, m := range methods {
-		c.methods[m.Name()] = m
+		c.methods[keyForMethod(m)] = m
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -15,7 +15,7 @@ import (
 // Transport is an http.RoundTripper that handles 402 Payment Required responses.
 // It wraps an inner transport and automatically negotiates payment.
 type Transport struct {
-	methods map[string]Method
+	methods map[methodKey]Method
 	inner   http.RoundTripper
 }
 
@@ -26,9 +26,9 @@ func NewTransport(methods []Method, inner http.RoundTripper) *Transport {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	m := make(map[string]Method, len(methods))
+	m := make(map[methodKey]Method, len(methods))
 	for _, method := range methods {
-		m[method.Name()] = method
+		m[keyForMethod(method)] = method
 	}
 	return &Transport{
 		methods: m,
@@ -69,7 +69,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				continue
 			}
 		}
-		if m, ok := t.methods[ch.Method]; ok {
+		if m, ok := t.methods[methodKey{name: ch.Method, intent: ch.Intent}]; ok {
 			matched = ch
 			method = m
 			break

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -15,15 +15,24 @@ import (
 
 // mockMethod implements Method for testing.
 type mockMethod struct {
-	name  string
-	cred  *mpp.Credential
-	err   error
-	calls int
+	name   string
+	intent string
+	cred   *mpp.Credential
+	err    error
+	calls  int
+	seen   []string
 }
 
 func (m *mockMethod) Name() string { return m.name }
+func (m *mockMethod) Intent() string {
+	if m.intent == "" {
+		return "payment"
+	}
+	return m.intent
+}
 func (m *mockMethod) CreateCredential(_ context.Context, ch *mpp.Challenge) (*mpp.Credential, error) {
 	m.calls++
+	m.seen = append(m.seen, ch.Intent)
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -151,6 +160,49 @@ func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {
 		return
 	}
 
+}
+
+func TestTransport_RoundTrip_MatchesMethodAndIntent(t *testing.T) {
+	var challenges []*mpp.Challenge
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			for _, challenge := range challenges {
+				w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			}
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := urlpkg.Parse(srv.URL)
+	if !assert.NoError(t, err) {
+		return
+	}
+	challenges = []*mpp.Challenge{
+		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "authorize", nil),
+		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "charge", nil),
+	}
+	method := &mockMethod{
+		name:   "tempo",
+		intent: "charge",
+		cred:   newTestCredential("tempo"),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+	resp, err := NewTransport([]Method{method}, nil).RoundTrip(req)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, method.calls)
+	assert.Equal(t, []string{"charge"}, method.seen)
 }
 
 func TestTransport_RoundTrip_402ExpiredChallenge(t *testing.T) {

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -86,6 +86,11 @@ func (m *Method) Name() string {
 	return tempo.MethodName
 }
 
+// Intent returns the charge intent handled by this method.
+func (m *Method) Intent() string {
+	return tempo.IntentCharge
+}
+
 // CreateCredential turns a Tempo charge Challenge into a Tempo Credential.
 func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge) (*mpp.Credential, error) {
 	if challenge.Method != tempo.MethodName {


### PR DESCRIPTION
## Motivation

Client challenge selection indexes handlers only by method name. When a server offers multiple intents for one method, the client can select an intent the handler does not support. mppx models each client capability as an exact method and intent pair.

## Summary

- Require client methods to declare their supported intent
- Index and select handlers by exact method and intent pairs
- Declare the Tempo client method as `tempo/charge`

## Key design considerations

- Intent support is explicit; handlers cannot implicitly accept every intent
- Distinct intent handlers under the same method name can coexist
- The client interface change is released as a minor change