### PR TITLE
feat: add requiresAuth so Payment credentials use Payment-Authorization

### DIFF
--- a/.changelog/requires-auth-payment-authorization.md
+++ b/.changelog/requires-auth-payment-authorization.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Add a `requiresAuth` server option that advertises `header="Payment-Authorization"` so Payment credentials can coexist with ordinary `Authorization`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ func main() {
 }
 ```
 
+If the endpoint already uses `Authorization` (API keys, Bearer tokens), create the server with `server.WithRequiresAuth(true)`. Challenges then advertise `header="Payment-Authorization"`, and clients send the Payment credential in that header instead of `Authorization`.
+
+```go
+payment, err := server.New(method, "api.example.com", secret, server.WithRequiresAuth(true))
+if err != nil {
+	log.Fatal(err)
+}
+
+handler := server.ChargeMiddleware(payment, server.ChargeParams{
+	Amount:      "0.50",
+	Description: "Paid content",
+})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": "paid content"})
+}))
+```
+
 ### Client
 
 ```go

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -125,7 +125,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, fmt.Errorf("mpp: cloning request for retry: %w", err)
 		}
-		request.Header.Set(mpp.HeaderAuthorization, cred.ToAuthorization())
+		request.Header.Set(selected.challenge.CredentialHeader(), cred.ToAuthorization())
 	}
 }
 

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -231,6 +231,52 @@ func TestTransport_RoundTrip_ReusesCredentialForRepeatedChallenge(t *testing.T) 
 	assert.Equal(t, authorizations[0], authorizations[1])
 }
 
