### PR TITLE
fix(mpp): keep large integers exact when decoding challenge JSON

### DIFF
--- a/.changelog/b64decode-large-integers.md
+++ b/.changelog/b64decode-large-integers.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Decode challenge and credential JSON with `json.Number` so integers above 2^53 keep their digits. Re-encoding a request through `float64` changed the bytes the challenge ID is an HMAC over, making challenges the server itself issued fail verification.

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -295,8 +295,8 @@ func parseJSONRequestValue(trimmed json.RawMessage) (map[string]any, string, err
 		return decoded, requestB64, nil
 	}
 
-	var request map[string]any
-	if err := json.Unmarshal(trimmed, &request); err != nil {
+	request, err := decodeJSONMap(trimmed)
+	if err != nil {
 		return nil, "", fmt.Errorf("mpp: request must be an object or base64url string: %w", err)
 	}
 	if request == nil {

--- a/pkg/mpp/json_test.go
+++ b/pkg/mpp/json_test.go
@@ -2,9 +2,11 @@ package mpp
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChallengeJSONMarshalUsesDecodedRequest(t *testing.T) {
@@ -305,4 +307,27 @@ func TestCredentialJSONUnmarshalNormalizesChallengeRequest(t *testing.T) {
 
 		})
 	}
+}
+
+func TestChallengeAndCredentialJSONRoundTripPreservesLargeIntegerRequest(t *testing.T) {
+	challenge := NewChallenge(
+		"secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": int64(1234567890123456789)},
+	)
+
+	challengeJSON, err := json.Marshal(challenge)
+	require.NoError(t, err)
+	var decodedChallenge Challenge
+	require.NoError(t, json.Unmarshal(challengeJSON, &decodedChallenge))
+	assert.Equal(t, challenge.RequestB64, decodedChallenge.RequestB64)
+	assert.True(t, decodedChallenge.Verify("secret", "api.example.com"))
+
+	credentialJSON, err := json.Marshal(challenge.NewCredential(map[string]any{"type": "hash"}))
+	require.NoError(t, err)
+	var decodedCredential Credential
+	require.NoError(t, json.Unmarshal(credentialJSON, &decodedCredential))
+	assert.Equal(t, challenge.RequestB64, decodedCredential.Challenge.Request)
 }

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -586,13 +587,21 @@ func isMethodName(value string) bool {
 }
 
 // B64Decode decodes a base64url (no padding) string into a map.
+//
+// Numbers decode as json.Number rather than float64. The challenge ID is an
+// HMAC over the re-encoded request, so a decode that cannot reproduce the
+// bytes it was given cannot reproduce the ID either: float64 carries 53 bits
+// of mantissa, and any JSON integer above 2^53 comes back rounded, making a
+// challenge the server itself issued fail to verify.
 func B64Decode(s string) (map[string]any, error) {
 	raw, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
 		return nil, fmt.Errorf("base64 decode: %w", err)
 	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
+	if err := decoder.Decode(&m); err != nil {
 		return nil, fmt.Errorf("json decode: %w", err)
 	}
 	return m, nil

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 )
@@ -598,11 +599,22 @@ func B64Decode(s string) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("base64 decode: %w", err)
 	}
+	m, err := decodeJSONMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("json decode: %w", err)
+	}
+	return m, nil
+}
+
+func decodeJSONMap(raw []byte) (map[string]any, error) {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var m map[string]any
 	if err := decoder.Decode(&m); err != nil {
-		return nil, fmt.Errorf("json decode: %w", err)
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing data")
 	}
 	return m, nil
 }

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -1,6 +1,8 @@
 package mpp
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -600,4 +602,45 @@ func assertCredentialEqual(t *testing.T, got, want *Credential) {
 		return
 	}
 
+}
+
+func TestB64DecodePreservesLargeIntegers(t *testing.T) {
+	// The challenge ID is an HMAC over the re-encoded request, so a decode that
+	// cannot reproduce the digits it was given cannot reproduce the ID either.
+	for _, literal := range []string{
+		"9007199254740991",    // 2^53-1, the largest float64-exact integer
+		"9007199254740993",    // 2^53+1
+		"1234567890123456789", // ~1.23 tokens on an 18-decimal asset
+		"18446744073709551615",
+	} {
+		encoded := b64EncodeAny(map[string]any{"amount": json.RawMessage(literal)})
+		decoded, err := B64Decode(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, literal, fmt.Sprint(decoded["amount"]),
+			"amount %s must survive a decode without being rounded through float64", literal)
+	}
+}
+
+func TestIssuedChallengeVerifiesAfterWireRoundTrip(t *testing.T) {
+	const (
+		secret = "0123456789abcdef0123456789abcdef"
+		realm  = "api"
+	)
+
+	// A challenge the server issued must verify after the round trip through the
+	// WWW-Authenticate header, whatever the magnitude of the amounts it carries.
+	for _, amount := range []int64{
+		1000,
+		9007199254740991,
+		9007199254740993,
+		1234567890123456789,
+	} {
+		request := map[string]any{"amount": amount, "asset": "usdc"}
+		issued := NewChallenge(secret, realm, "tempo", "charge", request)
+
+		parsed, err := ParseChallenge(issued.ToAuthenticate(realm))
+		require.NoError(t, err)
+		assert.True(t, parsed.Verify(secret, realm),
+			"challenge for amount %d was issued by this server and must verify", amount)
+	}
 }

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -1,6 +1,7 @@
 package mpp
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -619,6 +620,14 @@ func TestB64DecodePreservesLargeIntegers(t *testing.T) {
 		assert.Equal(t, literal, fmt.Sprint(decoded["amount"]),
 			"amount %s must survive a decode without being rounded through float64", literal)
 	}
