### PR TITLE
feat(client): add payment preference negotiation

### DIFF
--- a/.changelog/client-payment-negotiation.md
+++ b/.changelog/client-payment-negotiation.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Advertise and rank client payment capabilities with `Accept-Payment`, and support multiple challenge-aware handlers for the same method and intent.

--- a/pkg/client/accept_payment.go
+++ b/pkg/client/accept_payment.go
@@ -65,7 +65,10 @@ func resolvePaymentPreferences(methods []Method, configured PaymentPreferences) 
 }
 
 func parseAcceptPayment(header string) ([]paymentPreference, error) {
-	parts := strings.Split(header, ",")
+	parts, err := splitHeaderValue(header, ',')
+	if err != nil {
+		return nil, err
+	}
 	preferences := make([]paymentPreference, 0, len(parts))
 	for _, raw := range parts {
 		part := strings.TrimSpace(raw)
@@ -85,7 +88,10 @@ func parseAcceptPayment(header string) ([]paymentPreference, error) {
 }
 
 func parsePaymentPreference(value string, index int) (paymentPreference, error) {
-	parts := strings.Split(value, ";")
+	parts, err := splitHeaderValue(value, ';')
+	if err != nil {
+		return paymentPreference{}, err
+	}
 	method, intent, ok := strings.Cut(strings.TrimSpace(parts[0]), "/")
 	method = strings.TrimSpace(method)
 	intent = strings.TrimSpace(intent)
@@ -101,7 +107,7 @@ func parsePaymentPreference(value string, index int) (paymentPreference, error) 
 		if !ok || !validParameterName(name) || parameter == "" {
 			return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment parameter %q", raw)
 		}
-		if name != "q" {
+		if !strings.EqualFold(name, "q") {
 			continue
 		}
 		parsed, err := strconv.ParseFloat(parameter, 64)
@@ -118,6 +124,30 @@ func parsePaymentPreference(value string, index int) (paymentPreference, error) 
 		index:       index,
 		specificity: boolInt(method != "*") + boolInt(intent != "*"),
 	}, nil
+}
+
+func splitHeaderValue(value string, separator byte) ([]string, error) {
+	var parts []string
+	inQuote := false
+	escaped := false
+	start := 0
+	for i := range len(value) {
+		switch ch := value[i]; {
+		case escaped:
+			escaped = false
+		case inQuote && ch == '\\':
+			escaped = true
+		case ch == '"':
+			inQuote = !inQuote
+		case ch == separator && !inQuote:
+			parts = append(parts, strings.TrimSpace(value[start:i]))
+			start = i + 1
+		}
+	}
+	if inQuote || escaped {
+		return nil, fmt.Errorf("mpp: malformed quoted Accept-Payment parameter")
+	}
+	return append(parts, strings.TrimSpace(value[start:])), nil
 }
 
 func bestPaymentPreference(challenge *mpp.Challenge, preferences []paymentPreference) (paymentPreference, bool) {
@@ -190,10 +220,12 @@ func validPaymentToken(value string) bool {
 	}
 	for i := range len(value) {
 		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
 			continue
 		}
-		return false
+		if !strings.ContainsRune("!#$%&'*+-.^_`|~", rune(ch)) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/client/accept_payment.go
+++ b/pkg/client/accept_payment.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"math"
+	"mime"
 	"strconv"
 	"strings"
 
@@ -34,7 +35,7 @@ func resolvePaymentPreferences(methods []Method, configured PaymentPreferences) 
 	for _, method := range methods {
 		key := keyForMethod(method)
 		name := paymentPreferenceKey(key.name, key.intent)
-		if !validPaymentToken(key.name) || !validPaymentToken(key.intent) {
+		if _, _, err := mime.ParseMediaType(name); err != nil {
 			return nil, "", fmt.Errorf("mpp: invalid payment method capability %q", name)
 		}
 		if _, ok := known[name]; ok {
@@ -65,7 +66,7 @@ func resolvePaymentPreferences(methods []Method, configured PaymentPreferences) 
 }
 
 func parseAcceptPayment(header string) ([]paymentPreference, error) {
-	parts, err := splitHeaderValue(header, ',')
+	parts, err := splitHeaderList(header)
 	if err != nil {
 		return nil, err
 	}
@@ -88,28 +89,24 @@ func parseAcceptPayment(header string) ([]paymentPreference, error) {
 }
 
 func parsePaymentPreference(value string, index int) (paymentPreference, error) {
-	parts, err := splitHeaderValue(value, ';')
-	if err != nil {
-		return paymentPreference{}, err
-	}
-	method, intent, ok := strings.Cut(strings.TrimSpace(parts[0]), "/")
+	capability, parameters, hasParameters := strings.Cut(value, ";")
+	method, intent, ok := strings.Cut(strings.TrimSpace(capability), "/")
 	method = strings.TrimSpace(method)
 	intent = strings.TrimSpace(intent)
-	if !ok || !validPreferenceToken(method) || !validPreferenceToken(intent) {
+	if !ok {
 		return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment entry %q", value)
+	}
+	normalized := paymentPreferenceKey(method, intent)
+	if hasParameters {
+		normalized += ";" + parameters
+	}
+	_, parsedParameters, err := mime.ParseMediaType(normalized)
+	if err != nil {
+		return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment entry %q: %w", value, err)
 	}
 
 	quality := 1.0
-	for _, raw := range parts[1:] {
-		name, parameter, ok := strings.Cut(strings.TrimSpace(raw), "=")
-		name = strings.TrimSpace(name)
-		parameter = strings.TrimSpace(parameter)
-		if !ok || !validParameterName(name) || parameter == "" {
-			return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment parameter %q", raw)
-		}
-		if !strings.EqualFold(name, "q") {
-			continue
-		}
+	if parameter, ok := parsedParameters["q"]; ok {
 		parsed, err := strconv.ParseFloat(parameter, 64)
 		if err != nil || !validHeaderQuality(parameter) {
 			return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment q-value %q", parameter)
@@ -126,7 +123,10 @@ func parsePaymentPreference(value string, index int) (paymentPreference, error) 
 	}, nil
 }
 
-func splitHeaderValue(value string, separator byte) ([]string, error) {
+// splitHeaderList splits the comma-separated field value while preserving
+// commas in quoted extension parameters. The standard library handles each
+// resulting entry with mime.ParseMediaType but does not expose its list scanner.
+func splitHeaderList(value string) ([]string, error) {
 	var parts []string
 	inQuote := false
 	escaped := false
@@ -139,7 +139,7 @@ func splitHeaderValue(value string, separator byte) ([]string, error) {
 			escaped = true
 		case ch == '"':
 			inQuote = !inQuote
-		case ch == separator && !inQuote:
+		case ch == ',' && !inQuote:
 			parts = append(parts, strings.TrimSpace(value[start:i]))
 			start = i + 1
 		}
@@ -210,41 +210,6 @@ func validHeaderQuality(value string) bool {
 	return whole == "1" && strings.Trim(fraction, "0") == ""
 }
 
-func validPreferenceToken(value string) bool {
-	return value == "*" || validPaymentToken(value)
-}
-
-func validPaymentToken(value string) bool {
-	if value == "" {
-		return false
-	}
-	for i := range len(value) {
-		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
-			continue
-		}
-		if !strings.ContainsRune("!#$%&'*+-.^_`|~", rune(ch)) {
-			return false
-		}
-	}
-	return true
-}
-
-func validParameterName(value string) bool {
-	if value == "" {
-		return false
-	}
-	for i := range len(value) {
-		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-			(ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
 func allDigits(value string) bool {
 	for i := range len(value) {
 		if value[i] < '0' || value[i] > '9' {
@@ -262,5 +227,5 @@ func boolInt(value bool) int {
 }
 
 func formatQuality(quality float64) string {
-	return strings.TrimRight(strings.TrimRight(strconv.FormatFloat(quality, 'f', 3, 64), "0"), ".")
+	return strconv.FormatFloat(quality, 'f', -1, 64)
 }

--- a/pkg/client/accept_payment.go
+++ b/pkg/client/accept_payment.go
@@ -1,0 +1,234 @@
+package client
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+type paymentPreference struct {
+	method      string
+	intent      string
+	quality     float64
+	index       int
+	specificity int
+}
+
+func clonePaymentPreferences(preferences PaymentPreferences) PaymentPreferences {
+	if preferences == nil {
+		return nil
+	}
+	clone := make(PaymentPreferences, len(preferences))
+	for key, quality := range preferences {
+		clone[key] = quality
+	}
+	return clone
+}
+
+func resolvePaymentPreferences(methods []Method, configured PaymentPreferences) ([]paymentPreference, string, error) {
+	known := make(map[string]struct{}, len(methods))
+	preferences := make([]paymentPreference, 0, len(methods))
+	for _, method := range methods {
+		key := keyForMethod(method)
+		name := paymentPreferenceKey(key.name, key.intent)
+		if !validPaymentToken(key.name) || !validPaymentToken(key.intent) {
+			return nil, "", fmt.Errorf("mpp: invalid payment method capability %q", name)
+		}
+		if _, ok := known[name]; ok {
+			continue
+		}
+		known[name] = struct{}{}
+		quality := 1.0
+		if configuredQuality, ok := configured[name]; ok {
+			quality = configuredQuality
+		}
+		if err := validateQuality(quality); err != nil {
+			return nil, "", fmt.Errorf("mpp: invalid payment preference %q: %w", name, err)
+		}
+		preferences = append(preferences, paymentPreference{
+			method:      key.name,
+			intent:      key.intent,
+			quality:     quality,
+			index:       len(preferences),
+			specificity: 2,
+		})
+	}
+	for key := range configured {
+		if _, ok := known[key]; !ok {
+			return nil, "", fmt.Errorf("mpp: unknown payment preference %q", key)
+		}
+	}
+	return preferences, serializeAcceptPayment(preferences), nil
+}
+
+func parseAcceptPayment(header string) ([]paymentPreference, error) {
+	parts := strings.Split(header, ",")
+	preferences := make([]paymentPreference, 0, len(parts))
+	for _, raw := range parts {
+		part := strings.TrimSpace(raw)
+		if part == "" {
+			return nil, fmt.Errorf("mpp: invalid empty Accept-Payment entry")
+		}
+		preference, err := parsePaymentPreference(part, len(preferences))
+		if err != nil {
+			return nil, err
+		}
+		preferences = append(preferences, preference)
+	}
+	if len(preferences) == 0 {
+		return nil, fmt.Errorf("mpp: empty Accept-Payment header")
+	}
+	return preferences, nil
+}
+
+func parsePaymentPreference(value string, index int) (paymentPreference, error) {
+	parts := strings.Split(value, ";")
+	method, intent, ok := strings.Cut(strings.TrimSpace(parts[0]), "/")
+	method = strings.TrimSpace(method)
+	intent = strings.TrimSpace(intent)
+	if !ok || !validPreferenceToken(method) || !validPreferenceToken(intent) {
+		return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment entry %q", value)
+	}
+
+	quality := 1.0
+	for _, raw := range parts[1:] {
+		name, parameter, ok := strings.Cut(strings.TrimSpace(raw), "=")
+		name = strings.TrimSpace(name)
+		parameter = strings.TrimSpace(parameter)
+		if !ok || !validParameterName(name) || parameter == "" {
+			return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment parameter %q", raw)
+		}
+		if name != "q" {
+			continue
+		}
+		parsed, err := strconv.ParseFloat(parameter, 64)
+		if err != nil || !validHeaderQuality(parameter) {
+			return paymentPreference{}, fmt.Errorf("mpp: invalid Accept-Payment q-value %q", parameter)
+		}
+		quality = parsed
+	}
+
+	return paymentPreference{
+		method:      method,
+		intent:      intent,
+		quality:     quality,
+		index:       index,
+		specificity: boolInt(method != "*") + boolInt(intent != "*"),
+	}, nil
+}
+
+func bestPaymentPreference(challenge *mpp.Challenge, preferences []paymentPreference) (paymentPreference, bool) {
+	var best paymentPreference
+	found := false
+	for _, preference := range preferences {
+		if preference.method != "*" && preference.method != challenge.Method {
+			continue
+		}
+		if preference.intent != "*" && preference.intent != challenge.Intent {
+			continue
+		}
+		if !found || preference.specificity > best.specificity ||
+			(preference.specificity == best.specificity && preference.quality > best.quality) ||
+			(preference.specificity == best.specificity && preference.quality == best.quality && preference.index < best.index) {
+			best = preference
+			found = true
+		}
+	}
+	return best, found
+}
+
+func serializeAcceptPayment(preferences []paymentPreference) string {
+	entries := make([]string, 0, len(preferences))
+	for _, preference := range preferences {
+		entry := paymentPreferenceKey(preference.method, preference.intent)
+		if preference.quality != 1 {
+			entry += ";q=" + formatQuality(preference.quality)
+		}
+		entries = append(entries, entry)
+	}
+	return strings.Join(entries, ", ")
+}
+
+func paymentPreferenceKey(method, intent string) string {
+	return method + "/" + intent
+}
+
+func validateQuality(quality float64) error {
+	if math.IsNaN(quality) || math.IsInf(quality, 0) || quality < 0 || quality > 1 {
+		return fmt.Errorf("q-value must be between 0 and 1")
+	}
+	if math.Abs(quality*1000-math.Round(quality*1000)) > 1e-9 {
+		return fmt.Errorf("q-value must have at most three decimal places")
+	}
+	return nil
+}
+
+func validHeaderQuality(value string) bool {
+	if value == "0" || value == "1" {
+		return true
+	}
+	whole, fraction, ok := strings.Cut(value, ".")
+	if !ok || len(fraction) > 3 {
+		return false
+	}
+	if whole == "0" {
+		return allDigits(fraction)
+	}
+	return whole == "1" && strings.Trim(fraction, "0") == ""
+}
+
+func validPreferenceToken(value string) bool {
+	return value == "*" || validPaymentToken(value)
+}
+
+func validPaymentToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := range len(value) {
+		ch := value[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validParameterName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := range len(value) {
+		ch := value[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func allDigits(value string) bool {
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func formatQuality(quality float64) string {
+	return strings.TrimRight(strings.TrimRight(strconv.FormatFloat(quality, 'f', 3, 64), "0"), ".")
+}

--- a/pkg/client/accept_payment_test.go
+++ b/pkg/client/accept_payment_test.go
@@ -3,11 +3,13 @@ package client
 import (
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +56,16 @@ func TestResolvePaymentPreferences(t *testing.T) {
 			configured: PaymentPreferences{"tempo/charge": 0.1234},
 			wantErr:    "at most three decimal places",
 		},
+		{
+			name:       "q-value above one",
+			configured: PaymentPreferences{"tempo/charge": 1.1},
+			wantErr:    "between 0 and 1",
+		},
+		{
+			name:       "non-finite q-value",
+			configured: PaymentPreferences{"tempo/charge": math.Inf(1)},
+			wantErr:    "between 0 and 1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +86,120 @@ func TestResolvePaymentPreferences(t *testing.T) {
 	}
 }
 
-func TestParseAcceptPayment_BestMatch(t *testing.T) {
+func TestParseAcceptPayment(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		want       []paymentPreference
+		normalized string
+		wantErr    bool
+	}{
+		{
+			name:       "single capability",
+			header:     "tempo/charge",
+			want:       []paymentPreference{{method: "tempo", intent: "charge", quality: 1, specificity: 2}},
+			normalized: "tempo/charge",
+		},
+		{
+			name:   "whitespace wildcards and q-values",
+			header: " stripe/charge ; q = 0.25 , */session ; q=0 ",
+			want: []paymentPreference{
+				{method: "stripe", intent: "charge", quality: 0.25, specificity: 2},
+				{method: "*", intent: "session", quality: 0, index: 1, specificity: 1},
+			},
+			normalized: "stripe/charge;q=0.25, */session;q=0",
+		},
+		{
+			name:   "specific opt out",
+			header: "tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5",
+			want: []paymentPreference{
+				{method: "tempo", intent: "*", quality: 1, specificity: 1},
+				{method: "tempo", intent: "charge", quality: 0, index: 1, specificity: 2},
+				{method: "stripe", intent: "*", quality: 0.5, index: 2, specificity: 1},
+			},
+			normalized: "tempo/*, tempo/charge;q=0, stripe/*;q=0.5",
+		},
+		{
+			name:   "quoted extensions and case-insensitive q",
+			header: `tempo/charge;profile="a,b;c";Q=0, stripe/charge`,
+			want: []paymentPreference{
+				{method: "tempo", intent: "charge", quality: 0, specificity: 2},
+				{method: "stripe", intent: "charge", quality: 1, index: 1, specificity: 2},
+			},
+			normalized: "tempo/charge;q=0, stripe/charge",
+		},
+		{
+			name:       "custom HTTP tokens",
+			header:     "Custom/pre_authorize",
+			want:       []paymentPreference{{method: "Custom", intent: "pre_authorize", quality: 1, specificity: 2}},
+			normalized: "Custom/pre_authorize",
+		},
+		{name: "empty", header: "", wantErr: true},
+		{name: "missing intent", header: "tempo", wantErr: true},
+		{name: "extra slash", header: "tempo/charge/extra", wantErr: true},
+		{name: "q-value above one", header: "tempo/charge;q=2", wantErr: true},
+		{name: "q-value too precise", header: "tempo/charge;q=0.1234", wantErr: true},
+		{name: "missing parameter value", header: "tempo/charge;q", wantErr: true},
+		{name: "invalid parameter name", header: "tempo/charge;bad name=value", wantErr: true},
+		{name: "unterminated quote", header: `tempo/charge;profile="unterminated`, wantErr: true},
+		{name: "trailing comma", header: "tempo/charge,", wantErr: true},
+		{name: "conflicting duplicate q", header: "tempo/charge;q=0;q=1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAcceptPayment(tt.header)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.normalized, serializeAcceptPayment(got))
+		})
+	}
+}
+
+func TestSplitHeaderList(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:   "simple list",
+			header: "tempo/charge, stripe/charge",
+			want:   []string{"tempo/charge", "stripe/charge"},
+		},
+		{
+			name:   "quoted comma and semicolon",
+			header: `tempo/charge;profile="a,b;c", stripe/charge`,
+			want:   []string{`tempo/charge;profile="a,b;c"`, "stripe/charge"},
+		},
+		{
+			name:   "escaped quote before comma",
+			header: `tempo/charge;profile="a\",b", stripe/charge`,
+			want:   []string{`tempo/charge;profile="a\",b"`, "stripe/charge"},
+		},
+		{name: "unterminated quote", header: `tempo/charge;profile="a,b`, wantErr: true},
+		{name: "dangling quoted escape", header: `tempo/charge;profile="a\`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitHeaderList(tt.header)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBestPaymentPreference(t *testing.T) {
 	preferences, err := parseAcceptPayment("tempo/*, tempo/charge;q=0, */charge;q=0.5")
 	require.NoError(t, err)
 
@@ -93,41 +218,11 @@ func TestParseAcceptPayment_BestMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preference, ok := bestPaymentPreference(&mpp.Challenge{
-				Method: tt.method,
-				Intent: tt.intent,
-			}, preferences)
+			preference, ok := bestPaymentPreference(&mpp.Challenge{Method: tt.method, Intent: tt.intent}, preferences)
 			assert.Equal(t, tt.wantMatch, ok)
 			if ok {
 				assert.Equal(t, tt.want, preference.quality)
 			}
-		})
-	}
-}
-
-func TestParseAcceptPayment_QuotedParametersAndCaseInsensitiveQuality(t *testing.T) {
-	preferences, err := parseAcceptPayment(`tempo/charge;profile="a,b;c";Q=0, stripe/charge`)
-	require.NoError(t, err)
-	require.Len(t, preferences, 2)
-	assert.Equal(t, float64(0), preferences[0].quality)
-	assert.Equal(t, "stripe", preferences[1].method)
-}
-
-func TestParseAcceptPayment_RejectsMalformedValues(t *testing.T) {
-	for _, value := range []string{
-		"",
-		"tempo",
-		"tempo/charge/extra",
-		"tempo/charge;q=2",
-		"tempo/charge;q=0.1234",
-		"tempo/charge;q",
-		"tempo/charge;bad name=value",
-		`tempo/charge;profile="unterminated`,
-		"tempo/charge,",
-	} {
-		t.Run(value, func(t *testing.T) {
-			_, err := parseAcceptPayment(value)
-			assert.Error(t, err)
 		})
 	}
 }
@@ -141,45 +236,238 @@ func (m *matchingMockMethod) CanHandleChallenge(challenge *mpp.Challenge) bool {
 	return m.canHandle(challenge)
 }
 
-func TestTransport_RoundTrip_UsesChallengeMatcher(t *testing.T) {
-	var challenge *mpp.Challenge
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
-			w.WriteHeader(http.StatusPaymentRequired)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	parsedURL, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-	challenge = mpp.NewChallenge("secret", parsedURL.Host, "tempo", "session", map[string]any{
-		"protocol": "fallback",
-	})
-	primary := &matchingMockMethod{
-		mockMethod: &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")},
+func TestTransportChallengeCandidates(t *testing.T) {
+	tempoCharge := &mockMethod{name: "tempo", intent: "charge"}
+	tempoSession := &mockMethod{name: "tempo", intent: "session"}
+	stripeCharge := &mockMethod{name: "stripe", intent: "charge"}
+	primarySession := &matchingMockMethod{
+		mockMethod: &mockMethod{name: "tempo", intent: "session"},
 		canHandle: func(challenge *mpp.Challenge) bool {
-			return challenge.Request["protocol"] == "primary"
+			details, _ := challenge.Request["methodDetails"].(map[string]any)
+			return details["sessionProtocol"] == "primary"
 		},
 	}
-	fallback := &matchingMockMethod{
-		mockMethod: &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")},
+	fallbackSession := &matchingMockMethod{
+		mockMethod: &mockMethod{name: "tempo", intent: "session"},
 		canHandle: func(challenge *mpp.Challenge) bool {
-			return challenge.Request["protocol"] == "fallback"
+			details, _ := challenge.Request["methodDetails"].(map[string]any)
+			protocol, _ := details["sessionProtocol"].(string)
+			return protocol == "" || protocol == "fallback"
+		},
+	}
+	now := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		methods     []Method
+		challenges  []mpp.Challenge
+		preferences string
+		wantIDs     []string
+		wantMethods []Method
+	}{
+		{
+			name:    "higher q then server order for ties",
+			methods: []Method{tempoCharge, stripeCharge, tempoSession},
+			challenges: []mpp.Challenge{
+				{ID: "stripe", Method: "stripe", Intent: "charge"},
+				{ID: "tempo-charge", Method: "tempo", Intent: "charge"},
+				{ID: "tempo-session", Method: "tempo", Intent: "session"},
+			},
+			preferences: "stripe/charge;q=0.5, tempo/charge;q=0.9, tempo/session;q=0.9",
+			wantIDs:     []string{"tempo-charge", "tempo-session", "stripe"},
+		},
+		{
+			name:    "specific opt out overrides wildcard",
+			methods: []Method{tempoCharge, stripeCharge},
+			challenges: []mpp.Challenge{
+				{ID: "tempo", Method: "tempo", Intent: "charge"},
+				{ID: "stripe", Method: "stripe", Intent: "charge"},
+			},
+			preferences: "tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5",
+			wantIDs:     []string{"stripe"},
+		},
+		{
+			name:    "unsupported and disabled offers excluded",
+			methods: []Method{tempoCharge},
+			challenges: []mpp.Challenge{
+				{ID: "unknown", Method: "unknown", Intent: "charge"},
+				{ID: "tempo", Method: "tempo", Intent: "charge"},
+			},
+			preferences: "tempo/charge;q=0, unknown/charge",
+			wantIDs:     []string{},
+		},
+		{
+			name:    "duplicate capabilities use predicates",
+			methods: []Method{primarySession, fallbackSession},
+			challenges: []mpp.Challenge{
+				{ID: "primary", Method: "tempo", Intent: "session", Request: map[string]any{"methodDetails": map[string]any{"sessionProtocol": "primary"}}},
+				{ID: "fallback", Method: "tempo", Intent: "session", Request: map[string]any{"methodDetails": map[string]any{"sessionProtocol": "fallback"}}},
+				{ID: "unmarked", Method: "tempo", Intent: "session", Request: map[string]any{}},
+			},
+			preferences: "tempo/session",
+			wantIDs:     []string{"primary", "fallback", "unmarked"},
+			wantMethods: []Method{primarySession, fallbackSession, fallbackSession},
+		},
+		{
+			name:    "expired and malformed expiry skipped",
+			methods: []Method{tempoCharge},
+			challenges: []mpp.Challenge{
+				{ID: "expired", Method: "tempo", Intent: "charge", Expires: now.Add(-time.Minute).Format(time.RFC3339)},
+				{ID: "malformed", Method: "tempo", Intent: "charge", Expires: "later"},
+				{ID: "valid", Method: "tempo", Intent: "charge", Expires: now.Add(time.Minute).Format(time.RFC3339)},
+			},
+			preferences: "tempo/charge",
+			wantIDs:     []string{"valid"},
 		},
 	}
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	require.NoError(t, err)
-	resp, err := NewTransport([]Method{primary, fallback}, nil).RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preferences, err := parseAcceptPayment(tt.preferences)
+			require.NoError(t, err)
+			transport := NewTransport(tt.methods, roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return nil, nil
+			}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Zero(t, primary.calls)
-	assert.Equal(t, 1, fallback.calls)
+			got := transport.challengeCandidates(tt.challenges, preferences, now)
+			ids := make([]string, len(got))
+			for i, candidate := range got {
+				ids[i] = candidate.challenge.ID
+				if tt.wantMethods != nil {
+					assert.Same(t, tt.wantMethods[i], candidate.method)
+				}
+			}
+			assert.Equal(t, tt.wantIDs, ids)
+		})
+	}
+}
+
+type challengeSpec struct {
+	method  string
+	intent  string
+	request map[string]any
+}
+
+func TestTransport_RoundTrip_PaymentNegotiation(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func() ([]Method, []*mockMethod)
+		challenges []challengeSpec
+		configured PaymentPreferences
+		explicit   string
+		wantHeader string
+		wantStatus int
+		wantCalls  []int
+	}{
+		{
+			name: "challenge predicates select matching duplicate handler",
+			setup: func() ([]Method, []*mockMethod) {
+				primary := &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")}
+				fallback := &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")}
+				return []Method{
+					&matchingMockMethod{mockMethod: primary, canHandle: func(challenge *mpp.Challenge) bool {
+						return challenge.Request["protocol"] == "primary"
+					}},
+					&matchingMockMethod{mockMethod: fallback, canHandle: func(challenge *mpp.Challenge) bool {
+						return challenge.Request["protocol"] == "fallback"
+					}},
+				}, []*mockMethod{primary, fallback}
+			},
+			challenges: []challengeSpec{{method: "tempo", intent: "session", request: map[string]any{"protocol": "fallback"}}},
+			wantHeader: "tempo/session",
+			wantStatus: http.StatusOK,
+			wantCalls:  []int{0, 1},
+		},
+		{
+			name: "explicit specific opt out overrides wildcard",
+			setup: func() ([]Method, []*mockMethod) {
+				charge := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
+				session := &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")}
+				return []Method{charge, session}, []*mockMethod{charge, session}
+			},
+			challenges: []challengeSpec{
+				{method: "tempo", intent: "charge"},
+				{method: "tempo", intent: "session"},
+			},
+			explicit:   "tempo/*, tempo/charge;q=0",
+			wantHeader: "tempo/*, tempo/charge;q=0",
+			wantStatus: http.StatusOK,
+			wantCalls:  []int{0, 1},
+		},
+		{
+			name: "malformed explicit header falls back to configured ranking",
+			setup: func() ([]Method, []*mockMethod) {
+				tempo := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
+				stripe := &mockMethod{name: "stripe", intent: "charge", cred: newTestCredential("stripe")}
+				return []Method{tempo, stripe}, []*mockMethod{tempo, stripe}
+			},
+			challenges: []challengeSpec{
+				{method: "stripe", intent: "charge"},
+				{method: "tempo", intent: "charge"},
+			},
+			configured: PaymentPreferences{"stripe/charge": 0.5},
+			explicit:   "not a valid header",
+			wantHeader: "not a valid header",
+			wantStatus: http.StatusOK,
+			wantCalls:  []int{1, 0},
+		},
+		{
+			name: "q zero disables every supported offer",
+			setup: func() ([]Method, []*mockMethod) {
+				tempo := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
+				return []Method{tempo}, []*mockMethod{tempo}
+			},
+			challenges: []challengeSpec{{method: "tempo", intent: "charge"}},
+			explicit:   "tempo/charge;q=0",
+			wantHeader: "tempo/charge;q=0",
+			wantStatus: http.StatusPaymentRequired,
+			wantCalls:  []int{0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var challenges []*mpp.Challenge
+			var acceptPayment string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") == "" {
+					acceptPayment = r.Header.Get("Accept-Payment")
+					for _, challenge := range challenges {
+						w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+					}
+					w.WriteHeader(http.StatusPaymentRequired)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			parsedURL, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+			for _, spec := range tt.challenges {
+				challenges = append(challenges, mpp.NewChallenge("secret", parsedURL.Host, spec.method, spec.intent, spec.request))
+			}
+			methods, tracked := tt.setup()
+			transport := NewTransport(methods, nil, WithTransportPaymentPreferences(tt.configured))
+			req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+			require.NoError(t, err)
+			if tt.explicit != "" {
+				req.Header.Set("Accept-Payment", tt.explicit)
+			}
+
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+			assert.Equal(t, tt.wantHeader, acceptPayment)
+			calls := make([]int, len(tracked))
+			for i, method := range tracked {
+				calls[i] = method.calls
+			}
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
 }
 
 func TestClient_PaymentPreferences(t *testing.T) {
@@ -220,86 +508,147 @@ func TestClient_PaymentPreferences(t *testing.T) {
 	assert.Equal(t, 1, stripeMethod.calls)
 }
 
-func TestTransport_RoundTrip_ExplicitAcceptPaymentOverridesConfiguredPreferences(t *testing.T) {
-	var challenges []*mpp.Challenge
-	var acceptPayment string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "" {
-			acceptPayment = r.Header.Get("Accept-Payment")
-			for _, challenge := range challenges {
-				w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
-			}
-			w.WriteHeader(http.StatusPaymentRequired)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	parsedURL, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-	challenges = []*mpp.Challenge{
-		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "charge", nil),
-		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "session", nil),
-	}
-	charge := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
-	session := &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")}
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	require.NoError(t, err)
-	req.Header.Set("Accept-Payment", "tempo/*, tempo/charge;q=0")
-
-	resp, err := NewTransport([]Method{charge, session}, nil).RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, "tempo/*, tempo/charge;q=0", acceptPayment)
-	assert.Zero(t, charge.calls)
-	assert.Equal(t, 1, session.calls)
-}
-
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestTransport_RoundTrip_AdvertisesCapabilitiesWithoutMutatingRequest(t *testing.T) {
-	var acceptPayment string
-	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		acceptPayment = req.Header.Get("Accept-Payment")
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("")),
-		}, nil
-	})
-	method := &mockMethod{name: "tempo", intent: "charge"}
-	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
-	require.NoError(t, err)
+func TestTransportPrepareRequest(t *testing.T) {
+	tempo := &mockMethod{name: "tempo", intent: "charge"}
+	stripe := &mockMethod{name: "stripe", intent: "charge"}
 
-	resp, err := NewTransport([]Method{method}, inner).RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+	tests := []struct {
+		name          string
+		methods       []Method
+		configured    PaymentPreferences
+		explicit      string
+		hasExplicit   bool
+		nilHeader     bool
+		wantHeader    string
+		wantQuality   float64
+		wantMatch     bool
+		wantSameInput bool
+	}{
+		{
+			name:        "advertises configured capabilities",
+			methods:     []Method{tempo, stripe},
+			configured:  PaymentPreferences{"tempo/charge": 0.5},
+			wantHeader:  "tempo/charge;q=0.5, stripe/charge",
+			wantQuality: 0.5,
+			wantMatch:   true,
+		},
+		{
+			name:          "explicit header overrides configured preferences",
+			methods:       []Method{tempo, stripe},
+			configured:    PaymentPreferences{"tempo/charge": 0.5},
+			explicit:      "stripe/charge, tempo/charge;q=0.1",
+			hasExplicit:   true,
+			wantHeader:    "stripe/charge, tempo/charge;q=0.1",
+			wantQuality:   0.1,
+			wantMatch:     true,
+			wantSameInput: true,
+		},
+		{
+			name:          "malformed explicit header falls back without replacement",
+			methods:       []Method{tempo},
+			configured:    PaymentPreferences{"tempo/charge": 0.25},
+			explicit:      "not a valid header",
+			hasExplicit:   true,
+			wantHeader:    "not a valid header",
+			wantQuality:   0.25,
+			wantMatch:     true,
+			wantSameInput: true,
+		},
+		{
+			name:          "no capabilities leaves request unchanged",
+			wantSameInput: true,
+		},
+		{
+			name:        "nil header is initialized on clone",
+			methods:     []Method{tempo},
+			nilHeader:   true,
+			wantHeader:  "tempo/charge",
+			wantQuality: 1,
+			wantMatch:   true,
+		},
+	}
 
-	assert.Equal(t, "tempo/charge", acceptPayment)
-	assert.Empty(t, req.Header.Get("Accept-Payment"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewTransport(
+				tt.methods,
+				roundTripperFunc(func(*http.Request) (*http.Response, error) { return nil, nil }),
+				WithTransportPaymentPreferences(tt.configured),
+			)
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
+			if tt.nilHeader {
+				req.Header = nil
+			}
+			if tt.hasExplicit {
+				req.Header.Set("Accept-Payment", tt.explicit)
+			}
+
+			got, preferences := transport.prepareRequest(req)
+			assert.Equal(t, tt.wantSameInput, got == req)
+			assert.Equal(t, tt.wantHeader, got.Header.Get("Accept-Payment"))
+			if !tt.hasExplicit {
+				assert.Empty(t, req.Header.Get("Accept-Payment"))
+			}
+			preference, ok := bestPaymentPreference(&mpp.Challenge{Method: "tempo", Intent: "charge"}, preferences)
+			assert.Equal(t, tt.wantMatch, ok)
+			if ok {
+				assert.Equal(t, tt.wantQuality, preference.quality)
+			}
+		})
+	}
 }
 
 func TestTransport_RoundTrip_InvalidPreferencesFailBeforeRequest(t *testing.T) {
-	called := false
-	inner := roundTripperFunc(func(*http.Request) (*http.Response, error) {
-		called = true
-		return &http.Response{Body: io.NopCloser(strings.NewReader(""))}, nil
-	})
-	method := &mockMethod{name: "tempo", intent: "charge"}
-	transport := NewTransport(
-		[]Method{method},
-		inner,
-		WithTransportPaymentPreferences(PaymentPreferences{"unknown/charge": 1}),
-	)
-	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
-	require.NoError(t, err)
+	tests := []struct {
+		name        string
+		method      Method
+		preferences PaymentPreferences
+		wantErr     string
+	}{
+		{
+			name:        "unknown capability",
+			method:      &mockMethod{name: "tempo", intent: "charge"},
+			preferences: PaymentPreferences{"unknown/charge": 1},
+			wantErr:     `unknown payment preference "unknown/charge"`,
+		},
+		{
+			name:        "invalid q-value",
+			method:      &mockMethod{name: "tempo", intent: "charge"},
+			preferences: PaymentPreferences{"tempo/charge": 0.1234},
+			wantErr:     "at most three decimal places",
+		},
+		{
+			name:    "invalid capability token",
+			method:  &mockMethod{name: "bad/name", intent: "charge"},
+			wantErr: `invalid payment method capability "bad/name/charge"`,
+		},
+	}
 
-	_, err = transport.RoundTrip(req)
-	assert.ErrorContains(t, err, `unknown payment preference "unknown/charge"`)
-	assert.False(t, called)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			inner := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				called = true
+				return &http.Response{Body: io.NopCloser(strings.NewReader(""))}, nil
+			})
+			transport := NewTransport(
+				[]Method{tt.method},
+				inner,
+				WithTransportPaymentPreferences(tt.preferences),
+			)
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(req)
+			assert.ErrorContains(t, err, tt.wantErr)
+			assert.False(t, called)
+		})
+	}
 }

--- a/pkg/client/accept_payment_test.go
+++ b/pkg/client/accept_payment_test.go
@@ -1,0 +1,296 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+func TestResolvePaymentPreferences(t *testing.T) {
+	methods := []Method{
+		&mockMethod{name: "tempo", intent: "charge"},
+		&mockMethod{name: "tempo", intent: "charge"},
+		&mockMethod{name: "tempo", intent: "session"},
+		&mockMethod{name: "stripe", intent: "charge"},
+	}
+
+	tests := []struct {
+		name        string
+		configured  PaymentPreferences
+		wantHeader  string
+		wantQuality []float64
+		wantErr     string
+	}{
+		{
+			name:        "defaults and deduplicates",
+			wantHeader:  "tempo/charge, tempo/session, stripe/charge",
+			wantQuality: []float64{1, 1, 1},
+		},
+		{
+			name: "configured q-values",
+			configured: PaymentPreferences{
+				"tempo/charge":  0,
+				"stripe/charge": 0.125,
+			},
+			wantHeader:  "tempo/charge;q=0, tempo/session, stripe/charge;q=0.125",
+			wantQuality: []float64{0, 1, 0.125},
+		},
+		{
+			name:       "unknown method",
+			configured: PaymentPreferences{"evm/charge": 1},
+			wantErr:    `unknown payment preference "evm/charge"`,
+		},
+		{
+			name:       "invalid q-value",
+			configured: PaymentPreferences{"tempo/charge": 0.1234},
+			wantErr:    "at most three decimal places",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preferences, header, err := resolvePaymentPreferences(methods, tt.configured)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHeader, header)
+			qualities := make([]float64, len(preferences))
+			for i, preference := range preferences {
+				qualities[i] = preference.quality
+			}
+			assert.Equal(t, tt.wantQuality, qualities)
+		})
+	}
+}
+
+func TestParseAcceptPayment_BestMatch(t *testing.T) {
+	preferences, err := parseAcceptPayment("tempo/*, tempo/charge;q=0, */charge;q=0.5")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		method    string
+		intent    string
+		want      float64
+		wantMatch bool
+	}{
+		{name: "specific opt out", method: "tempo", intent: "charge", want: 0, wantMatch: true},
+		{name: "method wildcard", method: "tempo", intent: "session", want: 1, wantMatch: true},
+		{name: "intent wildcard", method: "stripe", intent: "charge", want: 0.5, wantMatch: true},
+		{name: "unsupported", method: "stripe", intent: "session", wantMatch: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preference, ok := bestPaymentPreference(&mpp.Challenge{
+				Method: tt.method,
+				Intent: tt.intent,
+			}, preferences)
+			assert.Equal(t, tt.wantMatch, ok)
+			if ok {
+				assert.Equal(t, tt.want, preference.quality)
+			}
+		})
+	}
+}
+
+func TestParseAcceptPayment_RejectsMalformedValues(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"tempo",
+		"Tempo/charge",
+		"tempo/charge/extra",
+		"tempo/charge;q=2",
+		"tempo/charge;q=0.1234",
+		"tempo/charge;q",
+		"tempo/charge;bad name=value",
+		"tempo/charge,",
+	} {
+		t.Run(value, func(t *testing.T) {
+			_, err := parseAcceptPayment(value)
+			assert.Error(t, err)
+		})
+	}
+}
+
+type matchingMockMethod struct {
+	*mockMethod
+	canHandle func(*mpp.Challenge) bool
+}
+
+func (m *matchingMockMethod) CanHandleChallenge(challenge *mpp.Challenge) bool {
+	return m.canHandle(challenge)
+}
+
+func TestTransport_RoundTrip_UsesChallengeMatcher(t *testing.T) {
+	var challenge *mpp.Challenge
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	challenge = mpp.NewChallenge("secret", parsedURL.Host, "tempo", "session", map[string]any{
+		"protocol": "fallback",
+	})
+	primary := &matchingMockMethod{
+		mockMethod: &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")},
+		canHandle: func(challenge *mpp.Challenge) bool {
+			return challenge.Request["protocol"] == "primary"
+		},
+	}
+	fallback := &matchingMockMethod{
+		mockMethod: &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")},
+		canHandle: func(challenge *mpp.Challenge) bool {
+			return challenge.Request["protocol"] == "fallback"
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := NewTransport([]Method{primary, fallback}, nil).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Zero(t, primary.calls)
+	assert.Equal(t, 1, fallback.calls)
+}
+
+func TestClient_PaymentPreferences(t *testing.T) {
+	var challenges []*mpp.Challenge
+	var acceptPayment string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			acceptPayment = r.Header.Get("Accept-Payment")
+			for _, challenge := range challenges {
+				w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			}
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	challenges = []*mpp.Challenge{
+		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "charge", nil),
+		mpp.NewChallenge("secret", parsedURL.Host, "stripe", "charge", nil),
+	}
+	tempoMethod := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
+	stripeMethod := &mockMethod{name: "stripe", intent: "charge", cred: newTestCredential("stripe")}
+	c := New(
+		[]Method{tempoMethod, stripeMethod},
+		WithPaymentPreferences(PaymentPreferences{"tempo/charge": 0.5}),
+	)
+
+	resp, err := c.Get(context.Background(), srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "tempo/charge;q=0.5, stripe/charge", acceptPayment)
+	assert.Zero(t, tempoMethod.calls)
+	assert.Equal(t, 1, stripeMethod.calls)
+}
+
+func TestTransport_RoundTrip_ExplicitAcceptPaymentOverridesConfiguredPreferences(t *testing.T) {
+	var challenges []*mpp.Challenge
+	var acceptPayment string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			acceptPayment = r.Header.Get("Accept-Payment")
+			for _, challenge := range challenges {
+				w.Header().Add("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			}
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	parsedURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	challenges = []*mpp.Challenge{
+		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "charge", nil),
+		mpp.NewChallenge("secret", parsedURL.Host, "tempo", "session", nil),
+	}
+	charge := &mockMethod{name: "tempo", intent: "charge", cred: newTestCredential("tempo")}
+	session := &mockMethod{name: "tempo", intent: "session", cred: newTestCredential("tempo")}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Payment", "tempo/*, tempo/charge;q=0")
+
+	resp, err := NewTransport([]Method{charge, session}, nil).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "tempo/*, tempo/charge;q=0", acceptPayment)
+	assert.Zero(t, charge.calls)
+	assert.Equal(t, 1, session.calls)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestTransport_RoundTrip_AdvertisesCapabilitiesWithoutMutatingRequest(t *testing.T) {
+	var acceptPayment string
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		acceptPayment = req.Header.Get("Accept-Payment")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+	method := &mockMethod{name: "tempo", intent: "charge"}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := NewTransport([]Method{method}, inner).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "tempo/charge", acceptPayment)
+	assert.Empty(t, req.Header.Get("Accept-Payment"))
+}
+
+func TestTransport_RoundTrip_InvalidPreferencesFailBeforeRequest(t *testing.T) {
+	called := false
+	inner := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{Body: io.NopCloser(strings.NewReader(""))}, nil
+	})
+	method := &mockMethod{name: "tempo", intent: "charge"}
+	transport := NewTransport(
+		[]Method{method},
+		inner,
+		WithTransportPaymentPreferences(PaymentPreferences{"unknown/charge": 1}),
+	)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	assert.ErrorContains(t, err, `unknown payment preference "unknown/charge"`)
+	assert.False(t, called)
+}

--- a/pkg/client/accept_payment_test.go
+++ b/pkg/client/accept_payment_test.go
@@ -20,6 +20,7 @@ func TestResolvePaymentPreferences(t *testing.T) {
 		&mockMethod{name: "tempo", intent: "charge"},
 		&mockMethod{name: "tempo", intent: "session"},
 		&mockMethod{name: "stripe", intent: "charge"},
+		&mockMethod{name: "custom", intent: "pre_authorize"},
 	}
 
 	tests := []struct {
@@ -31,8 +32,8 @@ func TestResolvePaymentPreferences(t *testing.T) {
 	}{
 		{
 			name:        "defaults and deduplicates",
-			wantHeader:  "tempo/charge, tempo/session, stripe/charge",
-			wantQuality: []float64{1, 1, 1},
+			wantHeader:  "tempo/charge, tempo/session, stripe/charge, custom/pre_authorize",
+			wantQuality: []float64{1, 1, 1, 1},
 		},
 		{
 			name: "configured q-values",
@@ -40,8 +41,8 @@ func TestResolvePaymentPreferences(t *testing.T) {
 				"tempo/charge":  0,
 				"stripe/charge": 0.125,
 			},
-			wantHeader:  "tempo/charge;q=0, tempo/session, stripe/charge;q=0.125",
-			wantQuality: []float64{0, 1, 0.125},
+			wantHeader:  "tempo/charge;q=0, tempo/session, stripe/charge;q=0.125, custom/pre_authorize",
+			wantQuality: []float64{0, 1, 0.125, 1},
 		},
 		{
 			name:       "unknown method",
@@ -104,16 +105,24 @@ func TestParseAcceptPayment_BestMatch(t *testing.T) {
 	}
 }
 
+func TestParseAcceptPayment_QuotedParametersAndCaseInsensitiveQuality(t *testing.T) {
+	preferences, err := parseAcceptPayment(`tempo/charge;profile="a,b;c";Q=0, stripe/charge`)
+	require.NoError(t, err)
+	require.Len(t, preferences, 2)
+	assert.Equal(t, float64(0), preferences[0].quality)
+	assert.Equal(t, "stripe", preferences[1].method)
+}
+
 func TestParseAcceptPayment_RejectsMalformedValues(t *testing.T) {
 	for _, value := range []string{
 		"",
 		"tempo",
-		"Tempo/charge",
 		"tempo/charge/extra",
 		"tempo/charge;q=2",
 		"tempo/charge;q=0.1234",
 		"tempo/charge;q",
 		"tempo/charge;bad name=value",
+		`tempo/charge;profile="unterminated`,
 		"tempo/charge,",
 	} {
 		t.Run(value, func(t *testing.T) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,17 @@ type Method interface {
 	CreateCredential(ctx context.Context, challenge *mpp.Challenge) (*mpp.Credential, error)
 }
 
+// ChallengeMatcher may be implemented by a Method that only handles some
+// challenges for its method and intent. It allows multiple handlers for the
+// same method and intent to select between method-specific request details.
+type ChallengeMatcher interface {
+	CanHandleChallenge(challenge *mpp.Challenge) bool
+}
+
+// PaymentPreferences assigns HTTP q-values to configured payment methods.
+// Keys use the "method/intent" form. Omitted methods default to q=1.
+type PaymentPreferences map[string]float64
+
 type methodKey struct {
 	name   string
 	intent string
@@ -31,8 +42,9 @@ func keyForMethod(method Method) methodKey {
 
 // Client is an HTTP client with automatic 402 payment handling.
 type Client struct {
-	methods    map[methodKey]Method
-	httpClient *http.Client
+	methods            []Method
+	httpClient         *http.Client
+	paymentPreferences PaymentPreferences
 }
 
 // Option configures the Client.
@@ -45,14 +57,20 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
+// WithPaymentPreferences sets client payment preferences. The preferences are
+// advertised in Accept-Payment and used to rank server challenges. Unknown
+// keys and invalid q-values cause Do to fail before sending the request.
+func WithPaymentPreferences(preferences PaymentPreferences) Option {
+	return func(c *Client) {
+		c.paymentPreferences = clonePaymentPreferences(preferences)
+	}
+}
+
 // New creates a Client with the given payment methods.
 func New(methods []Method, opts ...Option) *Client {
 	c := &Client{
-		methods:    make(map[methodKey]Method, len(methods)),
+		methods:    append([]Method(nil), methods...),
 		httpClient: http.DefaultClient,
-	}
-	for _, m := range methods {
-		c.methods[keyForMethod(m)] = m
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -71,10 +89,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	origin := requestOrigin(req.URL)
 	req = req.WithContext(withPaymentOrigin(req.Context(), origin))
 
-	transport := &Transport{
-		methods: c.methods,
-		inner:   inner,
-	}
+	transport := NewTransport(c.methods, inner, WithTransportPaymentPreferences(c.paymentPreferences))
 
 	// Use a copy of the http.Client with our payment-aware transport.
 	hc := *c.httpClient

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,30 +16,63 @@ import (
 // Transport is an http.RoundTripper that handles 402 Payment Required responses.
 // It wraps an inner transport and automatically negotiates payment.
 type Transport struct {
-	methods map[methodKey]Method
-	inner   http.RoundTripper
+	methods            map[methodKey][]Method
+	inner              http.RoundTripper
+	paymentPreferences []paymentPreference
+	acceptPayment      string
+	configErr          error
 }
 
 type paymentOriginContextKey struct{}
 
+// TransportOption configures a Transport.
+type TransportOption func(*transportConfig)
+
+type transportConfig struct {
+	paymentPreferences PaymentPreferences
+}
+
+// WithTransportPaymentPreferences sets payment preferences on a standalone
+// Transport. Client users should use WithPaymentPreferences instead. Unknown
+// keys and invalid q-values cause RoundTrip to fail before sending the request.
+func WithTransportPaymentPreferences(preferences PaymentPreferences) TransportOption {
+	return func(config *transportConfig) {
+		config.paymentPreferences = clonePaymentPreferences(preferences)
+	}
+}
+
 // NewTransport creates a payment-aware transport.
-func NewTransport(methods []Method, inner http.RoundTripper) *Transport {
+func NewTransport(methods []Method, inner http.RoundTripper, opts ...TransportOption) *Transport {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	m := make(map[methodKey]Method, len(methods))
-	for _, method := range methods {
-		m[keyForMethod(method)] = method
+	config := new(transportConfig)
+	for _, opt := range opts {
+		opt(config)
 	}
+	m := make(map[methodKey][]Method, len(methods))
+	for _, method := range methods {
+		key := keyForMethod(method)
+		m[key] = append(m[key], method)
+	}
+	preferences, header, err := resolvePaymentPreferences(methods, config.paymentPreferences)
 	return &Transport{
-		methods: m,
-		inner:   inner,
+		methods:            m,
+		inner:              inner,
+		paymentPreferences: preferences,
+		acceptPayment:      header,
+		configErr:          err,
 	}
 }
 
 // RoundTrip implements http.RoundTripper with automatic 402 handling.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := t.inner.RoundTrip(req)
+	if t.configErr != nil {
+		return nil, t.configErr
+	}
+
+	request, preferences := t.prepareRequest(req)
+	resp, err := t.inner.RoundTrip(request)
 	if err != nil {
 		return nil, err
 	}
@@ -50,9 +84,8 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	challenges, errs := t.parseChallenges(resp.Header)
 	_ = errs // Non-Payment or malformed headers are silently skipped.
 
-	// Find first challenge with a matching method that hasn't expired.
-	var matched *mpp.Challenge
-	var method Method
+	// Find the preferred challenge and method that can handle it.
+	candidates := make([]challengeCandidate, 0, len(challenges))
 	now := time.Now().UTC()
 	for i := range challenges {
 		ch := &challenges[i]
@@ -69,18 +102,35 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				continue
 			}
 		}
-		if m, ok := t.methods[methodKey{name: ch.Method, intent: ch.Intent}]; ok {
-			matched = ch
-			method = m
-			break
+		methods := t.methods[methodKey{name: ch.Method, intent: ch.Intent}]
+		if len(methods) == 0 {
+			continue
+		}
+		preference, ok := bestPaymentPreference(ch, preferences)
+		if !ok || preference.quality == 0 {
+			continue
+		}
+		for _, method := range methods {
+			if matcher, ok := method.(ChallengeMatcher); ok && !matcher.CanHandleChallenge(ch) {
+				continue
+			}
+			candidates = append(candidates, challengeCandidate{
+				challenge: ch,
+				method:    method,
+				quality:   preference.quality,
+			})
 		}
 	}
 
-	if matched == nil {
+	if len(candidates) == 0 {
 		// No matching method found — return original 402 response as-is.
 		return resp, nil
 	}
-	if err := validatePaymentOrigin(req, matched); err != nil {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].quality > candidates[j].quality
+	})
+	selected := candidates[0]
+	if err := validatePaymentOrigin(request, selected.challenge); err != nil {
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		return nil, err
@@ -91,19 +141,53 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp.Body.Close()
 
 	// Create payment credential.
-	cred, err := method.CreateCredential(req.Context(), matched)
+	cred, err := selected.method.CreateCredential(request.Context(), selected.challenge)
 	if err != nil {
-		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", matched.Method, err)
+		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", selected.challenge.Method, err)
 	}
 
 	// Clone the original request for retry.
-	retry, err := t.cloneRequest(req)
+	retry, err := t.cloneRequest(request)
 	if err != nil {
 		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
 	}
 	retry.Header.Set("Authorization", cred.ToAuthorization())
 
 	return t.inner.RoundTrip(retry)
+}
+
+type challengeCandidate struct {
+	challenge *mpp.Challenge
+	method    Method
+	quality   float64
+}
+
+func (t *Transport) prepareRequest(req *http.Request) (*http.Request, []paymentPreference) {
+	if header, ok := headerValue(req.Header, "Accept-Payment"); ok {
+		if preferences, err := parseAcceptPayment(header); err == nil {
+			return req, preferences
+		}
+		return req, t.paymentPreferences
+	}
+	if t.acceptPayment == "" {
+		return req, t.paymentPreferences
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = req.Header.Clone()
+	if clone.Header == nil {
+		clone.Header = make(http.Header)
+	}
+	clone.Header.Set("Accept-Payment", t.acceptPayment)
+	return clone, t.paymentPreferences
+}
+
+func headerValue(header http.Header, name string) (string, bool) {
+	for key, values := range header {
+		if strings.EqualFold(key, name) {
+			return strings.Join(values, ", "), true
+		}
+	}
+	return "", false
 }
 
 // parseChallengeExpiry parses a challenge expiry using RFC 3339 and the

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -84,9 +84,41 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	challenges, errs := t.parseChallenges(resp.Header)
 	_ = errs // Non-Payment or malformed headers are silently skipped.
 
-	// Find the preferred challenge and method that can handle it.
+	candidates := t.challengeCandidates(challenges, preferences, time.Now().UTC())
+
+	if len(candidates) == 0 {
+		// No matching method found — return original 402 response as-is.
+		return resp, nil
+	}
+	selected := candidates[0]
+	if err := validatePaymentOrigin(request, selected.challenge); err != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		return nil, err
+	}
+
+	// Drain and close the 402 response body so the connection can be reused.
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Create payment credential.
+	cred, err := selected.method.CreateCredential(request.Context(), selected.challenge)
+	if err != nil {
+		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", selected.challenge.Method, err)
+	}
+
+	// Clone the original request for retry.
+	retry, err := t.cloneRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
+	}
+	retry.Header.Set("Authorization", cred.ToAuthorization())
+
+	return t.inner.RoundTrip(retry)
+}
+
+func (t *Transport) challengeCandidates(challenges []mpp.Challenge, preferences []paymentPreference, now time.Time) []challengeCandidate {
 	candidates := make([]challengeCandidate, 0, len(challenges))
-	now := time.Now().UTC()
 	for i := range challenges {
 		ch := &challenges[i]
 		if ch.Expires != "" {
@@ -121,39 +153,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			})
 		}
 	}
-
-	if len(candidates) == 0 {
-		// No matching method found — return original 402 response as-is.
-		return resp, nil
-	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return candidates[i].quality > candidates[j].quality
 	})
-	selected := candidates[0]
-	if err := validatePaymentOrigin(request, selected.challenge); err != nil {
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		return nil, err
-	}
-
-	// Drain and close the 402 response body so the connection can be reused.
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	// Create payment credential.
-	cred, err := selected.method.CreateCredential(request.Context(), selected.challenge)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", selected.challenge.Method, err)
-	}
-
-	// Clone the original request for retry.
-	retry, err := t.cloneRequest(request)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
-	}
-	retry.Header.Set("Authorization", cred.ToAuthorization())
-
-	return t.inner.RoundTrip(retry)
+	return candidates
 }
 
 type challengeCandidate struct {

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -112,7 +112,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
 	}
-	retry.Header.Set("Authorization", cred.ToAuthorization())
+	retry.Header.Set(mpp.HeaderAuthorization, cred.ToAuthorization())
 
 	return t.inner.RoundTrip(retry)
 }
@@ -166,7 +166,7 @@ type challengeCandidate struct {
 }
 
 func (t *Transport) prepareRequest(req *http.Request) (*http.Request, []paymentPreference) {
-	if header, ok := headerValue(req.Header, "Accept-Payment"); ok {
+	if header, ok := headerValue(req.Header, mpp.HeaderAcceptPayment); ok {
 		if preferences, err := parseAcceptPayment(header); err == nil {
 			return req, preferences
 		}
@@ -180,7 +180,7 @@ func (t *Transport) prepareRequest(req *http.Request) (*http.Request, []paymentP
 	if clone.Header == nil {
 		clone.Header = make(http.Header)
 	}
-	clone.Header.Set("Accept-Payment", t.acceptPayment)
+	clone.Header.Set(mpp.HeaderAcceptPayment, t.acceptPayment)
 	return clone, t.paymentPreferences
 }
 
@@ -225,11 +225,11 @@ func (t *Transport) cloneRequest(req *http.Request) (*http.Request, error) {
 func (t *Transport) parseChallenges(header http.Header) ([]mpp.Challenge, []error) {
 	var challenges []mpp.Challenge
 	var errs []error
-	for _, h := range header.Values("WWW-Authenticate") {
+	for _, h := range header.Values(mpp.HeaderWWWAuthenticate) {
 		for _, part := range mpp.SplitAuthenticate(h) {
 			part = strings.TrimSpace(part)
 			scheme, _, ok := strings.Cut(part, " ")
-			if !ok || !strings.EqualFold(scheme, "Payment") {
+			if !ok || !strings.EqualFold(scheme, mpp.SchemePayment) {
 				continue
 			}
 			ch, err := mpp.ParseChallenge(part)

--- a/pkg/mpp/constants.go
+++ b/pkg/mpp/constants.go
@@ -1,0 +1,17 @@
+package mpp
+
+// MPP HTTP header names.
+const (
+	HeaderAcceptPayment          = "Accept-Payment"
+	HeaderAuthorization          = "Authorization"
+	HeaderPaymentAuthorization   = "Payment-Authorization"
+	HeaderPaymentReceipt         = "Payment-Receipt"
+	HeaderPaymentSession         = "Payment-Session"
+	HeaderPaymentSessionSnapshot = "Payment-Session-Snapshot"
+	HeaderWWWAuthenticate        = "WWW-Authenticate"
+)
+
+// MPP HTTP authentication schemes.
+const (
+	SchemePayment = "Payment"
+)

--- a/pkg/mpp/constants_test.go
+++ b/pkg/mpp/constants_test.go
@@ -1,0 +1,28 @@
+package mpp
+
+import "testing"
+
+func TestProtocolConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "accept payment", got: HeaderAcceptPayment, want: "Accept-Payment"},
+		{name: "authorization", got: HeaderAuthorization, want: "Authorization"},
+		{name: "payment authorization", got: HeaderPaymentAuthorization, want: "Payment-Authorization"},
+		{name: "payment receipt", got: HeaderPaymentReceipt, want: "Payment-Receipt"},
+		{name: "payment session", got: HeaderPaymentSession, want: "Payment-Session"},
+		{name: "payment session snapshot", got: HeaderPaymentSessionSnapshot, want: "Payment-Session-Snapshot"},
+		{name: "www authenticate", got: HeaderWWWAuthenticate, want: "WWW-Authenticate"},
+		{name: "payment scheme", got: SchemePayment, want: "Payment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/mpp/json.go
+++ b/pkg/mpp/json.go
@@ -63,11 +63,11 @@ func ExtractAuthorizationSchemeStrict(header, scheme string) (string, error) {
 // FindPaymentAuthorization returns the Payment credential from an Authorization
 // header. It tolerates comma-separated schemes and ignores non-Payment values.
 func FindPaymentAuthorization(header string) string {
-	return ExtractAuthorizationScheme(header, "Payment")
+	return ExtractAuthorizationScheme(header, SchemePayment)
 }
 
 // FindPaymentAuthorizationStrict returns the Payment credential from an
 // Authorization header, or an error if more than one Payment credential exists.
 func FindPaymentAuthorizationStrict(header string) (string, error) {
-	return ExtractAuthorizationSchemeStrict(header, "Payment")
+	return ExtractAuthorizationSchemeStrict(header, SchemePayment)
 }

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -192,7 +192,7 @@ func ParseChallenge(header string) (*Challenge, error) {
 	}
 
 	scheme, rest, ok := strings.Cut(header, " ")
-	if !ok || !strings.EqualFold(scheme, "Payment") {
+	if !ok || !strings.EqualFold(scheme, SchemePayment) {
 		return nil, fmt.Errorf("mpp: expected Payment scheme, got %q", scheme)
 	}
 
@@ -314,7 +314,7 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 		}
 	}
 
-	return "Payment " + strings.Join(parts, ", "), nil
+	return SchemePayment + " " + strings.Join(parts, ", "), nil
 }
 
 func b64EncodeRequest(request map[string]any) string {
@@ -351,7 +351,7 @@ func ParseCredential(header string) (*Credential, error) {
 	}
 
 	scheme, rest, ok := strings.Cut(header, " ")
-	if !ok || !strings.EqualFold(scheme, "Payment") {
+	if !ok || !strings.EqualFold(scheme, SchemePayment) {
 		return nil, fmt.Errorf("mpp: expected Payment scheme, got %q", scheme)
 	}
 
@@ -465,7 +465,7 @@ func FormatAuthorization(c *Credential) string {
 		payload["source"] = c.Source
 	}
 
-	return "Payment " + b64EncodeAny(payload)
+	return SchemePayment + " " + b64EncodeAny(payload)
 }
 
 // ParsePaymentReceipt parses a Payment-Receipt header value into a Receipt.

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -61,7 +61,7 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			auth := r.Header.Get("Authorization")
+			auth := r.Header.Get(mpp.HeaderAuthorization)
 			paymentAuth, err := mpp.FindPaymentAuthorizationStrict(auth)
 			if err != nil {
 				WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
@@ -165,7 +165,7 @@ func composeChallenges(w http.ResponseWriter, r *http.Request, entries []compose
 	}
 
 	for _, header := range headers {
-		w.Header().Add("WWW-Authenticate", header)
+		w.Header().Add(mpp.HeaderWWWAuthenticate, header)
 	}
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -30,7 +30,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 	return func(next echofw.HandlerFunc) echofw.HandlerFunc {
 		return func(c echofw.Context) error {
 			chargeParams := params
-			chargeParams.Authorization = c.Request().Header.Get("Authorization")
+			chargeParams.Authorization = c.Request().Header.Get(mpp.HeaderAuthorization)
 			chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request(), c.Path())
 			body, err := server.ReadRequestBody(c.Request())
 			if err != nil {
@@ -60,7 +60,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 			c.SetRequest(c.Request().WithContext(ctx))
 			c.Set(credentialKey, result.Credential)
 			c.Set(receiptKey, result.Receipt)
-			c.Response().Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+			c.Response().Header().Set(mpp.HeaderPaymentReceipt, result.Receipt.ToPaymentReceipt())
 			return next(c)
 		}
 	}

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -31,7 +31,7 @@ func Receipt(c *fiberfw.Ctx) *mpp.Receipt {
 func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler {
 	return func(c *fiberfw.Ctx) error {
 		chargeParams := params
-		chargeParams.Authorization = c.Get("Authorization")
+		chargeParams.Authorization = c.Get(mpp.HeaderAuthorization)
 		chargeParams.MppxScope = fiberScope(c)
 		if body := c.Body(); len(body) > 0 {
 			chargeParams.Body = append([]byte(nil), body...)
@@ -56,7 +56,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 		c.SetUserContext(ctx)
 		c.Locals(credentialKey, result.Credential)
 		c.Locals(receiptKey, result.Receipt)
-		c.Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+		c.Set(mpp.HeaderPaymentReceipt, result.Receipt.ToPaymentReceipt())
 		return c.Next()
 	}
 }
@@ -91,7 +91,7 @@ func WritePaymentErrorWithChallenge(c *fiberfw.Ctx, err error, challenge *mpp.Ch
 		return
 	}
 
-	c.Set("WWW-Authenticate", header)
+	c.Set(mpp.HeaderWWWAuthenticate, header)
 	WritePaymentError(c, err)
 }
 
@@ -106,7 +106,7 @@ func WriteChallenge(c *fiberfw.Ctx, challenge *mpp.Challenge, realm string) {
 		return
 	}
 
-	c.Set("WWW-Authenticate", header)
+	c.Set(mpp.HeaderWWWAuthenticate, header)
 	c.Set("Content-Type", "application/problem+json")
 	c.Set("Cache-Control", "no-store")
 

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -29,7 +29,7 @@ func Receipt(c *ginfw.Context) *mpp.Receipt {
 func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFunc {
 	return func(c *ginfw.Context) {
 		chargeParams := params
-		chargeParams.Authorization = c.GetHeader("Authorization")
+		chargeParams.Authorization = c.GetHeader(mpp.HeaderAuthorization)
 		chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request, c.FullPath())
 		body, err := server.ReadRequestBody(c.Request)
 		if err != nil {
@@ -63,7 +63,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 		c.Request = c.Request.WithContext(ctx)
 		c.Set(credentialKey, result.Credential)
 		c.Set(receiptKey, result.Receipt)
-		c.Writer.Header().Set("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+		c.Writer.Header().Set(mpp.HeaderPaymentReceipt, result.Receipt.ToPaymentReceipt())
 		c.Next()
 	}
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -73,7 +73,7 @@ func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handl
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			chargeParams := params
-			chargeParams.Authorization = r.Header.Get("Authorization")
+			chargeParams.Authorization = r.Header.Get(mpp.HeaderAuthorization)
 			chargeParams.MppxScope = ScopeFromHTTPRequest(r, "")
 			body, err := ReadRequestBody(r)
 			if err != nil {
@@ -125,7 +125,7 @@ func serveVerified(next http.Handler, w http.ResponseWriter, r *http.Request, cr
 	// Payment-Receipt to a different client. This mirrors the MPP spec
 	// (mpp.dev/protocol) and the rust reference implementation.
 	w.Header().Set("Cache-Control", "private")
-	w.Header().Set("Payment-Receipt", receipt.ToPaymentReceipt())
+	w.Header().Set(mpp.HeaderPaymentReceipt, receipt.ToPaymentReceipt())
 
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
@@ -143,7 +143,7 @@ func WritePaymentErrorWithChallenge(w http.ResponseWriter, err error, challenge 
 		return
 	}
 
-	w.Header().Set("WWW-Authenticate", header)
+	w.Header().Set(mpp.HeaderWWWAuthenticate, header)
 	WritePaymentError(w, err)
 }
 
@@ -155,7 +155,7 @@ func WriteChallenge(w http.ResponseWriter, challenge *mpp.Challenge, realm strin
 		return
 	}
 
-	w.Header().Set("WWW-Authenticate", header)
+	w.Header().Set(mpp.HeaderWWWAuthenticate, header)
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusPaymentRequired)


### PR DESCRIPTION
## Motivation

The client can select exact method and intent pairs, but it cannot advertise or rank those capabilities and only one handler survives for each pair. This prevents mppx-compatible preference negotiation and method-specific challenge filtering.

## Summary

- Advertise configured capabilities with `Accept-Payment`
- Configure per-capability q-values and rank challenges by preference
- Honor caller-provided `Accept-Payment` ranges, including wildcards and specific opt-outs
- Preserve multiple handlers per method and intent with optional `CanHandleChallenge` filtering
- Export shared MPP header names and authentication schemes from `pkg/mpp`

## Key design considerations

- Omitted q-values default to 1 and q=0 disables a capability
- Specific ranges override broader wildcards before q-value comparison
- Equal-ranked challenges and handlers preserve server and client declaration order
- Go `mime` helpers parse capability tokens, case-insensitive parameters, quoted values, and escapes
- A small quote-aware outer-list splitter remains because the standard library does not expose one
- Malformed explicit headers remain unchanged on the wire while selection falls back to configured defaults
- Requests are cloned before automatic header injection
- Client, parser, and server adapters share the same protocol constants