### PR TITLE
fix(mpp): reject invalid credential header names

### DIFF
--- a/.changelog/reject-invalid-credential-header.md
+++ b/.changelog/reject-invalid-credential-header.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: patch
+---
+
+Reject invalid advertised credential header names when creating or strictly formatting challenges.

--- a/pkg/mpp/challenge.go
+++ b/pkg/mpp/challenge.go
@@ -86,8 +86,8 @@ func NewChallenge(secretKey, realm, method, intent string, request map[string]an
 }
 
 // NewChallengeWithError creates a new Challenge with an HMAC-bound ID. It
-// rejects request values that JCS cannot represent without changing their
-// numeric value.
+// rejects invalid advertised credential headers and request values that JCS
+// cannot represent without changing their numeric value.
 func NewChallengeWithError(secretKey, realm, method, intent string, request map[string]any, opts ...ChallengeOption) (*Challenge, error) {
 	cfg := &challengeConfig{}
 	for _, o := range opts {

--- a/pkg/mpp/header_test.go
+++ b/pkg/mpp/header_test.go
@@ -69,3 +69,46 @@ func TestWWWAuthenticateRoundTripPreservesCredentialHeader(t *testing.T) {
 	assert.Equal(t, HeaderPaymentAuthorization, parsed.CredentialHeader())
 	assert.True(t, parsed.Verify("test-secret", "api.example.com"))
 }
+
+func TestChallengeCreationRejectsInvalidCredentialHeader(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewChallengeWithError(
+		"test-secret",
+		"api.example.com",
+		"tempo",
+		"charge",
+		map[string]any{"amount": "1000000"},
+		WithHeader("Payment Authorization"),
+	)
+	require.EqualError(t, err, "mpp: invalid HTTP header name")
+}
+
+func TestChallengeIDRejectsInvalidCredentialHeader(t *testing.T) {
+	t.Parallel()
+
+	_, err := GenerateChallengeIDWithError(GenerateChallengeIDInput{
+		SecretKey: "test-secret",
+		Realm:     "api.example.com",
+		Method:    "tempo",
+		Intent:    "charge",
+		Request:   map[string]any{"amount": "1000000"},
+		Header:    "Payment Authorization",
+	})
+	require.EqualError(t, err, "mpp: invalid HTTP header name")
+}
+
+func TestFormatAuthenticateStrictRejectsInvalidCredentialHeader(t *testing.T) {
+	t.Parallel()
+
+	challenge := &Challenge{
+		ID:      "challenge-id",
+		Realm:   "api.example.com",
+		Method:  "tempo",
+		Intent:  "charge",
+		Request: map[string]any{"amount": "1000000"},
+		Header:  "Payment Authorization",
+	}
+	_, err := challenge.ToAuthenticateStrict(challenge.Realm)
+	require.EqualError(t, err, "mpp: invalid HTTP header name")
+}

--- a/pkg/mpp/hmac.go
+++ b/pkg/mpp/hmac.go
@@ -41,8 +41,13 @@ func GenerateChallengeID(opts GenerateChallengeIDInput) string {
 }
 
 // GenerateChallengeIDWithError produces an HMAC-SHA256 challenge ID and
-// rejects request values that cannot be represented exactly by JCS.
+// rejects invalid advertised credential headers or request values that cannot
+// be represented exactly by JCS.
 func GenerateChallengeIDWithError(opts GenerateChallengeIDInput) (string, error) {
+	header, err := parseAdvertisedCredentialHeader(opts.Header)
+	if err != nil {
+		return "", err
+	}
 	requestB64, err := b64EncodeRequestWithError(opts.Request)
 	if err != nil {
 		return "", err
@@ -64,7 +69,7 @@ func GenerateChallengeIDWithError(opts GenerateChallengeIDInput) (string, error)
 		opts.Expires,
 		opts.Digest,
 	}
-	if header := AdvertisedCredentialHeader(opts.Header); header != "" {
+	if header != "" {
 		parts = append(parts, header)
 	}
 	parts = append(parts, opaqueB64)

--- a/pkg/mpp/parse.go
+++ b/pkg/mpp/parse.go
@@ -270,13 +270,13 @@ func FormatAuthenticateStrict(c *Challenge, realm string) (string, error) {
 	return formatAuthenticate(c, realm, true)
 }
 
-func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, error) {
+func formatAuthenticate(c *Challenge, realm string, strict bool) (string, error) {
 	var parts []string
 	add := func(k, v string) error {
 		if v == "" {
 			return nil
 		}
-		if rejectCRLF && strings.ContainsAny(v, "\r\n") {
+		if strict && strings.ContainsAny(v, "\r\n") {
 			return fmt.Errorf("mpp: invalid %s auth-param: contains CR or LF", k)
 		}
 		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, escapeQuoted(v)))
@@ -305,6 +305,14 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 			return "", fmt.Errorf("mpp: invalid challenge request: %w", err)
 		}
 	}
+	credentialHeader := AdvertisedCredentialHeader(c.Header)
+	if strict {
+		validatedHeader, err := parseAdvertisedCredentialHeader(c.Header)
+		if err != nil {
+			return "", err
+		}
+		credentialHeader = validatedHeader
+	}
 	for _, param := range []struct {
 		key   string
 		value string
@@ -313,7 +321,7 @@ func formatAuthenticate(c *Challenge, realm string, rejectCRLF bool) (string, er
 		{key: "digest", value: c.Digest},
 		{key: "expires", value: c.Expires},
 		{key: "description", value: c.Description},
-		{key: "header", value: AdvertisedCredentialHeader(c.Header)},
+		{key: "header", value: credentialHeader},
 	} {
 		if err := add(param.key, param.value); err != nil {
 			return "", err


### PR DESCRIPTION
## Problem

`WithHeader` normalizes the implicit `Authorization` default but does not validate custom HTTP field names. As a result, both `NewChallengeWithError` and `GenerateChallengeIDWithError` accept values such as `"Payment Authorization"` and bind them into a challenge ID. `ToAuthenticateStrict` also serializes the value, even though this SDK's own `ParseChallenge` rejects the resulting challenge as an invalid HTTP header name.

That leaves the public challenge APIs able to produce an HMAC-bound challenge that cannot complete a serialize/parse round trip.

## Fix

- Reuse the existing advertised-header parser in `GenerateChallengeIDWithError`, which also covers `NewChallengeWithError`.
- Apply the same validation in strict challenge formatting so manually constructed `Challenge` values fail closed.
- Add regression coverage for challenge creation, direct ID generation, and strict formatting.

The lenient `FormatAuthenticate` behavior is unchanged.

## Cross-SDK check

- Canonical mppx validates `Challenge.header` with the HTTP token regex in `Challenge.Schema`.
- pympp validates the same field from `Challenge.__post_init__` through `advertised_credential_header`.
- mpp-rs does not yet expose the credential-header parameter, so it has no corresponding input surface.
- mpp-go already applied this validation while parsing; this change closes the creation/formatting side of that internal mismatch.

## Testing

The new creation and ID tests fail on `main` and pass with this change.

- `go mod verify`
- formatting check with `gofmt -l .`
- `go vet ./...`
- `go build ./examples/...`
- `go test -race -count=1 ./...`