+func TestTransport_RoundTrip_UsesAdvertisedPaymentAuthorizationHeader(t *testing.T) {
+	callCount := 0
+	var challenge *mpp.Challenge
+	var retryAuth, retryPaymentAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Header.Get(mpp.HeaderPaymentAuthorization) == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			w.Write([]byte("pay me"))
+			return
+		}
+		retryAuth = r.Header.Get("Authorization")
+		retryPaymentAuth = r.Header.Get(mpp.HeaderPaymentAuthorization)
+		assert.Truef(t, strings.HasPrefix(retryPaymentAuth, "Payment "),
+			"expected Payment auth scheme, got %q", retryPaymentAuth)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("paid"))
+	}))
+	defer srv.Close()
+	challenge = challengeForURL(t, srv.URL, "tempo", nil, mpp.WithHeader(mpp.HeaderPaymentAuthorization))
+
+	cred := newTestCredential("tempo")
+	method := &mockMethod{name: "tempo", cred: cred}
+	tr := NewTransport([]Method{method}, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer app-token")
+	resp, err := tr.RoundTrip(req)
+	if !assert.NoErrorf(t, err,
+		"unexpected error: %v", err) {
+		return
+	}
+
+	defer resp.Body.Close()
+	if !assert.Equalf(t, http.StatusOK, resp.StatusCode,
+		"expected 200, got %d", resp.StatusCode) {
+		return
+	}
+
+	assert.Equal(t, 2, callCount)
+	assert.Equal(t, "Bearer app-token", retryAuth)
+	assert.True(t, strings.HasPrefix(retryPaymentAuth, "Payment "))
+}
+
 func TestTransport_RoundTrip_402NoMatchingMethod(t *testing.T) {
 	challenge := mpp.NewChallenge("secret", "realm", "stripe", "payment", nil)
 

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -19,6 +19,10 @@ type Challenge struct {
 	Expires     string            `json:"expires,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Opaque      map[string]string `json:"opaque,omitempty"`
+	// Header is the HTTP field for the Payment credential. Empty means the
+	// implicit default, Authorization. When set, it is advertised as the
+	// challenge header parameter and bound into the challenge ID.
+	Header string `json:"header,omitempty"`
 }
 
 // ChallengeEcho is the subset of a Challenge echoed back in a Credential.
@@ -31,6 +35,7 @@ type ChallengeEcho struct {
 	Expires string            `json:"expires,omitempty"`
 	Digest  string            `json:"digest,omitempty"`
 	Opaque  map[string]string `json:"opaque,omitempty"`
+	Header  string            `json:"header,omitempty"`
 }
 
 // ChallengeOption configures optional fields when creating a new Challenge.
@@ -41,6 +46,7 @@ type challengeConfig struct {
 	digest      string
 	description string
 	opaque      map[string]string
+	header      string
 }
 
 // WithExpires sets the expiration timestamp on a Challenge.
@@ -63,6 +69,12 @@ func WithMeta(meta map[string]string) ChallengeOption {
 	return func(c *challengeConfig) { c.opaque = meta }
 }
 
+// WithHeader sets the HTTP field that must carry the Payment credential.
+// Authorization is the implicit default and is not advertised on the wire.
+func WithHeader(header string) ChallengeOption {
+	return func(c *challengeConfig) { c.header = AdvertisedCredentialHeader(header) }
+}
+
 // NewChallenge creates a new Challenge with an HMAC-bound ID. The secretKey
 // and realm are used to compute the ID via GenerateChallengeID.
 func NewChallenge(secretKey, realm, method, intent string, request map[string]any, opts ...ChallengeOption) *Challenge {
@@ -82,6 +94,7 @@ func NewChallenge(secretKey, realm, method, intent string, request map[string]an
 		Expires:   cfg.expires,
 		Digest:    cfg.digest,
 		Opaque:    cfg.opaque,
+		Header:    cfg.header,
 	})
 
 	return &Challenge{
@@ -95,6 +108,7 @@ func NewChallenge(secretKey, realm, method, intent string, request map[string]an
 		Expires:     cfg.expires,
 		Description: cfg.description,
 		Opaque:      cfg.opaque,
+		Header:      cfg.header,
 	}
 }
 
@@ -115,6 +129,7 @@ func (c Challenge) MarshalJSON() ([]byte, error) {
 		Expires     string         `json:"expires,omitempty"`
 		Description string         `json:"description,omitempty"`
 		Opaque      any            `json:"opaque,omitempty"`
+		Header      string         `json:"header,omitempty"`
 	}{
 		ID:          c.ID,
 		Method:      c.Method,
@@ -125,6 +140,7 @@ func (c Challenge) MarshalJSON() ([]byte, error) {
 		Expires:     c.Expires,
 		Description: c.Description,
 		Opaque:      opaqueForJSON(c.Opaque),
+		Header:      AdvertisedCredentialHeader(c.Header),
 	})
 }
 
@@ -142,6 +158,7 @@ func (c *Challenge) UnmarshalJSON(data []byte) error {
 		Expires     string          `json:"expires,omitempty"`
 		Description string          `json:"description,omitempty"`
 		Opaque      json.RawMessage `json:"opaque,omitempty"`
+		Header      string          `json:"header,omitempty"`
 	}
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
@@ -152,6 +169,10 @@ func (c *Challenge) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	opaque, err := decodeJSONOpaque(decoded.Opaque)
+	if err != nil {
+		return err
+	}
+	header, err := parseAdvertisedCredentialHeader(decoded.Header)
 	if err != nil {
 		return err
 	}
@@ -167,6 +188,7 @@ func (c *Challenge) UnmarshalJSON(data []byte) error {
 		Expires:     decoded.Expires,
 		Description: decoded.Description,
 		Opaque:      opaque,
+		Header:      header,
 	}
 	return nil
 }
@@ -199,8 +221,18 @@ func (c *Challenge) Verify(secretKey, realm string) bool {
 		Expires:   c.Expires,
 		Digest:    c.Digest,
 		Opaque:    c.Opaque,
+		Header:    c.Header,
 	})
 	return ConstantTimeEqual(c.ID, expected)
+}
+
+// CredentialHeader returns the HTTP field a client must use for the payment
+// credential. Challenges that omit header default to Authorization.
+func (c *Challenge) CredentialHeader() string {
+	if AdvertisedCredentialHeader(c.Header) == "" {
+		return HeaderAuthorization
+	}
+	return c.Header
 }
 
 // ToEcho returns the ChallengeEcho representation suitable for inclusion
@@ -219,6 +251,7 @@ func (c *Challenge) ToEcho() ChallengeEcho {
 		Expires: c.Expires,
 		Digest:  c.Digest,
 		Opaque:  c.Opaque,
+		Header:  AdvertisedCredentialHeader(c.Header),
 	}
 }
 
@@ -232,6 +265,7 @@ func (e ChallengeEcho) toChallenge() Challenge {
 		Digest:     e.Digest,
 		Expires:    e.Expires,
 		Opaque:     e.Opaque,
+		Header:     AdvertisedCredentialHeader(e.Header),
 	}
 }
 

--- a/pkg/mpp/credential.go
+++ b/pkg/mpp/credential.go
@@ -2,8 +2,9 @@ package mpp
 
 import "encoding/json"
 
-// Credential represents a client-submitted payment credential sent via the
-// Authorization header.
+// Credential represents a client-submitted payment proof. It is sent in
+// Authorization by default, or in Payment-Authorization when the challenge
+// advertised that header.
 type Credential struct {
 	Challenge ChallengeEcho  `json:"challenge"`
 	Payload   map[string]any `json:"payload,omitempty"`

--- a/pkg/mpp/header_test.go
+++ b/pkg/mpp/header_test.go
@@ -1,0 +1,71 @@
+package mpp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizationHeaderDoesNotChangeChallengeID(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{"amount": "1000000"}
+	implicit := NewChallenge("test-secret-key-12345", "api.example.com", "tempo", "charge", params)
+	explicit := NewChallenge(
+		"test-secret-key-12345",
+		"api.example.com",
+		"tempo",
+		"charge",
+		params,
+		WithHeader(HeaderAuthorization),
+	)
+
+	assert.Empty(t, implicit.Header)
+	assert.Empty(t, explicit.Header)
+	assert.Equal(t, implicit.ID, explicit.ID)
+	assert.NotContains(t, implicit.ToAuthenticate("api.example.com"), "header=")
+	assert.Equal(t, HeaderAuthorization, implicit.CredentialHeader())
+}
+
+func TestPaymentAuthorizationHeaderIsBoundIntoID(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{"amount": "1000000"}
+	implicit := NewChallenge("test-secret-key-12345", "api.example.com", "tempo", "charge", params)
+	advertised := NewChallenge(
+		"test-secret-key-12345",
+		"api.example.com",
+		"tempo",
+		"charge",
+		params,
+		WithHeader(HeaderPaymentAuthorization),
+	)
+
+	assert.NotEqual(t, implicit.ID, advertised.ID)
+	assert.Equal(t, HeaderPaymentAuthorization, advertised.Header)
+	assert.True(t, advertised.Verify("test-secret-key-12345", "api.example.com"))
+	assert.Contains(t, advertised.ToAuthenticate("api.example.com"), `header="`+HeaderPaymentAuthorization+`"`)
+	assert.Equal(t, HeaderPaymentAuthorization, advertised.CredentialHeader())
+}
+
+func TestWWWAuthenticateRoundTripPreservesCredentialHeader(t *testing.T) {
+	t.Parallel()
+
+	challenge := NewChallenge(
+		"test-secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": "1000000"},
+		WithHeader(HeaderPaymentAuthorization),
+	)
+	header := challenge.ToAuthenticate("api.example.com")
+	parsed, err := ParseChallenge(header)
+	require.NoError(t, err)
+
+	assert.Contains(t, header, `header="`+HeaderPaymentAuthorization+`"`)
+	assert.Equal(t, HeaderPaymentAuthorization, parsed.Header)
+	assert.Equal(t, HeaderPaymentAuthorization, parsed.CredentialHeader())
+	assert.True(t, parsed.Verify("test-secret", "api.example.com"))
+}

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -19,12 +20,17 @@ type GenerateChallengeIDInput struct {
 	Expires   string
 	Digest    string
 	Opaque    map[string]string
+	Header    string
 }
 
 // GenerateChallengeID produces an HMAC-SHA256 challenge ID from the given inputs.
 // The HMAC is computed over pipe-delimited fields:
 //
 //	realm|method|intent|request_b64|expires|digest|opaque_b64
+//
+// Challenges that advertise a credential header insert it immediately before
+// the final opaque slot. Authorization is the implicit default and is never
+// included, preserving the legacy binding.
 //
 // The result is base64url-encoded without padding.
 func GenerateChallengeID(opts GenerateChallengeIDInput) string {
@@ -42,13 +48,40 @@ func GenerateChallengeID(opts GenerateChallengeIDInput) string {
 		requestB64,
 		opts.Expires,
 		opts.Digest,
-		opaqueB64,
 	}
+	if header := AdvertisedCredentialHeader(opts.Header); header != "" {
+		parts = append(parts, header)
+	}
+	parts = append(parts, opaqueB64)
 
 	mac := hmac.New(sha256.New, []byte(opts.SecretKey))
 	mac.Write([]byte(strings.Join(parts, "|")))
 
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// AdvertisedCredentialHeader returns a challenge header parameter value, or
+// empty for the implicit Authorization default.
+func AdvertisedCredentialHeader(header string) string {
+	if isDefaultCredentialHeader(header) {
+		return ""
+	}
+	return header
+}
+
+func isDefaultCredentialHeader(header string) bool {
+	return header == "" || strings.EqualFold(header, HeaderAuthorization)
+}
+
+func parseAdvertisedCredentialHeader(header string) (string, error) {
+	header = AdvertisedCredentialHeader(header)
+	if header == "" {
+		return "", nil
+	}
+	if !isHTTPHeaderName(header) {
+		return "", fmt.Errorf("mpp: invalid HTTP header name")
+	}
+	return header, nil
 }
 
 // ConstantTimeEqual returns true if a and b are equal, using constant-time

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -222,6 +222,10 @@ func ParseChallenge(header string) (*Challenge, error) {
 	expires := params["expires"]
 	digest := params["digest"]
 	description := params["description"]
+	credentialHeader, err := parseAdvertisedCredentialHeader(params["header"])
+	if err != nil {
+		return nil, err
+	}
 
 	var opaque map[string]string
 	if opaqueB64, ok := params["opaque"]; ok && opaqueB64 != "" {
@@ -246,6 +250,7 @@ func ParseChallenge(header string) (*Challenge, error) {
 		Expires:     expires,
 		Description: description,
 		Opaque:      opaque,
+		Header:      credentialHeader,
 	}, nil
 }
 
@@ -302,6 +307,7 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 		{key: "digest", value: c.Digest},
 		{key: "expires", value: c.Expires},
 		{key: "description", value: c.Description},
+		{key: "header", value: AdvertisedCredentialHeader(c.Header)},
 	} {
 		if err := add(param.key, param.value); err != nil {
 			return "", err
@@ -388,6 +394,11 @@ func ParseCredential(header string) (*Credential, error) {
 		Expires: anyStr(challengeMap["expires"]),
 		Digest:  anyStr(challengeMap["digest"]),
 	}
+	credentialHeader, err := parseAdvertisedCredentialHeader(anyStr(challengeMap["header"]))
+	if err != nil {
+		return nil, err
+	}
+	echo.Header = credentialHeader
 	if echo.ID == "" {
 		return nil, fmt.Errorf("mpp: credential challenge missing required field: id")
 	}
@@ -448,6 +459,9 @@ func FormatAuthorization(c *Credential) string {
 	}
 	if c.Challenge.Digest != "" {
 		challengeDict["digest"] = c.Challenge.Digest
+	}
+	if header := AdvertisedCredentialHeader(c.Challenge.Header); header != "" {
+		challengeDict["header"] = header
 	}
 	if c.Challenge.Opaque != nil {
 		if raw, ok := c.Challenge.Opaque["_raw"]; ok {
@@ -583,6 +597,18 @@ func isMethodName(value string) bool {
 		}
 	}
 	return value != ""
+}
+
+func isHTTPHeaderName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if !isTokenChar(value[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // B64Decode decodes a base64url (no padding) string into a map.

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -294,6 +294,7 @@ func TestParseChallenge(t *testing.T) {
 		WithDigest("sha-256=:abc123:"),
 		WithDescription("Pay for API access"),
 		WithMeta(map[string]string{"trace": "123", "route": "paid"}),
+		WithHeader(HeaderPaymentAuthorization),
 	)
 
 	tests := []struct {
@@ -382,6 +383,17 @@ func TestParseChallenge(t *testing.T) {
 			wantErr: `invalid request field`,
 		},
 		{
+			name:    "invalid credential header name",
+			header:  `Payment id="abc", realm="api.example.com", method="tempo", intent="charge", request="e30", header="not a header"`,
+			wantErr: `invalid HTTP header name`,
+		},
+		{
+			name: "omits default authorization header",
+			header: NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{}, WithHeader(HeaderAuthorization)).
+				ToAuthenticate("api.example.com"),
+			want: NewChallenge("secret", "api.example.com", "tempo", "charge", map[string]any{}),
+		},
+		{
 			name:    "header too large",
 			header:  "Payment " + strings.Repeat("a", maxHeaderPayload),
 			wantErr: `WWW-Authenticate header exceeds maximum size`,
@@ -441,6 +453,18 @@ func TestParseCredential(t *testing.T) {
 		Source:  "did:pkh:eip155:42431:0x1234",
 	}
 
+	headerCredential := &Credential{
+		Challenge: ChallengeEcho{
+			ID:      "challenge-id",
+			Realm:   "api.example.com",
+			Method:  "tempo",
+			Intent:  "charge",
+			Request: b64EncodeAny(map[string]any{"amount": "100", "currency": "0xabc"}),
+			Header:  HeaderPaymentAuthorization,
+		},
+		Payload: map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
 	tests := []struct {
 		name    string
 		header  string
@@ -451,6 +475,11 @@ func TestParseCredential(t *testing.T) {
 			name:   "roundtrip payment credential",
 			header: credential.ToAuthorization(),
 			want:   credential,
+		},
+		{
+			name:   "roundtrip preserves credential header",
+			header: headerCredential.ToAuthorization(),
+			want:   headerCredential,
 		},
 		{
 			name:   "merged authorization header",
@@ -571,6 +600,10 @@ func assertChallengeEqual(t *testing.T, got, want *Challenge) {
 	}
 	if !assert.Equalf(t, want.Opaque, got.Opaque,
 		"challenge opaque mismatch: got %#v want %#v", got.Opaque, want.Opaque) {
+		return
+	}
+	if !assert.Equalf(t, want.Header, got.Header,
+		"challenge header mismatch: got %q want %q", got.Header, want.Header) {
 		return
 	}
 

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -61,8 +61,7 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			auth := r.Header.Get(mpp.HeaderAuthorization)
-			paymentAuth, err := mpp.FindPaymentAuthorizationStrict(auth)
+			paymentAuth, err := composePaymentCredential(entries, r)
 			if err != nil {
 				WritePaymentError(w, mpp.ErrBadRequest(err.Error()))
 				return
@@ -98,7 +97,8 @@ func ComposeMiddleware(configs ...ComposeConfig) func(http.Handler) http.Handler
 			}
 
 			params := entry.params
-			params.Authorization = paymentAuth
+			params.Authorization = r.Header.Get(mpp.HeaderAuthorization)
+			params.PaymentAuthorization = r.Header.Get(mpp.HeaderPaymentAuthorization)
 			if len(scope) > 0 {
 				params.MppxScope = scope
 			}
@@ -223,4 +223,38 @@ func (entry composedEntry) scopedRequest(scope map[string]string) (map[string]an
 		params.MppxScope = scope
 	}
 	return entry.mpp.buildChargeRequest(params)
+}
+
+func composePaymentCredential(entries []composedEntry, r *http.Request) (string, error) {
+	needsDefault := false
+	needsAuth := false
+	for _, entry := range entries {
+		if entry.mpp.requiresAuth {
+			needsAuth = true
+		} else {
+			needsDefault = true
+		}
+	}
+
+	var authorization, paymentAuthorization string
+	var err error
+	if needsDefault {
+		authorization, err = mpp.FindPaymentAuthorizationStrict(r.Header.Get(mpp.HeaderAuthorization))
+		if err != nil {
+			return "", err
+		}
+	}
+	if needsAuth {
+		paymentAuthorization, err = mpp.FindPaymentAuthorizationStrict(r.Header.Get(mpp.HeaderPaymentAuthorization))
+		if err != nil {
+			return "", err
+		}
+	}
+	if authorization != "" && paymentAuthorization != "" {
+		return "", fmt.Errorf("mpp: multiple Payment credentials")
+	}
+	if paymentAuthorization != "" {
+		return paymentAuthorization, nil
+	}
+	return authorization, nil
 }

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -677,3 +677,37 @@ func TestComposeMiddleware_PanicsOnMixedRealms(t *testing.T) {
 		ComposeConfig{Mpp: b, Params: ChargeParams{Amount: "2.00"}},
 	)
 }
+
+func TestComposeMiddleware_RequiresAuthAdvertisesAndAcceptsPaymentAuthorization(t *testing.T) {
+	methodA := newTestServer(t, composeTestMethod{name: "alpha"}, composeRealm, composeSecret, WithRequiresAuth(true))
+	methodB := newTestServer(t, composeTestMethod{name: "beta"}, composeRealm, composeSecret, WithRequiresAuth(true))
+
+	srv := composeTestServer(t,
+		ComposeConfig{Mpp: methodA, Params: ChargeParams{Amount: "1.00"}},
+		ComposeConfig{Mpp: methodB, Params: ChargeParams{Amount: "2.00"}},
+	)
+	defer srv.Close()
+
+	resp := getChallenge(t, srv.URL)
+	defer resp.Body.Close()
+	for _, value := range resp.Header.Values("WWW-Authenticate") {
+		challenge, err := mpp.ParseChallenge(value)
+		require.NoError(t, err)
+		assert.Equal(t, mpp.HeaderPaymentAuthorization, challenge.Header)
+		assert.Contains(t, value, `header="`+mpp.HeaderPaymentAuthorization+`"`)
+	}
+
+	betaChallenge := findChallenge(t, resp, "beta")
+	credential := betaChallenge.NewCredential(map[string]any{"type": "hash", "hash": "0xabc"})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer app-token")
+	req.Header.Set(mpp.HeaderPaymentAuthorization, credential.ToAuthorization())
+	paid, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer paid.Body.Close()
+	require.Equal(t, http.StatusOK, paid.StatusCode)
+
+	body, _ := io.ReadAll(paid.Body)
+	assert.Equal(t, "beta:0xreceipt-beta", string(body))
+}

--- a/pkg/server/echo/middleware.go
+++ b/pkg/server/echo/middleware.go
@@ -31,6 +31,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) echofw.Middlewa
 		return func(c echofw.Context) error {
 			chargeParams := params
 			chargeParams.Authorization = c.Request().Header.Get(mpp.HeaderAuthorization)
+			chargeParams.PaymentAuthorization = c.Request().Header.Get(mpp.HeaderPaymentAuthorization)
 			chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request(), c.Path())
 			body, err := server.ReadRequestBody(c.Request())
 			if err != nil {

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -220,9 +220,9 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	assert.Equal(t, originalBody, paidResponse.Body.String())
 }
 
-func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string, opts ...server.Option) *server.Mpp {
 	t.Helper()
-	payment, err := server.New(method, realm, secretKey)
+	payment, err := server.New(method, realm, secretKey, opts...)
 	require.NoError(t, err)
 	return payment
 }

--- a/pkg/server/fiber/middleware.go
+++ b/pkg/server/fiber/middleware.go
@@ -32,6 +32,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) fiberfw.Handler
 	return func(c *fiberfw.Ctx) error {
 		chargeParams := params
 		chargeParams.Authorization = c.Get(mpp.HeaderAuthorization)
+		chargeParams.PaymentAuthorization = c.Get(mpp.HeaderPaymentAuthorization)
 		chargeParams.MppxScope = fiberScope(c)
 		if body := c.Body(); len(body) > 0 {
 			chargeParams.Body = append([]byte(nil), body...)

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -259,9 +259,9 @@ func TestChargeMiddlewareRejectsCRLFChallengeDescription(t *testing.T) {
 	assert.Equal(t, string(mpp.ErrorTypeBadRequest), problem.Type)
 }
 
-func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string, opts ...server.Option) *server.Mpp {
 	t.Helper()
-	payment, err := server.New(method, realm, secretKey)
+	payment, err := server.New(method, realm, secretKey, opts...)
 	require.NoError(t, err)
 	return payment
 }

--- a/pkg/server/gin/middleware.go
+++ b/pkg/server/gin/middleware.go
@@ -30,6 +30,7 @@ func ChargeMiddleware(m *server.Mpp, params server.ChargeParams) ginfw.HandlerFu
 	return func(c *ginfw.Context) {
 		chargeParams := params
 		chargeParams.Authorization = c.GetHeader(mpp.HeaderAuthorization)
+		chargeParams.PaymentAuthorization = c.GetHeader(mpp.HeaderPaymentAuthorization)
 		chargeParams.MppxScope = server.ScopeFromHTTPRequest(c.Request, c.FullPath())
 		body, err := server.ReadRequestBody(c.Request)
 		if err != nil {

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -100,6 +100,36 @@ func TestChargeMiddleware_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestChargeMiddleware_RequiresAuthUsesPaymentAuthorization(t *testing.T) {
+	t.Parallel()
+
+	ginfw.SetMode(ginfw.TestMode)
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret", server.WithRequiresAuth(true))
+	router := ginfw.New()
+	router.GET("/paid", ChargeMiddleware(payment, server.ChargeParams{Amount: "0.50"}), func(c *ginfw.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	challengeRequest.Header.Set("Authorization", "Bearer app-token")
+	challengeResponse := httptest.NewRecorder()
+	router.ServeHTTP(challengeResponse, challengeRequest)
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.Code)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header().Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.HeaderPaymentAuthorization, challenge.Header)
+
+	credential := challenge.NewCredential(map[string]any{"type": "hash", "hash": "0xabc123"})
+	paidRequest := httptest.NewRequest(http.MethodGet, "/paid", nil)
+	paidRequest.Header.Set("Authorization", "Bearer app-token")
+	paidRequest.Header.Set(mpp.HeaderPaymentAuthorization, credential.ToAuthorization())
+	paidResponse := httptest.NewRecorder()
+	router.ServeHTTP(paidResponse, paidRequest)
+	require.Equal(t, http.StatusOK, paidResponse.Code)
+	assert.NotEmpty(t, paidResponse.Header().Get("Payment-Receipt"))
+}
+
 func TestChargeMiddlewareAutoScopesRouteResourceAndQuery(t *testing.T) {
 	t.Parallel()
 
@@ -204,9 +234,9 @@ func TestChargeMiddlewarePreservesVerifiedRequestBody(t *testing.T) {
 	assert.Equal(t, originalBody, paidResponse.Body.String())
 }
 
-func newTestServer(t *testing.T, method server.Method, realm, secretKey string) *server.Mpp {
+func newTestServer(t *testing.T, method server.Method, realm, secretKey string, opts ...server.Option) *server.Mpp {
 	t.Helper()
-	payment, err := server.New(method, realm, secretKey)
+	payment, err := server.New(method, realm, secretKey, opts...)
 	require.NoError(t, err)
 	return payment
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -66,14 +66,15 @@ func ReceiptFromContext(ctx context.Context) *mpp.Receipt {
 // ChargeMiddleware creates an http.Handler middleware for the charge intent.
 //
 // It calls Mpp.Charge with the provided ChargeParams, injects the incoming
-// Authorization header automatically, returns a 402 challenge when payment is
-// required, and stores the verified Credential and Receipt in the request
-// context on success.
+// Authorization and Payment-Authorization headers automatically, returns a 402
+// challenge when payment is required, and stores the verified Credential and
+// Receipt in the request context on success.
 func ChargeMiddleware(m *Mpp, params ChargeParams) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			chargeParams := params
 			chargeParams.Authorization = r.Header.Get(mpp.HeaderAuthorization)
+			chargeParams.PaymentAuthorization = r.Header.Get(mpp.HeaderPaymentAuthorization)
 			chargeParams.MppxScope = ScopeFromHTTPRequest(r, "")
 			body, err := ReadRequestBody(r)
 			if err != nil {

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -398,3 +398,34 @@ func (w *optionalResponseWriter) Flush() {
 func (w *optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, nil
 }
+
+func TestChargeMiddleware_RequiresAuthReadsPaymentAuthorizationAndPreservesBearer(t *testing.T) {
+	payment := newTestServer(t, middlewareTestMethod{}, "api.example.com", "test-secret-key-minimum-32-byte-secret", WithRequiresAuth(true))
+	handler := ChargeMiddleware(payment, ChargeParams{Amount: "0.50"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "OK")
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	challengeResponse, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer challengeResponse.Body.Close()
+	require.Equal(t, http.StatusPaymentRequired, challengeResponse.StatusCode)
+
+	challenge, err := mpp.ParseChallenge(challengeResponse.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	assert.Equal(t, mpp.HeaderPaymentAuthorization, challenge.Header)
+	assert.Contains(t, challengeResponse.Header.Get("WWW-Authenticate"), `header="`+mpp.HeaderPaymentAuthorization+`"`)
+
+	credential := challenge.NewCredential(map[string]any{"type": "hash", "hash": "0xabc123"})
+	retry, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	retry.Header.Set("Authorization", "Bearer app-token")
+	retry.Header.Set(mpp.HeaderPaymentAuthorization, credential.ToAuthorization())
+
+	paidResponse, err := http.DefaultClient.Do(retry)
+	require.NoError(t, err)
+	defer paidResponse.Body.Close()
+	require.Equal(t, http.StatusOK, paidResponse.StatusCode)
+	assert.NotEmpty(t, paidResponse.Header.Get("Payment-Receipt"))
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -176,28 +176,71 @@ const minimumSecretKeyBytes = 32
 
 // Mpp is the server-side payment handler.
 type Mpp struct {
-	method    Method
-	realm     string
-	secretKey string
+	method       Method
+	realm        string
+	secretKey    string
+	requiresAuth bool
+}
+
+// Option configures an Mpp instance.
+type Option func(*Mpp)
+
+// WithRequiresAuth advertises header="Payment-Authorization" so Payment
+// credentials leave Authorization available for application authentication.
+func WithRequiresAuth(enabled bool) Option {
+	return func(m *Mpp) {
+		m.requiresAuth = enabled
+	}
 }
 
 // New creates an Mpp instance. It returns an error when secretKey is shorter
 // than minimumSecretKeyBytes, since a weak secret yields forgeable,
 // HMAC-bound challenge IDs.
-func New(method Method, realm, secretKey string) (*Mpp, error) {
+func New(method Method, realm, secretKey string, opts ...Option) (*Mpp, error) {
 	if len(secretKey) < minimumSecretKeyBytes {
 		return nil, fmt.Errorf("server: secret key must be at least %d bytes", minimumSecretKeyBytes)
 	}
-	return &Mpp{
+	m := &Mpp{
 		method:    method,
 		realm:     realm,
 		secretKey: secretKey,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m, nil
 }
 
 // Realm returns the WWW-Authenticate realm used by this payment handler.
 func (m *Mpp) Realm() string {
 	return m.realm
+}
+
+// RequiresAuth reports whether Payment credentials use Payment-Authorization.
+func (m *Mpp) RequiresAuth() bool {
+	return m.requiresAuth
+}
+
+// CredentialHeader returns the HTTP field this handler expects for Payment credentials.
+func (m *Mpp) CredentialHeader() string {
+	if m.requiresAuth {
+		return mpp.HeaderPaymentAuthorization
+	}
+	return mpp.HeaderAuthorization
+}
+
+func (m *Mpp) advertisedCredentialHeader() string {
+	if m.requiresAuth {
+		return mpp.HeaderPaymentAuthorization
+	}
+	return ""
+}
+
+func (m *Mpp) paymentCredentialValue(authorization, paymentAuthorization string) string {
+	if m.requiresAuth {
+		return paymentAuthorization
+	}
+	return authorization
 }
 
 // ValidateCredential validates an issued credential without consuming or broadcasting it.
@@ -227,6 +270,9 @@ func (m *Mpp) VerifyCredential(ctx context.Context, credential *mpp.Credential) 
 type ChargeParams struct {
 	// Authorization is the incoming Authorization header value.
 	Authorization string
+	// PaymentAuthorization is the incoming Payment-Authorization header value.
+	// Used when the handler was created with WithRequiresAuth(true).
+	PaymentAuthorization string
 	// Amount is the human-readable charge amount.
 	Amount string
 	// Currency overrides the method's default currency.
@@ -327,7 +373,7 @@ func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, e
 	}
 
 	result, err := VerifyOrChallenge(ctx, VerifyParams{
-		Authorization: params.Authorization,
+		Authorization: m.paymentCredentialValue(params.Authorization, params.PaymentAuthorization),
 		Intent:        intent,
 		Request:       request,
 		Body:          params.Body,
@@ -337,6 +383,7 @@ func (m *Mpp) Charge(ctx context.Context, params ChargeParams) (*ChargeResult, e
 		Description:   params.Description,
 		Meta:          params.Meta,
 		Expires:       params.Expires,
+		Header:        m.advertisedCredentialHeader(),
 	})
 	if err != nil {
 		if result != nil {

--- a/pkg/server/server_charge_test.go
+++ b/pkg/server/server_charge_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
 type chargeTestMethod struct {
@@ -78,4 +81,46 @@ func TestMppCharge_RequiresChargeIntent(t *testing.T) {
 		return
 	}
 
+}
+
+func TestMppCharge_RequiresAuthAdvertisesPaymentAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	payment := newTestServer(t, chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}, "api.example.com", "test-secret-key-minimum-32-byte-secret", WithRequiresAuth(true))
+	result, err := payment.Charge(context.Background(), ChargeParams{
+		Amount:        "0.50",
+		Authorization: "Bearer app-token",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsChallenge())
+	assert.Equal(t, mpp.HeaderPaymentAuthorization, result.Challenge.Header)
+	assert.Contains(t, result.Challenge.ToAuthenticate(payment.Realm()), `header="`+mpp.HeaderPaymentAuthorization+`"`)
+}
+
+func TestMppCharge_RequiresAuthVerifiesPaymentAuthorizationAndIgnoresBearer(t *testing.T) {
+	t.Parallel()
+
+	payment := newTestServer(t, chargeTestMethod{intents: map[string]Intent{"charge": verifyTestIntent{}}}, "api.example.com", "test-secret-key-minimum-32-byte-secret", WithRequiresAuth(true))
+	challengeResult, err := payment.Charge(context.Background(), ChargeParams{Amount: "0.50"})
+	require.NoError(t, err)
+	require.True(t, challengeResult.IsChallenge())
+
+	credential := challengeResult.Challenge.NewCredential(map[string]any{"type": "test"})
+
+	ignored, err := payment.Charge(context.Background(), ChargeParams{
+		Amount:        "0.50",
+		Authorization: credential.ToAuthorization(),
+	})
+	require.NoError(t, err)
+	assert.True(t, ignored.IsChallenge())
+
+	paid, err := payment.Charge(context.Background(), ChargeParams{
+		Amount:               "0.50",
+		Authorization:        "Bearer app-token",
+		PaymentAuthorization: credential.ToAuthorization(),
+	})
+	require.NoError(t, err)
+	require.False(t, paid.IsChallenge())
+	require.NotNil(t, paid.Receipt)
+	assert.Equal(t, "success", paid.Receipt.Status)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -38,9 +38,9 @@ func TestNewAcceptsMinimumLengthSecret(t *testing.T) {
 
 // newTestServer constructs an Mpp for tests and fails the test if New rejects
 // the secret. Callers must pass a secret of at least minimumSecretKeyBytes.
-func newTestServer(t *testing.T, method Method, realm, secretKey string) *Mpp {
+func newTestServer(t *testing.T, method Method, realm, secretKey string, opts ...Option) *Mpp {
 	t.Helper()
-	payment, err := New(method, realm, secretKey)
+	payment, err := New(method, realm, secretKey, opts...)
 	require.NoError(t, err)
 	return payment
 }

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -34,6 +34,9 @@ type VerifyParams struct {
 	Meta map[string]string
 	// Expires overrides the default Challenge expiry.
 	Expires string
+	// Header selects the HTTP field for the Payment credential. Empty defaults
+	// to Authorization. Payment-Authorization is advertised when set.
+	Header string
 }
 
 // VerifyResult is either a Challenge or a verified (Credential, Receipt) pair.
@@ -77,6 +80,9 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 	}
 	if params.Meta != nil {
 		opts = append(opts, mpp.WithMeta(params.Meta))
+	}
+	if params.Header != "" {
+		opts = append(opts, mpp.WithHeader(params.Header))
 	}
 	if params.Body != nil {
 		opts = append(opts, mpp.WithDigest(mpp.BodyDigest.Compute(params.Body)))
@@ -253,6 +259,9 @@ func echoedChallengeOpts(cred *mpp.Credential) []mpp.ChallengeOption {
 	}
 	if cred.Challenge.Opaque != nil {
 		opts = append(opts, mpp.WithMeta(cred.Challenge.Opaque))
+	}
+	if cred.Challenge.Header != "" {
+		opts = append(opts, mpp.WithHeader(cred.Challenge.Header))
 	}
 	return opts
 }


### PR DESCRIPTION
When an endpoint already uses Authorization for application auth, challenges advertise header="Payment-Authorization" and clients send the credential there instead.

Mirrors mppx change: https://github.com/wevm/mppx/pull/821

Follows spec change here: https://github.com/tempoxyz/mpp-specs/pull/328