+}
+
+func TestB64DecodeRejectsTrailingJSON(t *testing.T) {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(`{"amount":1}{"amount":2}`))
+
+	_, err := B64Decode(encoded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected trailing data")
 }
 
 func TestIssuedChallengeVerifiesAfterWireRoundTrip(t *testing.T) {

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -69,6 +69,34 @@ func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {
 
 }
 
+func TestVerifyOrChallenge_VerifiesLargeIntegerRequest(t *testing.T) {
+	const amount int64 = 1234567890123456789
+	request := map[string]any{"amount": amount, "currency": "0xabc", "recipient": "0xdef"}
+	params := VerifyParams{
+		Intent:    verifyTestIntent{},
+		Request:   request,
+		Realm:     "api.example.com",
+		SecretKey: "secret-key",
+		Method:    "tempo",
+	}
+
+	issued, err := VerifyOrChallenge(context.Background(), params)
+	if !assert.NoError(t, err) || !assert.NotNil(t, issued.Challenge) {
+		return
+	}
+	credential := &mpp.Credential{
+		Challenge: issued.Challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	params.Authorization = credential.ToAuthorization()
+	result, err := VerifyOrChallenge(context.Background(), params)
+	if !assert.NoError(t, err) || !assert.NotNil(t, result.Receipt) {
+		return
+	}
+	assert.Equal(t, "0xreceipt", result.Receipt.Reference)
+}
+
 func TestVerifyOrChallenge_UsesPublicBroadcastingIntent(t *testing.T) {
 	request := map[string]any{"amount": "100", "currency": "0xabc", "recipient": "0xdef"}
 	challenge := mpp.NewChallenge(


### PR DESCRIPTION
## The bug

`B64Decode` unmarshals into `map[string]any`, so every JSON number arrives as a `float64`:

```go
var m map[string]any
if err := json.Unmarshal(raw, &m); err != nil {
```

The challenge `id` is an HMAC over the base64url of the **re-encoded** request, and the server rebuilds that request by decoding the client's echo — `echoedRequestMap` → `NewChallenge` in `pkg/server/verify.go`. `AGENTS.md` states the model plainly: *"Server recomputes HMAC from echoed challenge parameters and compares to `id`."*

A `float64` carries 53 bits of mantissa. Any integer above 2^53 is re-encoded with different digits than the server signed, so the recomputed HMAC no longer matches the `id` the server itself issued:

| amount in `request` | re-encoded as |
|---|---|
| `9007199254740993` | `9007199254740992` |
| `1234567890123456789` | `1234567890123456800` |
| `18446744073709551615` | `18446744073709552000` |

`1234567890123456789` is roughly 1.23 tokens of an 18-decimal asset, so this is squarely in the range real amounts occupy.

The failure is silent and misattributed. Verification rejects with:

```
challenge was not issued by this server
```

for a challenge the server did issue, pointing the operator at challenge binding or secret rotation rather than at number handling.

## Reachability

The bundled Tempo method carries amounts as strings (`big.Int` → `string`) and is **not** affected. This is reachable through the public `pkg/mpp` API, where `request` is a caller-supplied `map[string]any` — putting a Go integer in it is the natural thing to write, and nothing in the signature or docs suggests it is unsafe:

```go
issued := mpp.NewChallenge(secret, realm, "tempo", "charge",
    map[string]any{"amount": int64(1234567890123456789), "asset": "usdc"})

parsed, _ := mpp.ParseChallenge(issued.ToAuthenticate(realm))
parsed.Verify(secret, realm) // false, before this change
```

The spec's binding section is built on the same assumption this breaks — slot 3 is the request "JCS-serialized per RFC 8785, then base64url-encoded", and it warns that differing serializations "would produce different HMAC values, breaking cross-implementation" agreement. A decode that cannot reproduce the digits it was given cannot reproduce that slot.

## The fix

Decode with `json.Number` so the literal digits survive the round trip. `encoding/json` marshals `json.Number` back verbatim, so the re-encoded request is byte-identical to what was signed.

Two notes for review:

- This changes the dynamic type of numbers returned by the exported `B64Decode` from `float64` to `json.Number`. No non-test code in the repo type-asserts `.(float64)`, and the full suite passes unchanged, but it is a visible change for external callers — happy to scope it to the verification path instead if you would rather keep `B64Decode`'s current shape.
- It fixes the `mpp.JSONEqual(echoedRequest, params.Request)` comparison in `verify.go` for the same reason: a server-side `int64` and the echoed value now serialize identically.

## Test Plan

Two tests added to `pkg/mpp/parse_test.go`. Reverting only `parse.go` and keeping the tests turns both red:

```
--- FAIL: TestB64DecodePreservesLargeIntegers
    expected: "9007199254740993"
    actual  : "9.007199254740992e+15"
    expected: "1234567890123456789"
    actual  : "1.2345678901234568e+18"
--- FAIL: TestIssuedChallengeVerifiesAfterWireRoundTrip
    challenge for amount 9007199254740993 was issued by this server and must verify
```

To be precise about the boundary: `Verify` fails only above 2^53. `9007199254740991` (2^53−1) is float64-exact and verifies both before and after; it appears in the decode test because that test pins the stronger property — the decoded value keeps the literal digits.

`go build ./...`, `go test ./...` and `go vet ./...` are clean, including the Tempo end-to-end suites. `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
