### PR TITLE
fix: align payment challenge retry behavior

### DIFF
--- a/.changelog/agricola-client-server-parity.md
+++ b/.changelog/agricola-client-server-parity.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Retry supported payment challenges up to three times and emit initial payment challenges without an error body.

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -23,6 +23,13 @@ type Transport struct {
 	configErr          error
 }
 
+const defaultMaxPaymentRetries = 3
+
+type credentialKey struct {
+	id     string
+	method methodKey
+}
+
 type paymentOriginContextKey struct{}
 
 // TransportOption configures a Transport.
@@ -71,50 +78,55 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, t.configErr
 	}
 
-	request, preferences := t.prepareRequest(req)
-	resp, err := t.inner.RoundTrip(request)
-	if err != nil {
-		return nil, err
+	baseRequest, preferences := t.prepareRequest(req)
+	credentials := make(map[credentialKey]*mpp.Credential)
+	request := baseRequest
+
+	for retries := 0; ; retries++ {
+		resp, err := t.inner.RoundTrip(request)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusPaymentRequired || retries >= defaultMaxPaymentRetries {
+			return resp, nil
+		}
+
+		challenges, errs := t.parseChallenges(resp.Header)
+		_ = errs // Non-Payment or malformed headers are silently skipped.
+		candidates := t.challengeCandidates(challenges, preferences, time.Now().UTC())
+		if len(candidates) == 0 {
+			return resp, nil
+		}
+		selected := candidates[0]
+		if err := validatePaymentOrigin(request, selected.challenge); err != nil {
+			drainAndClose(resp.Body)
+			return nil, err
+		}
+
+		drainAndClose(resp.Body)
+
+		key := credentialKey{
+			id: selected.challenge.ID,
+			method: methodKey{
+				name:   selected.challenge.Method,
+				intent: selected.challenge.Intent,
+			},
+		}
+		cred := credentials[key]
+		if cred == nil {
+			cred, err = selected.method.CreateCredential(baseRequest.Context(), selected.challenge)
+			if err != nil {
+				return nil, fmt.Errorf("mpp: creating credential for method %q: %w", selected.challenge.Method, err)
+			}
+			credentials[key] = cred
+		}
+
+		request, err = t.cloneRequest(baseRequest)
+		if err != nil {
+			return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
+		}
+		request.Header.Set(mpp.HeaderAuthorization, cred.ToAuthorization())
 	}
-	if resp.StatusCode != http.StatusPaymentRequired {
-		return resp, nil
-	}
-
-	// Parse all WWW-Authenticate headers looking for Payment challenges (RFC 9110).
-	challenges, errs := t.parseChallenges(resp.Header)
-	_ = errs // Non-Payment or malformed headers are silently skipped.
-
-	candidates := t.challengeCandidates(challenges, preferences, time.Now().UTC())
-
-	if len(candidates) == 0 {
-		// No matching method found — return original 402 response as-is.
-		return resp, nil
-	}
-	selected := candidates[0]
-	if err := validatePaymentOrigin(request, selected.challenge); err != nil {
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		return nil, err
-	}
-
-	// Drain and close the 402 response body so the connection can be reused.
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	// Create payment credential.
-	cred, err := selected.method.CreateCredential(request.Context(), selected.challenge)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: creating credential for method %q: %w", selected.challenge.Method, err)
-	}
-
-	// Clone the original request for retry.
-	retry, err := t.cloneRequest(request)
-	if err != nil {
-		return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
-	}
-	retry.Header.Set(mpp.HeaderAuthorization, cred.ToAuthorization())
-
-	return t.inner.RoundTrip(retry)
 }
 
 func (t *Transport) challengeCandidates(challenges []mpp.Challenge, preferences []paymentPreference, now time.Time) []challengeCandidate {
@@ -191,6 +203,11 @@ func headerValue(header http.Header, name string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
 }
 
 // parseChallengeExpiry parses a challenge expiry using RFC 3339 and the

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
@@ -133,6 +134,101 @@ func TestTransport_RoundTrip_402WithPayment(t *testing.T) {
 		return
 	}
 
+}
+
+func TestTransport_RoundTrip_RetriesFreshPaymentChallenges(t *testing.T) {
+	var challenges []*mpp.Challenge
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount <= len(challenges) {
+			if callCount > 1 {
+				assert.NotEmpty(t, r.Header.Get("Authorization"))
+			}
+			challenge := challenges[callCount-1]
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	challenges = []*mpp.Challenge{
+		challengeForURL(t, srv.URL, "tempo", map[string]any{"attempt": 1}),
+		challengeForURL(t, srv.URL, "tempo", map[string]any{"attempt": 2}),
+	}
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := NewTransport([]Method{method}, nil).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, callCount)
+	assert.Equal(t, 2, method.calls)
+}
+
+func TestTransport_RoundTrip_StopsAtDefaultPaymentRetryLimit(t *testing.T) {
+	var challenges []*mpp.Challenge
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		challenge := challenges[callCount]
+		callCount++
+		w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer srv.Close()
+
+	for attempt := 1; attempt <= defaultMaxPaymentRetries+1; attempt++ {
+		challenges = append(challenges, challengeForURL(t, srv.URL, "tempo", map[string]any{"attempt": attempt}))
+	}
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := NewTransport([]Method{method}, nil).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+	assert.Equal(t, defaultMaxPaymentRetries+1, callCount)
+	assert.Equal(t, defaultMaxPaymentRetries, method.calls)
+}
+
+func TestTransport_RoundTrip_ReusesCredentialForRepeatedChallenge(t *testing.T) {
+	var challenge *mpp.Challenge
+	var authorizations []string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if authorization := r.Header.Get("Authorization"); authorization != "" {
+			authorizations = append(authorizations, authorization)
+		}
+		if callCount <= 2 {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	challenge = challengeForURL(t, srv.URL, "tempo", nil)
+	method := &mockMethod{name: "tempo", cred: newTestCredential("tempo")}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := NewTransport([]Method{method}, nil).RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, method.calls)
+	require.Len(t, authorizations, 2)
+	assert.Equal(t, authorizations[0], authorizations[1])
 }
 
 func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -147,7 +147,7 @@ func WritePaymentErrorWithChallenge(w http.ResponseWriter, err error, challenge 
 	WritePaymentError(w, err)
 }
 
