### PR TITLE
ci: build all example packages in CI

### DIFF
--- a/.changelog/ci-build-all-examples.md
+++ b/.changelog/ci-build-all-examples.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Build all example packages in CI and via `make build_examples` so framework and relay examples cannot compile-drift unnoticed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - run: go build ./examples/...
       - run: go test -race -count=1 ./...
 
   integration:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,9 @@
 # Default target
 all: check
 
-# Builds all runnable examples
+# Builds every example package to catch compile drift in CI and locally.
 build_examples:
-	@mkdir -p bin
-	go build -o bin/charge-basic ./examples/charge-basic
-	go build -o bin/charge-hash ./examples/charge-hash
-	go build -o bin/charge-fee-payer ./examples/charge-fee-payer
+	go build ./examples/...
 
 # Cleans generated artifacts
 clean:
@@ -51,7 +48,7 @@ docs:
 # Show available targets
 help:
 	@echo "Available targets:"
-	@echo "  build_examples  Build the example binaries into ./bin"
+	@echo "  build_examples  Build all example packages (compile check)"
 	@echo "  clean           Remove build artifacts and coverage files"
 	@echo "  test            Run unit tests"
 	@echo "  test-coverage   Run unit tests with coverage report"


### PR DESCRIPTION
## Summary

- Run `go build ./examples/...` in CI before unit tests to catch compile drift in framework and relay examples.
- Simplify `make build_examples` to build every example package instead of only three charge demos.

## Context

CI previously ran `go test ./...` but did not compile all examples. Packages like `examples/gin/server`, `examples/echo/server`, `examples/fiber/server`, `examples/chi/server`, `examples/charge-relay`, and `examples/basic/*` could break on `main` without failing CI.

## Test plan

- [x] `go build ./examples/...`
- [x] `go test ./examples/...`
- [x] `go test ./...`