### PR TITLE
fix: allow hash credentials with explicit memos

### DIFF
--- a/.changelog/hash-explicit-memo.md
+++ b/.changelog/hash-explicit-memo.md
@@ -2,4 +2,4 @@
 github.com/tempoxyz/mpp-go: patch
 ---
 
-Allow push-mode hash credentials for Tempo charge challenges with an explicit memo, matching the memo exactly during receipt verification.
+Allow push-mode hash credentials for Tempo charge challenges with an explicit memo, matching the application-provided correlation value exactly during receipt verification.

--- a/.changelog/hash-explicit-memo.md
+++ b/.changelog/hash-explicit-memo.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Allow push-mode hash credentials for Tempo charge challenges with an explicit memo, matching the memo exactly during receipt verification.

--- a/pkg/tempo/client/method.go
+++ b/pkg/tempo/client/method.go
@@ -149,9 +149,6 @@ func (m *Method) CreateCredential(ctx context.Context, challenge *mpp.Challenge)
 	if credentialType == tempo.CredentialTypeProof {
 		return nil, fmt.Errorf("tempo client: proof credentials are only valid for zero-amount challenges")
 	}
-	if credentialType == tempo.CredentialTypeHash && request.MethodDetails.Memo != "" {
-		return nil, fmt.Errorf("tempo client: hash credentials cannot be used with explicit memo challenges")
-	}
 	if credentialType == tempo.CredentialTypeHash && request.MethodDetails.FeePayer {
 		return nil, fmt.Errorf("tempo client: hash credentials cannot be used with fee payer challenges")
 	}