-// WriteChallenge serializes a 402 challenge response using RFC 9457 problem details.
+// WriteChallenge serializes an initial 402 challenge response.
 func WriteChallenge(w http.ResponseWriter, challenge *mpp.Challenge, realm string) {
 	header, err := challenge.ToAuthenticateStrict(realm)
 	if err != nil {
@@ -156,12 +156,8 @@ func WriteChallenge(w http.ResponseWriter, challenge *mpp.Challenge, realm strin
 	}
 
 	w.Header().Set(mpp.HeaderWWWAuthenticate, header)
-	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusPaymentRequired)
-
-	problem := mpp.ErrPaymentRequired(realm, challenge.Description)
-	json.NewEncoder(w).Encode(problem.ProblemDetails(""))
 }
 
 // WritePaymentError serializes MPP verification errors as problem details.

--- a/pkg/server/payment_middleware_test.go
+++ b/pkg/server/payment_middleware_test.go
@@ -33,3 +33,17 @@ func TestWritePaymentError_FormatsProblemResponses(t *testing.T) {
 	}
 
 }
+
+func TestWriteChallenge_FormatsBodylessPaymentRequired(t *testing.T) {
+	t.Parallel()
+
+	challenge := mpp.NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{"amount": "100"})
+	response := httptest.NewRecorder()
+	WriteChallenge(response, challenge, challenge.Realm)
+
+	assert.Equal(t, http.StatusPaymentRequired, response.Code)
+	assert.NotEmpty(t, response.Header().Get("WWW-Authenticate"))
+	assert.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+	assert.Empty(t, response.Header().Get("Content-Type"))
+	assert.Empty(t, response.Body.String())
+}


### PR DESCRIPTION
## Motivation

Clients can receive another supported payment challenge after submitting a credential, and initial challenges are negotiation responses rather than verification errors.

## Summary

- retry supported payment challenges up to three times
- reuse credentials for identical repeated challenges
- emit initial 402 challenges without a problem-details body
- add client and server regression coverage and a patch release note

## Key design considerations

- retain payment preferences and request bodies across retries
- bound retries while returning the final response to the caller
- keep problem details on actual payment verification errors
