### PR TITLE
fix: canonicalize challenge-bound JSON

### DIFF
--- a/.changelog/jcs-challenge-encoding.md
+++ b/.changelog/jcs-challenge-encoding.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Use RFC 8785 JSON Canonicalization Scheme (JCS) for challenge-bound request and opaque values, keeping challenge IDs reproducible across SDKs for Unicode data and JCS number formatting.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/gofiber/fiber/v2 v2.52.14
+	github.com/gowebpki/jcs v1.0.1
 	github.com/labstack/echo/v4 v4.15.4
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -134,6 +136,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -310,7 +310,7 @@ func decodeJSONRequest(request json.RawMessage, requestB64 string) (map[string]a
 	if err != nil {
 		return nil, "", fmt.Errorf("mpp: invalid request encoding: %w", err)
 	}
-	if !JSONEqual(decoded, decodedB64) {
+	if !ChallengeBoundJSONEqual(decoded, decodedB64) {
 		return nil, "", fmt.Errorf("mpp: challenge request and requestB64 do not match")
 	}
 	return decoded, requestB64, nil

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -78,14 +78,28 @@ func WithHeader(header string) ChallengeOption {
 // NewChallenge creates a new Challenge with an HMAC-bound ID. The secretKey
 // and realm are used to compute the ID via GenerateChallengeID.
 func NewChallenge(secretKey, realm, method, intent string, request map[string]any, opts ...ChallengeOption) *Challenge {
+	challenge, err := NewChallengeWithError(secretKey, realm, method, intent, request, opts...)
+	if err != nil {
+		panic(fmt.Sprintf("mpp: invalid challenge request: %v", err))
+	}
+	return challenge
+}
+
+// NewChallengeWithError creates a new Challenge with an HMAC-bound ID. It
+// rejects request values that JCS cannot represent without changing their
+// numeric value.
+func NewChallengeWithError(secretKey, realm, method, intent string, request map[string]any, opts ...ChallengeOption) (*Challenge, error) {
 	cfg := &challengeConfig{}
 	for _, o := range opts {
 		o(cfg)
 	}
 
-	requestB64 := b64EncodeRequest(request)
+	requestB64, err := b64EncodeRequestWithError(request)
+	if err != nil {
+		return nil, err
+	}
 
-	id := GenerateChallengeID(GenerateChallengeIDInput{
+	id, err := GenerateChallengeIDWithError(GenerateChallengeIDInput{
 		SecretKey: secretKey,
 		Realm:     realm,
 		Method:    method,
@@ -96,6 +110,9 @@ func NewChallenge(secretKey, realm, method, intent string, request map[string]an
 		Opaque:    cfg.opaque,
 		Header:    cfg.header,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return &Challenge{
 		ID:          id,
@@ -109,7 +126,7 @@ func NewChallenge(secretKey, realm, method, intent string, request map[string]an
 		Description: cfg.description,
 		Opaque:      cfg.opaque,
 		Header:      cfg.header,
-	}
+	}, nil
 }
 
 // MarshalJSON emits the standard JSON challenge shape with a decoded request
@@ -212,7 +229,7 @@ func (c *Challenge) ToAuthenticateStrict(realm string) (string, error) {
 // Verify checks whether the challenge ID matches the expected HMAC for the
 // given secretKey and realm. Uses constant-time comparison.
 func (c *Challenge) Verify(secretKey, realm string) bool {
-	expected := GenerateChallengeID(GenerateChallengeIDInput{
+	expected, err := GenerateChallengeIDWithError(GenerateChallengeIDInput{
 		SecretKey: secretKey,
 		Realm:     realm,
 		Method:    c.Method,
@@ -223,6 +240,9 @@ func (c *Challenge) Verify(secretKey, realm string) bool {
 		Opaque:    c.Opaque,
 		Header:    c.Header,
 	})
+	if err != nil {
+		return false
+	}
 	return ConstantTimeEqual(c.ID, expected)
 }
 
@@ -336,7 +356,11 @@ func parseJSONRequestValue(trimmed json.RawMessage) (map[string]any, string, err
 	if request == nil {
 		request = map[string]any{}
 	}
-	return request, b64EncodeRequest(request), nil
+	requestB64, err := b64EncodeRequestWithError(request)
+	if err != nil {
+		return nil, "", fmt.Errorf("mpp: invalid request encoding: %w", err)
+	}
+	return request, requestB64, nil
 }
 
 func decodeJSONOpaque(raw json.RawMessage) (map[string]string, error) {

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -6,7 +6,6 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -90,29 +89,12 @@ func ConstantTimeEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-// b64EncodeSortedStringMap encodes a map[string]string as compact sorted JSON
-// then base64url without padding.
+// b64EncodeSortedStringMap encodes a map[string]string as RFC 8785 canonical
+// JSON, then base64url without padding.
 func b64EncodeSortedStringMap(m map[string]string) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+	encoded, err := encodeCanonicalJSON(m)
+	if err != nil {
+		return ""
 	}
-	sort.Strings(keys)
-
-	// Build a sorted JSON object manually to guarantee key order.
-	buf := strings.Builder{}
-	buf.WriteByte('{')
-	for i, k := range keys {
-		if i > 0 {
-			buf.WriteByte(',')
-		}
-		kb, _ := encodeStableJSON(k)
-		vb, _ := encodeStableJSON(m[k])
-		buf.Write(kb)
-		buf.WriteByte(':')
-		buf.Write(vb)
-	}
-	buf.WriteByte('}')
-
-	return base64.RawURLEncoding.EncodeToString([]byte(buf.String()))
+	return base64.RawURLEncoding.EncodeToString(encoded)
 }

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -33,11 +33,27 @@ type GenerateChallengeIDInput struct {
 //
 // The result is base64url-encoded without padding.
 func GenerateChallengeID(opts GenerateChallengeIDInput) string {
-	requestB64 := b64EncodeRequest(opts.Request)
+	id, err := GenerateChallengeIDWithError(opts)
+	if err != nil {
+		panic(fmt.Sprintf("mpp: invalid challenge request: %v", err))
+	}
+	return id
+}
+
+// GenerateChallengeIDWithError produces an HMAC-SHA256 challenge ID and
+// rejects request values that cannot be represented exactly by JCS.
+func GenerateChallengeIDWithError(opts GenerateChallengeIDInput) (string, error) {
+	requestB64, err := b64EncodeRequestWithError(opts.Request)
+	if err != nil {
+		return "", err
+	}
 
 	opaqueB64 := ""
 	if opts.Opaque != nil {
-		opaqueB64 = b64EncodeSortedStringMap(opts.Opaque)
+		opaqueB64, err = b64EncodeSortedStringMapWithError(opts.Opaque)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	parts := []string{
@@ -56,7 +72,7 @@ func GenerateChallengeID(opts GenerateChallengeIDInput) string {
 	mac := hmac.New(sha256.New, []byte(opts.SecretKey))
 	mac.Write([]byte(strings.Join(parts, "|")))
 
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 }
 
 // AdvertisedCredentialHeader returns a challenge header parameter value, or
@@ -92,9 +108,14 @@ func ConstantTimeEqual(a, b string) bool {
 // b64EncodeSortedStringMap encodes a map[string]string as RFC 8785 canonical
 // JSON, then base64url without padding.
 func b64EncodeSortedStringMap(m map[string]string) string {
+	encoded, _ := b64EncodeSortedStringMapWithError(m)
+	return encoded
+}
+
+func b64EncodeSortedStringMapWithError(m map[string]string) (string, error) {
 	encoded, err := encodeCanonicalJSON(m)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(encoded)
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
 }

--- a/pkg/mpp/jcs_test.go
+++ b/pkg/mpp/jcs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChallengeBoundValuesUseJCS(t *testing.T) {
@@ -52,10 +53,10 @@ func TestChallengeBoundValuesUseJCS(t *testing.T) {
 	}
 }
 
-func TestChallengeBoundJSONEqualUsesJCSNumberSemantics(t *testing.T) {
+func TestChallengeBoundJSONEqualRejectsLossyJCSNumbers(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t,
+	assert.False(t,
 		ChallengeBoundJSONEqual(
 			map[string]any{"amount": int64(1234567890123456789)},
 			map[string]any{"amount": json.Number("1234567890123456800")},
@@ -67,6 +68,25 @@ func TestChallengeBoundJSONEqualUsesJCSNumberSemantics(t *testing.T) {
 			map[string]any{"amount": "101"},
 		),
 	)
+}
+
+func TestNewChallengeWithErrorRejectsLossyJCSNumbers(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []any{
+		int64(1234567890123456789),
+		json.Number("1234567890123456789"),
+		json.Number("1e400"),
+	} {
+		_, err := NewChallengeWithError(
+			"secret",
+			"api.example.com",
+			"tempo",
+			"charge",
+			map[string]any{"amount": value},
+		)
+		require.Error(t, err, "value %#v must not be bound to a JCS challenge", value)
+	}
 }
 
 func TestChallengeWireAndIDUseSameJCSValues(t *testing.T) {

--- a/pkg/mpp/jcs_test.go
+++ b/pkg/mpp/jcs_test.go
@@ -1,0 +1,135 @@
+package mpp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChallengeBoundValuesUseJCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data map[string]any
+		want string
+	}{
+		{
+			name: "unicode strings",
+			data: map[string]any{
+				"description": "Payment for café ☕",
+				"amount":      "1000000",
+			},
+			want: "eyJhbW91bnQiOiIxMDAwMDAwIiwiZGVzY3JpcHRpb24iOiJQYXltZW50IGZvciBjYWbDqSDimJUifQ",
+		},
+		{
+			name: "UTF-16 key ordering",
+			data: map[string]any{
+				"\U00010000": "supplementary",
+				"\ue000":     "private",
+			},
+			want: "eyLwkICAIjoic3VwcGxlbWVudGFyeSIsIu6AgCI6InByaXZhdGUifQ",
+		},
+		{
+			name: "ECMAScript number formatting",
+			data: map[string]any{
+				"integer":      333333333.33333329,
+				"large":        1e21,
+				"negativeZero": -0.0,
+				"scientific":   1e-7,
+				"small":        1e-6,
+			},
+			want: "eyJpbnRlZ2VyIjozMzMzMzMzMzMuMzMzMzMzMywibGFyZ2UiOjFlKzIxLCJuZWdhdGl2ZVplcm8iOjAsInNjaWVudGlmaWMiOjFlLTcsInNtYWxsIjowLjAwMDAwMX0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, b64EncodeRequest(tt.data))
+		})
+	}
+}
+
+func TestChallengeBoundJSONEqualUsesJCSNumberSemantics(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t,
+		ChallengeBoundJSONEqual(
+			map[string]any{"amount": int64(1234567890123456789)},
+			map[string]any{"amount": json.Number("1234567890123456800")},
+		),
+	)
+	assert.False(t,
+		ChallengeBoundJSONEqual(
+			map[string]any{"amount": "100"},
+			map[string]any{"amount": "101"},
+		),
+	)
+}
+
+func TestChallengeWireAndIDUseSameJCSValues(t *testing.T) {
+	t.Parallel()
+
+	const (
+		requestB64 = "eyJhbW91bnQiOiIxMDAwMDAwIiwiZGVzY3JpcHRpb24iOiJQYXltZW50IGZvciBjYWbDqSDimJUifQ"
+		opaqueB64  = "eyLwkICAIjoic3VwcGxlbWVudGFyeSIsIu6AgCI6InByaXZhdGUifQ"
+	)
+	request := map[string]any{
+		"description": "Payment for café ☕",
+		"amount":      "1000000",
+	}
+	opaque := map[string]string{
+		"\U00010000": "supplementary",
+		"\ue000":     "private",
+	}
+	challenge := NewChallenge(
+		"test-secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		request,
+		WithMeta(opaque),
+		WithHeader("Payment-Authorization"),
+	)
+
+	assert.Equal(t,
+		"5ICqnT2yXt8jNyNF013hXjilUbs6zxFDO4jjYfsRi3w",
+		challenge.ID,
+	)
+	header := challenge.ToAuthenticate(challenge.Realm)
+	assert.Contains(t, header, `request="`+requestB64+`"`)
+	assert.Contains(t, header, `opaque="`+opaqueB64+`"`)
+	assert.Equal(t, requestB64, challenge.ToEcho().Request)
+
+	parsed, err := ParseChallenge(header)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.True(t, parsed.Verify("test-secret", "api.example.com"))
+	assert.Equal(t, header, parsed.ToAuthenticate(parsed.Realm))
+
+	credential := &Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   map[string]any{"type": "hash"},
+	}
+	parsedCredential, err := ParseCredential(credential.ToAuthorization())
+	if !assert.NoError(t, err) {
+		return
+	}
+	echoedRequest, err := B64Decode(parsedCredential.Challenge.Request)
+	if !assert.NoError(t, err) {
+		return
+	}
+	reconstructed := NewChallenge(
+		"test-secret",
+		parsedCredential.Challenge.Realm,
+		parsedCredential.Challenge.Method,
+		parsedCredential.Challenge.Intent,
+		echoedRequest,
+		WithMeta(parsedCredential.Challenge.Opaque),
+		WithHeader(parsedCredential.Challenge.Header),
+	)
+	assert.Equal(t, challenge.ID, reconstructed.ID)
+}

--- a/pkg/mpp/json.go
+++ b/pkg/mpp/json.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/gowebpki/jcs"
 )
 
 // JSONEqual compares two JSON-like values using Go's stable JSON encoding.
@@ -28,6 +30,31 @@ func encodeStableJSON(value any) ([]byte, error) {
 		return nil, err
 	}
 	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
+}
+
+// encodeCanonicalJSON serializes a value using RFC 8785 JSON Canonicalization
+// Scheme (JCS). Challenge-bound request and opaque values use this encoding so
+// their HMAC inputs are reproducible across SDKs.
+func encodeCanonicalJSON(value any) ([]byte, error) {
+	encoded, err := encodeStableJSON(value)
+	if err != nil {
+		return nil, err
+	}
+	return jcs.Transform(encoded)
+}
+
+// ChallengeBoundJSONEqual compares values using the RFC 8785 representation
+// used to bind challenge requests and opaque values into their HMAC IDs.
+func ChallengeBoundJSONEqual(left, right any) bool {
+	leftJSON, err := encodeCanonicalJSON(left)
+	if err != nil {
+		return false
+	}
+	rightJSON, err := encodeCanonicalJSON(right)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(leftJSON, rightJSON)
 }
 
 // ExtractAuthorizationScheme returns the first authorization value that matches

--- a/pkg/mpp/json.go
+++ b/pkg/mpp/json.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/gowebpki/jcs"
@@ -40,7 +43,14 @@ func encodeCanonicalJSON(value any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return jcs.Transform(encoded)
+	canonical, err := jcs.Transform(encoded)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateJCSNumericRoundTrip(encoded, canonical); err != nil {
+		return nil, err
+	}
+	return canonical, nil
 }
 
 // ChallengeBoundJSONEqual compares values using the RFC 8785 representation
@@ -55,6 +65,107 @@ func ChallengeBoundJSONEqual(left, right any) bool {
 		return false
 	}
 	return bytes.Equal(leftJSON, rightJSON)
+}
+
+// validateJCSNumericRoundTrip rejects numbers that JCS would round or
+// underflow. Without this check, distinct Go integers could produce the same
+// challenge ID after conversion through JCS's IEEE-754 number representation.
+func validateJCSNumericRoundTrip(original, canonical []byte) error {
+	originalValue, err := decodeJSONValue(original)
+	if err != nil {
+		return err
+	}
+	canonicalValue, err := decodeJSONValue(canonical)
+	if err != nil {
+		return err
+	}
+	return compareJSONNumbers(originalValue, canonicalValue)
+}
+
+func decodeJSONValue(data []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing data")
+	}
+	return value, nil
+}
+
+func compareJSONNumbers(original, canonical any) error {
+	switch original := original.(type) {
+	case json.Number:
+		canonicalNumber, ok := canonical.(json.Number)
+		if !ok {
+			return fmt.Errorf("mpp: JCS changed a JSON number's type")
+		}
+		originalValue, err := exactJSONNumber(original.String())
+		if err != nil {
+			return err
+		}
+		canonicalValue, err := exactJSONNumber(canonicalNumber.String())
+		if err != nil {
+			return err
+		}
+		if originalValue.Cmp(canonicalValue) != 0 {
+			return fmt.Errorf("mpp: JSON number is not exactly representable by JCS")
+		}
+	case []any:
+		canonicalArray, ok := canonical.([]any)
+		if !ok || len(original) != len(canonicalArray) {
+			return fmt.Errorf("mpp: JCS changed a JSON array")
+		}
+		for index := range original {
+			if err := compareJSONNumbers(original[index], canonicalArray[index]); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		canonicalObject, ok := canonical.(map[string]any)
+		if !ok || len(original) != len(canonicalObject) {
+			return fmt.Errorf("mpp: JCS changed a JSON object")
+		}
+		for key, originalValue := range original {
+			canonicalValue, ok := canonicalObject[key]
+			if !ok {
+				return fmt.Errorf("mpp: JCS changed a JSON object")
+			}
+			if err := compareJSONNumbers(originalValue, canonicalValue); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func exactJSONNumber(value string) (*big.Rat, error) {
+	mantissa, exponent, hasExponent := strings.Cut(strings.ToLower(value), "e")
+	result, ok := new(big.Rat).SetString(mantissa)
+	if !ok {
+		return nil, fmt.Errorf("mpp: invalid JSON number %q", value)
+	}
+	if !hasExponent {
+		return result, nil
+	}
+	power, err := strconv.Atoi(exponent)
+	if err != nil || power < -324 || power > 308 {
+		return nil, fmt.Errorf("mpp: JSON number %q is outside JCS range", value)
+	}
+	factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(abs(power))), nil)
+	if power < 0 {
+		return result.Quo(result, new(big.Rat).SetInt(factor)), nil
+	}
+	return result.Mul(result, new(big.Rat).SetInt(factor)), nil
+}
+
+func abs(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 // ExtractAuthorizationScheme returns the first authorization value that matches

--- a/pkg/mpp/json_test.go
+++ b/pkg/mpp/json_test.go
@@ -309,25 +309,14 @@ func TestCredentialJSONUnmarshalNormalizesChallengeRequest(t *testing.T) {
 	}
 }
 
-func TestChallengeAndCredentialJSONRoundTripPreservesLargeIntegerRequest(t *testing.T) {
-	challenge := NewChallenge(
+func TestChallengeJSONRoundTripRejectsLossyLargeIntegerRequest(t *testing.T) {
+	_, err := NewChallengeWithError(
 		"secret",
 		"api.example.com",
 		"tempo",
 		"charge",
 		map[string]any{"amount": int64(1234567890123456789)},
 	)
-
-	challengeJSON, err := json.Marshal(challenge)
-	require.NoError(t, err)
-	var decodedChallenge Challenge
-	require.NoError(t, json.Unmarshal(challengeJSON, &decodedChallenge))
-	assert.Equal(t, challenge.RequestB64, decodedChallenge.RequestB64)
-	assert.True(t, decodedChallenge.Verify("secret", "api.example.com"))
-
-	credentialJSON, err := json.Marshal(challenge.NewCredential(map[string]any{"type": "hash"}))
-	require.NoError(t, err)
-	var decodedCredential Credential
-	require.NoError(t, json.Unmarshal(credentialJSON, &decodedCredential))
-	assert.Equal(t, challenge.RequestB64, decodedCredential.Challenge.Request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not exactly representable by JCS")
 }

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -329,7 +329,11 @@ func b64EncodeRequest(request map[string]any) string {
 	if request == nil {
 		request = map[string]any{}
 	}
-	return b64EncodeAny(request)
+	encoded, err := encodeCanonicalJSON(request)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded)
 }
 
 func escapeQuoted(value string) string {

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -299,7 +299,11 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 
 	reqB64 := c.RequestB64
 	if reqB64 == "" {
-		reqB64 = b64EncodeRequest(c.Request)
+		var err error
+		reqB64, err = b64EncodeRequestWithError(c.Request)
+		if err != nil {
+			return "", fmt.Errorf("mpp: invalid challenge request: %w", err)
+		}
 	}
 	for _, param := range []struct {
 		key   string
@@ -326,14 +330,19 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 }
 
 func b64EncodeRequest(request map[string]any) string {
+	encoded, _ := b64EncodeRequestWithError(request)
+	return encoded
+}
+
+func b64EncodeRequestWithError(request map[string]any) (string, error) {
 	if request == nil {
 		request = map[string]any{}
 	}
 	encoded, err := encodeCanonicalJSON(request)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(encoded)
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
 }
 
 func escapeQuoted(value string) string {

--- a/pkg/mpp/parse_test.go
+++ b/pkg/mpp/parse_test.go
@@ -209,6 +209,21 @@ func TestFormatAuthenticateStrict(t *testing.T) {
 	assert.Contains(t, got, `description="Pay \"premium\" path C:\\tempo\\api"`)
 }
 
+func TestFormatAuthenticateStrictRejectsLossyJCSRequest(t *testing.T) {
+	t.Parallel()
+
+	challenge := &Challenge{
+		ID:      "challenge-id",
+		Method:  "tempo",
+		Intent:  "charge",
+		Request: map[string]any{"amount": json.Number("1234567890123456789")},
+	}
+	_, err := challenge.ToAuthenticateStrict("api.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid challenge request")
+	assert.Empty(t, challenge.ToAuthenticate("api.example.com"))
+}
+
 func TestFormatAuthenticateStrictRejectsCRLF(t *testing.T) {
 	t.Parallel()
 
@@ -669,13 +684,11 @@ func TestIssuedChallengeVerifiesAfterWireRoundTrip(t *testing.T) {
 		realm  = "api"
 	)
 
-	// A challenge the server issued must verify after the round trip through the
-	// WWW-Authenticate header, whatever the magnitude of the amounts it carries.
+	// A challenge with JCS-safe integer values must verify after a round trip
+	// through the WWW-Authenticate header.
 	for _, amount := range []int64{
 		1000,
 		9007199254740991,
-		9007199254740993,
-		1234567890123456789,
 	} {
 		request := map[string]any{"amount": amount, "asset": "usdc"}
 		issued := NewChallenge(secret, realm, "tempo", "charge", request)

--- a/pkg/server/compose.go
+++ b/pkg/server/compose.go
@@ -281,7 +281,7 @@ func findMatchingEntry(entries []composedEntry, cred *mpp.Credential, scope map[
 		if err != nil {
 			return composedEntry{}, false, err
 		}
-		if mpp.JSONEqual(echoedRequest, request) && reflect.DeepEqual(cred.Challenge.Opaque, entry.params.Meta) {
+		if mpp.ChallengeBoundJSONEqual(echoedRequest, request) && reflect.DeepEqual(cred.Challenge.Opaque, entry.params.Meta) {
 			return entry, true, nil
 		}
 	}

--- a/pkg/server/lifecycle.go
+++ b/pkg/server/lifecycle.go
@@ -55,7 +55,7 @@ func (m *Mpp) prepareCredential(credential *mpp.Credential) (Intent, map[string]
 		return nil, nil, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
 	}
 	echoed := &credential.Challenge
-	echoedChallenge := mpp.NewChallenge(
+	echoedChallenge, err := mpp.NewChallengeWithError(
 		m.secretKey,
 		echoed.Realm,
 		echoed.Method,
@@ -63,6 +63,9 @@ func (m *Mpp) prepareCredential(credential *mpp.Credential) (Intent, map[string]
 		echoedRequest,
 		echoedChallengeOpts(credential)...,
 	)
+	if err != nil {
+		return nil, nil, mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err))
+	}
 	if !mpp.ConstantTimeEqual(echoed.ID, echoedChallenge.ID) {
 		return nil, nil, mpp.ErrInvalidChallenge(echoed.ID, "challenge was not issued by this server")
 	}

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -88,7 +88,7 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		opts = append(opts, mpp.WithDigest(mpp.BodyDigest.Compute(params.Body)))
 	}
 
-	challenge := mpp.NewChallenge(
+	challenge, err := mpp.NewChallengeWithError(
 		params.SecretKey,
 		params.Realm,
 		params.Method,
@@ -96,6 +96,9 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		params.Request,
 		opts...,
 	)
+	if err != nil {
+		return nil, mpp.ErrBadRequest(fmt.Sprintf("invalid challenge request: %v", err))
+	}
 
 	// 1. No authorization header — issue challenge.
 	if params.Authorization == "" {
@@ -127,7 +130,7 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		)
 	}
 
-	echoedChallenge := mpp.NewChallenge(
+	echoedChallenge, err := mpp.NewChallengeWithError(
 		params.SecretKey,
 		credential.Challenge.Realm,
 		credential.Challenge.Method,
@@ -135,6 +138,12 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		echoedRequest,
 		echoedChallengeOpts(credential)...,
 	)
+	if err != nil {
+		return challengeResultError(
+			challenge,
+			mpp.ErrMalformedCredential(fmt.Sprintf("invalid echoed request: %v", err)),
+		)
+	}
 
 	if !mpp.ConstantTimeEqual(credential.Challenge.ID, echoedChallenge.ID) {
 		return challengeResultError(challenge, mpp.ErrInvalidChallenge(

--- a/pkg/server/verify.go
+++ b/pkg/server/verify.go
@@ -155,7 +155,7 @@ func VerifyOrChallenge(ctx context.Context, params VerifyParams) (*VerifyResult,
 		return challengeResultError(challenge, mpp.ErrInvalidChallenge(echoed.ID, "intent mismatch"))
 	}
 
-	if !mpp.JSONEqual(echoedRequest, params.Request) {
+	if !mpp.ChallengeBoundJSONEqual(echoedRequest, params.Request) {
 		return challengeResultError(challenge, mpp.ErrInvalidChallenge(
 			echoed.ID,
 			"credential request does not match this route's requirements",

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 )
 
@@ -69,8 +71,8 @@ func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {
 
 }
 
-func TestVerifyOrChallenge_VerifiesLargeIntegerRequest(t *testing.T) {
-	const amount int64 = 1234567890123456789
+func TestVerifyOrChallenge_VerifiesLargeIntegerStringRequest(t *testing.T) {
+	const amount = "1234567890123456789"
 	request := map[string]any{"amount": amount, "currency": "0xabc", "recipient": "0xdef"}
 	params := VerifyParams{
 		Intent:    verifyTestIntent{},
@@ -95,6 +97,52 @@ func TestVerifyOrChallenge_VerifiesLargeIntegerRequest(t *testing.T) {
 		return
 	}
 	assert.Equal(t, "0xreceipt", result.Receipt.Reference)
+}
+
+func TestVerifyOrChallengeRejectsLossyJCSRequest(t *testing.T) {
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Intent:    verifyTestIntent{},
+		Request:   map[string]any{"amount": int64(1234567890123456789)},
+		Realm:     "api.example.com",
+		SecretKey: "secret-key",
+		Method:    "tempo",
+	})
+
+	assert.Nil(t, result)
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, http.StatusBadRequest, paymentErr.Status)
+	assert.Contains(t, paymentErr.Detail, "invalid challenge request")
+}
+
+func TestVerifyOrChallengeRejectsLossyEchoedJCSRequest(t *testing.T) {
+	credential := &mpp.Credential{
+		Challenge: mpp.ChallengeEcho{
+			ID:      "challenge-id",
+			Realm:   "api.example.com",
+			Method:  "tempo",
+			Intent:  "charge",
+			Request: base64.RawURLEncoding.EncodeToString([]byte(`{"amount":1234567890123456789}`)),
+			Expires: mpp.Expires.Minutes(5),
+		},
+		Payload: map[string]any{"type": "hash", "hash": "0xabc123"},
+	}
+
+	result, err := VerifyOrChallenge(context.Background(), VerifyParams{
+		Authorization: credential.ToAuthorization(),
+		Intent:        verifyTestIntent{},
+		Request:       map[string]any{"amount": "100"},
+		Realm:         "api.example.com",
+		SecretKey:     "secret-key",
+		Method:        "tempo",
+	})
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.Challenge)
+	var paymentErr *mpp.PaymentError
+	require.ErrorAs(t, err, &paymentErr)
+	assert.Equal(t, mpp.ErrorTypeMalformedCredential, paymentErr.Type)
+	assert.Contains(t, paymentErr.Detail, "invalid echoed request")
 }
 
 func TestVerifyOrChallenge_UsesPublicBroadcastingIntent(t *testing.T) {


### PR DESCRIPTION
## Motivation

Challenge IDs must bind RFC 8785 canonical JSON so equivalent values serialize identically across SDKs.

## Summary

- Use JCS for challenge request and opaque encodings
- Align challenge-bound request comparison with the HMAC representation
- Add cross-SDK byte, wire, and HMAC vectors
- Related: tempoxyz/pympp#235

## Key design considerations

- Retains standard JSON encoding for credentials and receipts
- Uses the RFC-referenced Go JCS implementation