--- a/pkg/tempo/client/method_test.go
+++ b/pkg/tempo/client/method_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/tempo"
@@ -83,24 +84,6 @@ func TestCreateCredentialScenarios(t *testing.T) {
 			wantBroadcasts: 0,
 		},
 		{
-			name: "hash credential rejected for explicit memo challenge",
-			config: Config{
-				ChainID:        42431,
-				CredentialType: tempo.CredentialTypeHash,
-			},
-			rpc: &mockRPC{chainID: 42431},
-			params: tempo.ChargeRequestParams{
-				Amount:    "0.50",
-				Currency:  testCurrency,
-				Recipient: testRecipient,
-				Decimals:  6,
-				ChainID:   42431,
-				Memo:      "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
-			},
-			wantErr:        "hash credentials cannot be used with explicit memo challenges",
-			wantBroadcasts: 0,
-		},
-		{
 			name: "chain id mismatch",
 			config: Config{
 				ChainID: 42431,
@@ -165,6 +148,58 @@ func TestCreateCredentialScenarios(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestCreateCredentialHashWithExplicitMemo(t *testing.T) {
+	t.Parallel()
+
+	params := tempo.ChargeRequestParams{
+		Amount:    "0.50",
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+		Memo:      "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+	}
+	request, err := tempo.NormalizeChargeRequest(params)
+	if !assert.NoErrorf(t, err, "NormalizeChargeRequest() error = %v", err) {
+		return
+	}
+	rpc := &mockRPC{chainID: 42431}
+	method, err := New(Config{
+		ChainID:        42431,
+		CredentialType: tempo.CredentialTypeHash,
+		PrivateKey:     testPrivateKey,
+		RPC:            rpc,
+	})
+	if !assert.NoErrorf(t, err, "New() error = %v", err) {
+		return
+	}
+
+	challenge := buildChallenge(t, params)
+	credential, err := method.CreateCredential(context.Background(), challenge)
+	if !assert.NoErrorf(t, err, "CreateCredential() error = %v", err) {
+		return
+	}
+	payload, err := tempo.ParseChargeCredentialPayload(credential.Payload)
+	if !assert.NoErrorf(t, err, "ParseChargeCredentialPayload() error = %v", err) {
+		return
+	}
+	if !assert.Equal(t, tempo.CredentialTypeHash, payload.Type) ||
+		!assert.Equal(t, "0xabc123", payload.Hash) ||
+		!assert.Len(t, rpc.sentRawTxs, 1) {
+		return
+	}
+	tx, err := tempotx.Deserialize(rpc.sentRawTxs[0])
+	if !assert.NoErrorf(t, err, "Deserialize() error = %v", err) ||
+		!assert.Len(t, tx.Calls, 1) {
+		return
+	}
+	if !assert.True(t, tempo.MatchTransferCalldata(
+		hexutil.Encode(tx.Calls[0].Data), request, challenge.Realm, challenge.ID,
+	), "MatchTransferCalldata() = false, want explicit memo transfer") {
+		return
 	}
 }
 

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -278,9 +278,6 @@ func (i *Intent) validateHash(
 ) error {
 	request := validated.request
 	source := validated.source
-	if request.MethodDetails.Memo != "" {
-		return mpp.ErrInvalidPayload("hash credentials are not supported when the primary transfer uses an explicit memo")
-	}
 	if source == nil {
 		return mpp.ErrInvalidPayload("hash credential must include a source")
 	}

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -285,6 +285,9 @@ func (i *Intent) validateHash(
 	if err != nil {
 		return err
 	}
+	// Explicit memos are application-provided correlation values. Receipt
+	// matching requires their exact value; generated attribution memos provide
+	// challenge binding when the application does not provide one.
 	if !receiptMatches(receiptMap, credential, request, source.address) {
 		return mpp.ErrVerificationFailed("transaction receipt does not satisfy the charge request")
 	}

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -1098,17 +1098,27 @@ func TestChargeFlow_HashCredentialIgnoresFeeControllerLogs(t *testing.T) {
 
 func TestChargeFlow_HashCredentialAcceptsExplicitPrimaryMemo(t *testing.T) {
 	ctx := context.Background()
-	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
+	method := NewMethod(MethodConfig{
+		Currency:  testCurrency,
+		Recipient: testRecipient,
+		Decimals:  6,
+		ChainID:   42431,
+	})
+	requestMap, err := method.BuildChargeRequest(server.ChargeParams{
 		Amount:         "0.50",
-		Currency:       testCurrency,
-		Recipient:      testRecipient,
-		Decimals:       6,
-		ChainID:        42431,
 		Memo:           "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
 		SupportedModes: []tempo.ChargeMode{tempo.ChargeModePush},
 	})
 	if !assert.NoErrorf(t, err,
-		"NormalizeChargeRequest() error = %v", err) {
+		"BuildChargeRequest() error = %v", err) {
+		return
+	}
+	request, err := tempo.ParseChargeRequest(requestMap)
+	if !assert.NoErrorf(t, err,
+		"ParseChargeRequest() error = %v", err) {
+		return
+	}
+	if !assert.Equal(t, []tempo.ChargeMode{tempo.ChargeModePush}, request.MethodDetails.SupportedModes) {
 		return
 	}
 

--- a/pkg/tempo/server/charge_test.go
+++ b/pkg/tempo/server/charge_test.go
@@ -1096,7 +1096,7 @@ func TestChargeFlow_HashCredentialIgnoresFeeControllerLogs(t *testing.T) {
 	}
 }
 
-func TestChargeFlow_HashCredentialRejectsExplicitPrimaryMemo(t *testing.T) {
+func TestChargeFlow_HashCredentialAcceptsExplicitPrimaryMemo(t *testing.T) {
 	ctx := context.Background()
 	request, err := tempo.NormalizeChargeRequest(tempo.ChargeRequestParams{
 		Amount:         "0.50",
@@ -1112,30 +1112,35 @@ func TestChargeFlow_HashCredentialRejectsExplicitPrimaryMemo(t *testing.T) {
 		return
 	}
 
-	signer, err := temposigner.NewSigner(testPrivateKey)
+	rpc := newMockRPC(request)
+	challenge := buildChallenge(t, request)
+	credential, err := newClientMethod(t, rpc, tempo.CredentialTypeHash).CreateCredential(ctx, challenge)
 	if !assert.NoErrorf(t, err,
-		"NewSigner() error = %v", err) {
+		"CreateCredential() error = %v", err) {
 		return
 	}
 
-	challenge := buildChallenge(t, request)
-	credential := &mpp.Credential{
-		Challenge: challenge.ToEcho(),
-		Payload: tempo.ChargeCredentialPayload{
-			Type: tempo.CredentialTypeHash,
-			Hash: testReceiptHash,
-		}.Map(),
-		Source: tempo.ProofSource(42431, signer.Address()),
-	}
-
-	intent, err := NewIntent(IntentConfig{RPC: newMockRPC(request)})
+	intent, err := NewIntent(IntentConfig{RPC: rpc})
 	if !assert.NoErrorf(t, err,
 		"NewIntent() error = %v", err) {
 		return
 	}
 
-	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "explicit memo") {
-		assert.Failf(t, "", "Verify() error = %v, want explicit memo rejection", err)
+	wrongMemoRequest := request
+	wrongMemoRequest.MethodDetails.Memo = "0x2020202020202020202020202020202020202020202020202020202020202020"
+	if _, err := intent.Verify(ctx, credential, wrongMemoRequest.Map()); err == nil || !strings.Contains(err.Error(), "does not satisfy") {
+		assert.Failf(t, "", "Verify() error = %v, want memo mismatch", err)
+		return
+	}
+
+	receipt, err := intent.Verify(ctx, credential, request.Map())
+	if !assert.NoErrorf(t, err, "Verify() error = %v", err) ||
+		!assert.Equal(t, testReceiptHash, receipt.Reference) {
+		return
+	}
+
+	if _, err := intent.Verify(ctx, credential, request.Map()); err == nil || !strings.Contains(err.Error(), "already used") {
+		assert.Failf(t, "", "Verify() error = %v, want hash replay rejection", err)
 		return
 	}
 }

--- a/pkg/tempo/server/method.go
+++ b/pkg/tempo/server/method.go
@@ -133,7 +133,7 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 		FeePayerURL:    feePayerURL,
 		Memo:           memo,
 		Splits:         append([]tempo.SplitParams(nil), params.Splits...),
-		SupportedModes: resolvedModes(memo, params.SupportedModes, m.supportedModes),
+		SupportedModes: resolvedModes(params.SupportedModes, m.supportedModes),
 	})
 	if err != nil {
 		return nil, err
@@ -141,24 +141,9 @@ func (m *Method) BuildChargeRequest(params mppserver.ChargeParams) (map[string]a
 	return request.Map(), nil
 }
 
-func resolvedModes(memo string, requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {
-	var modes []tempo.ChargeMode
+func resolvedModes(requestModes, defaultModes []tempo.ChargeMode) []tempo.ChargeMode {
 	if len(requestModes) > 0 {
-		modes = append([]tempo.ChargeMode(nil), requestModes...)
-	} else {
-		modes = append([]tempo.ChargeMode(nil), defaultModes...)
+		return append([]tempo.ChargeMode(nil), requestModes...)
 	}
-	if memo == "" {
-		return modes
-	}
-	filtered := make([]tempo.ChargeMode, 0, len(modes))
-	for _, mode := range modes {
-		if mode != tempo.ChargeModePush {
-			filtered = append(filtered, mode)
-		}
-	}
-	if len(filtered) == 0 {
-		return []tempo.ChargeMode{tempo.ChargeModePull}
-	}
-	return filtered
+	return append([]tempo.ChargeMode(nil), defaultModes...)
 }

--- a/pkg/tempo/server/method_test.go
+++ b/pkg/tempo/server/method_test.go
@@ -124,7 +124,7 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "explicit primary memo forces pull mode",
+			name: "explicit primary memo preserves push mode",
 			config: MethodConfig{
 				Currency:  "0x20c0000000000000000000000000000000000001",
 				Recipient: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
@@ -139,8 +139,8 @@ func TestMethodBuildChargeRequest(t *testing.T) {
 				t.Helper()
 				{
 					got := len(request.MethodDetails.SupportedModes)
-					if !assert.Falsef(t, got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePull,
-						"request.MethodDetails.SupportedModes = %#v, want [pull]", request.MethodDetails.SupportedModes) {
+					if !assert.Falsef(t, got != 1 || request.MethodDetails.SupportedModes[0] != tempo.ChargeModePush,
+						"request.MethodDetails.SupportedModes = %#v, want [push]", request.MethodDetails.SupportedModes) {
 						return
 					}
 				}


### PR DESCRIPTION
## Motivation

Keep Tempo push-mode behavior consistent when applications use an explicit memo as their payment correlation value.

## Summary

- allow hash credential clients to broadcast transfers with explicit memos
- accept hash credentials when receipt transfers exactly match the requested memo
- add client and server regression coverage plus a patch release note

## Key design considerations

- preserve exact amount, currency, recipient, and memo matching
- retain source validation, the fee-payer restriction, and atomic hash replay protection