### PR TITLE
fix(mpp): require method for successful receipts

### DIFF
--- a/.changelog/require-success-receipt-method.md
+++ b/.changelog/require-success-receipt-method.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/mpp-go: minor
+---
+
+Require the payment method when constructing successful receipts so they always contain this required base field.

--- a/pkg/mpp/errors_receipt_test.go
+++ b/pkg/mpp/errors_receipt_test.go
@@ -240,14 +240,18 @@ func TestReceiptRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	receipt := Success(
+		"tempo",
 		"ref-123",
-		WithReceiptMethod("tempo"),
 		WithExternalID("ext-123"),
 		WithSubscriptionID("sub-123"),
 		WithExtra(map[string]any{"settled": true}),
 	)
 	if !assert.Equalf(t, "success", receipt.Status,
 		"receipt.Status = %q, want %q", receipt.Status, "success") {
+		return
+	}
+	if !assert.Equalf(t, "tempo", receipt.Method,
+		"receipt.Method = %q, want %q", receipt.Method, "tempo") {
 		return
 	}
 	if !assert.Equalf(t, time.UTC, receipt.Timestamp.Location(),

--- a/pkg/mpp/receipt.go
+++ b/pkg/mpp/receipt.go
@@ -27,11 +27,6 @@ type Receipt struct {
 // ReceiptOption configures optional fields when creating a Receipt.
 type ReceiptOption func(*Receipt)
 
-// WithReceiptMethod sets the payment method on a Receipt.
-func WithReceiptMethod(method string) ReceiptOption {
-	return func(r *Receipt) { r.Method = method }
-}
-
 // WithExternalID sets the external transaction ID on a Receipt.
 func WithExternalID(id string) ReceiptOption {
 	return func(r *Receipt) { r.ExternalID = id }
@@ -47,12 +42,14 @@ func WithExtra(extra map[string]any) ReceiptOption {
 	return func(r *Receipt) { r.Extra = extra }
 }
 
-// Success creates a new successful Receipt with the given reference and options.
-func Success(reference string, opts ...ReceiptOption) *Receipt {
+// Success creates a new successful Receipt with the given method, reference,
+// and options.
+func Success(method, reference string, opts ...ReceiptOption) *Receipt {
 	r := &Receipt{
 		Status:    "success",
 		Timestamp: time.Now().UTC(),
 		Reference: reference,
+		Method:    method,
 	}
 	for _, o := range opts {
 		o(r)

--- a/pkg/server/compose_test.go
+++ b/pkg/server/compose_test.go
@@ -33,7 +33,7 @@ type composeTestIntent struct {
 func (i composeTestIntent) Name() string { return "charge" }
 
 func (i composeTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
-	return mpp.Success("0xreceipt-"+i.method, mpp.WithReceiptMethod(i.method)), nil
+	return mpp.Success(i.method, "0xreceipt-"+i.method), nil
 }
 
 const (

--- a/pkg/server/echo/middleware_test.go
+++ b/pkg/server/echo/middleware_test.go
@@ -28,7 +28,7 @@ type verifyTestIntent struct{}
 func (verifyTestIntent) Name() string { return "charge" }
 
 func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
-	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xreceipt"), nil
 }
 
 func TestChargeMiddleware_EndToEnd(t *testing.T) {

--- a/pkg/server/fiber/middleware_test.go
+++ b/pkg/server/fiber/middleware_test.go
@@ -29,7 +29,7 @@ type verifyTestIntent struct{}
 func (verifyTestIntent) Name() string { return "charge" }
 
 func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
-	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xreceipt"), nil
 }
 
 func TestChargeMiddleware_EndToEnd(t *testing.T) {

--- a/pkg/server/gin/middleware_test.go
+++ b/pkg/server/gin/middleware_test.go
@@ -28,7 +28,7 @@ type verifyTestIntent struct{}
 func (verifyTestIntent) Name() string { return "charge" }
 
 func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
-	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xreceipt"), nil
 }
 
 func TestChargeMiddleware_EndToEnd(t *testing.T) {

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -53,7 +53,7 @@ func (i *publicSplitTestIntent) Broadcast(
 		return nil, err
 	}
 	i.broadcastCalls++
-	return mpp.Success("0xpublic", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xpublic"), nil
 }
 
 func (i *publicSplitTestIntent) Verify(
@@ -62,7 +62,7 @@ func (i *publicSplitTestIntent) Verify(
 	map[string]any,
 ) (*mpp.Receipt, error) {
 	i.verifyCalls++
-	return mpp.Success("0xlegacy"), nil
+	return mpp.Success("tempo", "0xlegacy"), nil
 }
 
 func (i *splitTestIntent) Name() string { return "charge" }
@@ -96,7 +96,7 @@ func (i *splitTestIntent) Broadcast(
 	if i.broadcastErr != nil {
 		return nil, i.broadcastErr
 	}
-	return mpp.Success("0xsplit", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xsplit"), nil
 }
 
 func newSplitTestServerIntent(t *testing.T, hooks *splitTestIntent) Intent {
@@ -226,13 +226,13 @@ func TestNewIntentSynthesizesVerify(t *testing.T) {
 func TestNewIntentValidatesHookShape(t *testing.T) {
 	t.Parallel()
 	verify := func(context.Context, *mpp.Credential, map[string]any) (*mpp.Receipt, error) {
-		return mpp.Success("0xlegacy"), nil
+		return mpp.Success("tempo", "0xlegacy"), nil
 	}
 	validate := func(context.Context, *mpp.Credential, map[string]any) (*Validation, error) {
 		return &Validation{}, nil
 	}
 	broadcast := func(context.Context, *mpp.Credential, map[string]any) (*mpp.Receipt, error) {
-		return mpp.Success("0xsplit"), nil
+		return mpp.Success("tempo", "0xsplit"), nil
 	}
 	tests := []struct {
 		name      string

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -352,7 +352,7 @@ func TestServeVerified_PreservesResponseWriterOptionalInterfaces(t *testing.T) {
 		w,
 		httptest.NewRequest(http.MethodGet, "/", nil),
 		&mpp.Credential{},
-		mpp.Success("0xreceipt"),
+		mpp.Success("tempo", "0xreceipt"),
 	)
 
 	if !w.flushed {

--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -17,7 +17,7 @@ type verifyTestIntent struct{}
 func (verifyTestIntent) Name() string { return "charge" }
 
 func (verifyTestIntent) Verify(_ context.Context, _ *mpp.Credential, _ map[string]any) (*mpp.Receipt, error) {
-	return mpp.Success("0xreceipt", mpp.WithReceiptMethod("tempo")), nil
+	return mpp.Success("tempo", "0xreceipt"), nil
 }
 
 func TestVerifyOrChallenge_UsesCanonicalRequestMatching(t *testing.T) {

--- a/pkg/tempo/server/charge.go
+++ b/pkg/tempo/server/charge.go
@@ -407,7 +407,7 @@ func (i *Intent) broadcastCredential(
 		if !accepted {
 			return nil, mpp.ErrVerificationFailed("transaction hash already used")
 		}
-		return mpp.Success(hash, mpp.WithReceiptMethod(tempo.MethodName), mpp.WithExternalID(validated.request.ExternalID)), nil
+		return mpp.Success(tempo.MethodName, hash, mpp.WithExternalID(validated.request.ExternalID)), nil
 	case tempo.CredentialTypeProof:
 		challengeID := credential.Challenge.ID
 		accepted, err := i.store.PutIfAbsent(ctx, tempo.ChargeProofStoreKey(challengeID), challengeID)
@@ -417,7 +417,7 @@ func (i *Intent) broadcastCredential(
 		if !accepted {
 			return nil, mpp.ErrVerificationFailed("proof credential already used")
 		}
-		return mpp.Success(challengeID, mpp.WithReceiptMethod(tempo.MethodName), mpp.WithExternalID(validated.request.ExternalID)), nil
+		return mpp.Success(tempo.MethodName, challengeID, mpp.WithExternalID(validated.request.ExternalID)), nil
 	case tempo.CredentialTypeTransaction:
 		return i.broadcastTransaction(ctx, credential, validated)
 	default:
@@ -578,8 +578,8 @@ func (i *Intent) broadcastTransaction(
 		}
 	}
 	return mpp.Success(
+		tempo.MethodName,
 		txHash,
-		mpp.WithReceiptMethod(tempo.MethodName),
 		mpp.WithExternalID(request.ExternalID),
 	), nil
 }


### PR DESCRIPTION
## Motivation

`mpp.Success` could construct a receipt without the required payment method, producing a header rejected by the SDK parser. Fixes the Go side of tempoxyz/mpp-tools#207.

## Summary

- Require `method` as a positional `Success` constructor argument
- Remove the optional receipt method setter
- Update built-in methods and regression coverage
- Add a minor release note

## Key design considerations

- Constructor shape makes omission a compile-time error
- Method precedes reference to match the receipt field model